### PR TITLE
[KAIZEN-0] FAGSYSTEM-24937: Fjerner sensurering for diskresjonskode

### DIFF
--- a/src/main/java/no/nav/fo/veilarbportefolje/indeksering/SolrUtils.java
+++ b/src/main/java/no/nav/fo/veilarbportefolje/indeksering/SolrUtils.java
@@ -91,9 +91,6 @@ public class SolrUtils {
         if(!harTilgangTilEgenAnsatt){
             solrQuery.addFilterQuery("egen_ansatt:false");
         }
-        if(!harTilgangTilKode6 && !harTilgangTilKode7){
-            solrQuery.addFilterQuery("-diskresjonskode:*");
-        }
 
         if(!harTilgangTilKode6){
             solrQuery.addFilterQuery("-diskresjonskode:6");

--- a/src/test/java/no/nav/fo/veilarbportefolje/util/SolrUtilsTest.java
+++ b/src/test/java/no/nav/fo/veilarbportefolje/util/SolrUtilsTest.java
@@ -246,7 +246,9 @@ public class SolrUtilsTest {
         assertThat(SolrUtils.buildSolrQuery("", Optional.empty(), new LinkedList<>(), "",
                 "", filter, pepClient).getQuery()).isEqualTo("navn_sok: Test Person");
         assertThat(SolrUtils.buildSolrQuery("", Optional.empty(), new LinkedList<>(), "",
-                "", filter, pepClient).getFilterQueries()).contains("-diskresjonskode:*");
+                "", filter, pepClient).getFilterQueries()).contains("-diskresjonskode:6");
+        assertThat(SolrUtils.buildSolrQuery("", Optional.empty(), new LinkedList<>(), "",
+                "", filter, pepClient).getFilterQueries()).contains("-diskresjonskode:7");
         assertThat(SolrUtils.buildSolrQuery("", Optional.empty(), new LinkedList<>(), "",
                 "", filter, pepClient).getFilterQueries()).contains("egen_ansatt:false");
     }


### PR DESCRIPTION
- Vi har allerede sensurering av kode 6/7 mens mange av brukerne har
kode 0, som ikke betyr noe. Disse blir allikevel fjernet i søk-resultat
og dermed ikke vist.