### PR TITLE
KAIZEN-0 Spør feed om id+1 for å unngå å få samme element om igjen

### DIFF
--- a/src/main/java/no/nav/fo/veilarbportefolje/config/feed/OppfolgingerfeedConfig.java
+++ b/src/main/java/no/nav/fo/veilarbportefolje/config/feed/OppfolgingerfeedConfig.java
@@ -50,7 +50,7 @@ public class OppfolgingerfeedConfig {
             FeedCallback<BrukerOppdatertInformasjon> callback) {
         BaseConfig<BrukerOppdatertInformasjon> baseConfig = new BaseConfig<>(
                 BrukerOppdatertInformasjon.class,
-                () -> sisteId(db),
+                () -> nesteId(db),
                 getRequiredProperty(VEILARBOPPFOLGING_URL_PROPERTY),
                 BrukerOppdatertInformasjon.FEED_NAME
         );
@@ -81,11 +81,12 @@ public class OppfolgingerfeedConfig {
                 transactor);
     }
 
-    static String sisteId(JdbcTemplate db) {
+    static String nesteId(JdbcTemplate db) {
         return ((BigDecimal) db.queryForList(SELECT_OPPFOLGING_SIST_OPPDATERT_ID_FROM_METADATA).stream()
                 .findFirst()
                 .map(m -> m.get("oppfolging_sist_oppdatert_id"))
                 .orElse(valueOf(0)))
+                .add(valueOf(1))
                 .toPlainString();
     }
 }

--- a/src/test/java/no/nav/fo/veilarbportefolje/config/feed/OppfolgingerfeedConfigTest.java
+++ b/src/test/java/no/nav/fo/veilarbportefolje/config/feed/OppfolgingerfeedConfigTest.java
@@ -1,7 +1,7 @@
 package no.nav.fo.veilarbportefolje.config.feed;
 
 import static no.nav.fo.veilarbportefolje.config.feed.OppfolgingerfeedConfig.SELECT_OPPFOLGING_SIST_OPPDATERT_ID_FROM_METADATA;
-import static no.nav.fo.veilarbportefolje.config.feed.OppfolgingerfeedConfig.sisteId;
+import static no.nav.fo.veilarbportefolje.config.feed.OppfolgingerfeedConfig.nesteId;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -31,20 +31,20 @@ public class OppfolgingerfeedConfigTest {
     public void skalHenteSisteIdNumerisk() {
         when(db.queryForList(SELECT_OPPFOLGING_SIST_OPPDATERT_ID_FROM_METADATA))
             .thenReturn(queryMap("oppfolging_sist_oppdatert_id", BigDecimal.valueOf(50)));
-        assertThat(sisteId(db), is("50"));
+        assertThat(nesteId(db), is("51"));
     }
 
     @Test
     public void skalHandtereAtSisteIdErNull() {
         when(db.queryForList(SELECT_OPPFOLGING_SIST_OPPDATERT_ID_FROM_METADATA))
             .thenReturn(queryMap("oppfolging_sist_oppdatert_id", null));
-        assertThat(sisteId(db), is("0"));
+        assertThat(nesteId(db), is("1"));
     }
     
     @Test
     public void skalHandtereAtMetadataRadIkkeFinnes() {
         when(db.queryForList(SELECT_OPPFOLGING_SIST_OPPDATERT_ID_FROM_METADATA))
             .thenReturn(Collections.emptyList());
-        assertThat(sisteId(db), is("0"));
+        assertThat(nesteId(db), is("1"));
     }
 }


### PR DESCRIPTION
Siden vi har gått over fra dato til numerisk id som feed-nøkkel, trenger vi ikke lenger å spørre _fra og med_ siste kjente id, siden vi vet at det ikke vil komme noen elementer med lik id. Da kan vi heller spørre fra og med _neste mulige id_, som er id på sist behandlede element + 1. Dermed slipper vi å hele tiden få det siste elementet om igjen i hver spørring mot feeden.