### PR TITLE
KAIZEN-0 La til user token finder for bedre filtrering av OpenAM brukere

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <common.version>2.2020.08.06_11.28-05c901c817c2</common.version>
+        <common.version>2.2020.08.24_12.17-ce8722430a1d</common.version>
         <common1.version>1.2020.05.06_16.29-028d26fc1c42</common1.version>
         <no.nav.tjenestespesifikasjoner.version>1.2018.11.20-18.20-f058c54de62c</no.nav.tjenestespesifikasjoner.version>
         <jsch.version>0.1.54</jsch.version>

--- a/src/main/java/no/nav/pto/veilarbportefolje/config/FilterConfig.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/config/FilterConfig.java
@@ -4,6 +4,7 @@ import no.nav.common.auth.oidc.filter.OidcAuthenticationFilter;
 import no.nav.common.auth.oidc.filter.OidcAuthenticatorConfig;
 import no.nav.common.auth.subject.IdentType;
 import no.nav.common.auth.utils.ServiceUserTokenFinder;
+import no.nav.common.auth.utils.UserTokenFinder;
 import no.nav.common.log.LogFilter;
 import no.nav.common.rest.filter.SetStandardHttpHeadersFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -50,7 +51,7 @@ public class FilterConfig {
                 .withClientId(properties.getOpenAmClientId())
                 .withIdTokenCookieName(OPEN_AM_ID_TOKEN_COOKIE_NAME)
                 .withRefreshTokenCookieName(REFRESH_TOKEN_COOKIE_NAME)
-                .withIdTokenFinder((req) -> Optional.empty()) // This overrides the default finder which checks the Authorization header for tokens
+                .withIdTokenFinder(new UserTokenFinder())
                 .withRefreshUrl(properties.getOpenAmRefreshUrl())
                 .withIdentType(IdentType.InternBruker);
     }


### PR DESCRIPTION
Interne brukere ble ikke plukket opp av riktig auth config siden den ikke sjekker etter token i Authorization header.