### PR TITLE
68 Endre sjekk på sletting av arbeidsliste

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetService.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.pto.veilarbportefolje.database.PersistentOppdatering;
 import no.nav.pto.veilarbportefolje.domene.AktoerId;
 import no.nav.pto.veilarbportefolje.kafka.KafkaConsumerService;
-import no.nav.pto.veilarbportefolje.service.PersonIdService;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
 import no.nav.pto.veilarbportefolje.util.BatchConsumer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,14 +21,14 @@ import static no.nav.pto.veilarbportefolje.util.BatchConsumer.batchConsumer;
 @Service
 public class AktivitetService implements KafkaConsumerService<String> {
 
-    private final PersonIdService personIdService;
+    private final BrukerService brukerService;
     private final AktivitetDAO aktivitetDAO;
     private final PersistentOppdatering persistentOppdatering;
 
     @Autowired
-    public AktivitetService(AktivitetDAO aktivitetDAO, PersistentOppdatering persistentOppdatering, PersonIdService personIdService) {
+    public AktivitetService(AktivitetDAO aktivitetDAO, PersistentOppdatering persistentOppdatering, BrukerService brukerService) {
         this.aktivitetDAO = aktivitetDAO;
-        this.personIdService = personIdService;
+        this.brukerService = brukerService;
         this.persistentOppdatering = persistentOppdatering;
     }
 
@@ -70,7 +70,7 @@ public class AktivitetService implements KafkaConsumerService<String> {
     private void utledOgLagreAktivitetstatuser(List<String> aktoerider) {
         aktoerider.forEach(aktoerId -> {
             AktoerAktiviteter aktoerAktiviteter = aktivitetDAO.getAktiviteterForAktoerid(AktoerId.of(aktoerId));
-            AktivitetBrukerOppdatering aktivitetBrukerOppdateringer = AktivitetUtils.konverterTilBrukerOppdatering(aktoerAktiviteter, personIdService);
+            AktivitetBrukerOppdatering aktivitetBrukerOppdateringer = AktivitetUtils.konverterTilBrukerOppdatering(aktoerAktiviteter, brukerService);
             Optional.ofNullable(aktivitetBrukerOppdateringer)
                     .ifPresent(oppdatering -> persistentOppdatering.lagreBrukeroppdateringerIDB(Collections.singletonList(oppdatering)));
         });
@@ -78,7 +78,7 @@ public class AktivitetService implements KafkaConsumerService<String> {
     }
 
     public void utledOgIndekserAktivitetstatuserForAktoerid(AktoerId aktoerId) {
-        AktivitetBrukerOppdatering aktivitetBrukerOppdateringer = AktivitetUtils.hentAktivitetBrukerOppdateringer(aktoerId, personIdService, aktivitetDAO);
+        AktivitetBrukerOppdatering aktivitetBrukerOppdateringer = AktivitetUtils.hentAktivitetBrukerOppdateringer(aktoerId, brukerService, aktivitetDAO);
         Optional.ofNullable(aktivitetBrukerOppdateringer)
                 .ifPresent(oppdatering -> persistentOppdatering.lagreBrukeroppdateringerIDBogIndekser(Collections.singletonList(oppdatering)));
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetUtils.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetUtils.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.pto.veilarbportefolje.arenafiler.gr202.tiltak.Brukertiltak;
 import no.nav.pto.veilarbportefolje.arenafiler.gr202.tiltak.TiltakHandler;
 import no.nav.pto.veilarbportefolje.domene.*;
-import no.nav.pto.veilarbportefolje.service.PersonIdService;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
 import no.nav.pto.veilarbportefolje.util.DateUtils;
 import no.nav.pto.veilarbportefolje.util.DbUtils;
 
@@ -25,10 +25,10 @@ public class AktivitetUtils {
     private static final String DATO_FORMAT = "yyyy-MM-dd";
 
     public static AktivitetBrukerOppdatering konverterTilBrukerOppdatering(AktoerAktiviteter aktoerAktiviteter,
-                                                                           PersonIdService personIdService) {
+                                                                           BrukerService brukerService) {
         AktoerId aktoerId = AktoerId.of(aktoerAktiviteter.getAktoerid());
 
-        Try<PersonId> personid = personIdService.hentPersonidFraAktoerid(aktoerId)
+        Try<PersonId> personid = brukerService.hentPersonidFraAktoerid(aktoerId)
                 .onFailure((e) -> log.warn("Kunne ikke hente personid for aktoerid {}", aktoerId.toString(), e));
 
         return personid
@@ -68,9 +68,9 @@ public class AktivitetUtils {
     }
 
 
-    public static AktivitetBrukerOppdatering hentAktivitetBrukerOppdateringer(AktoerId aktoerId, PersonIdService personIdService, AktivitetDAO aktivitetDAO) {
+    public static AktivitetBrukerOppdatering hentAktivitetBrukerOppdateringer(AktoerId aktoerId, BrukerService brukerService, AktivitetDAO aktivitetDAO) {
         AktoerAktiviteter aktiviteter = aktivitetDAO.getAktiviteterForAktoerid(aktoerId);
-        return konverterTilBrukerOppdatering(aktiviteter, personIdService);
+        return konverterTilBrukerOppdatering(aktiviteter, brukerService);
     }
 
     public static boolean erAktivitetIPeriode(AktivitetDTO aktivitet, LocalDate today) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteDTO.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteDTO.java
@@ -21,6 +21,7 @@ public class ArbeidslisteDTO {
     Timestamp endringstidspunkt;
     Boolean isOppfolgendeVeileder;
     Arbeidsliste.Kategori kategori;
+    String navKontorForArbeidsliste;
 
     public static ArbeidslisteDTO of(Fnr fnr, String overskrift, String kommentar, Timestamp frist, Arbeidsliste.Kategori kategori) {
         return

--- a/src/main/java/no/nav/pto/veilarbportefolje/arenafiler/FilmottakConfig.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arenafiler/FilmottakConfig.java
@@ -10,7 +10,7 @@ import no.nav.pto.veilarbportefolje.database.PersistentOppdatering;
 import no.nav.pto.veilarbportefolje.aktiviteter.AktivitetDAO;
 import no.nav.pto.veilarbportefolje.database.BrukerRepository;
 import no.nav.pto.veilarbportefolje.aktiviteter.AktivitetService;
-import no.nav.pto.veilarbportefolje.service.PersonIdService;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -31,11 +31,11 @@ public class FilmottakConfig {
     public TiltakHandler tiltakHandler(
             TiltakRepository tiltakRepository,
             AktivitetDAO aktivitetDAO,
-            PersonIdService personIdService,
+            BrukerService brukerService,
             BrukerRepository brukerRepository,
             EnvironmentProperties environmentProperties
             ) {
-        return new TiltakHandler(tiltakRepository, aktivitetDAO, personIdService, brukerRepository, environmentProperties);
+        return new TiltakHandler(tiltakRepository, aktivitetDAO, brukerService, brukerRepository, environmentProperties);
     }
 
     public static class SftpConfig {

--- a/src/main/java/no/nav/pto/veilarbportefolje/arenafiler/gr202/tiltak/TiltakHandler.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arenafiler/gr202/tiltak/TiltakHandler.java
@@ -19,7 +19,7 @@ import no.nav.pto.veilarbportefolje.domene.Brukerdata;
 import no.nav.pto.veilarbportefolje.domene.Fnr;
 import no.nav.pto.veilarbportefolje.domene.PersonId;
 import no.nav.pto.veilarbportefolje.domene.Tiltakkodeverk;
-import no.nav.pto.veilarbportefolje.service.PersonIdService;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
 import org.apache.commons.vfs2.FileObject;
 
 import java.sql.Timestamp;
@@ -49,13 +49,13 @@ public class TiltakHandler {
     private final TiltakRepository tiltakrepository;
     private final AktivitetDAO aktivitetDAO;
     private final BrukerRepository brukerRepository;
-    private final PersonIdService personIdService;
+    private final BrukerService brukerService;
     private final EnvironmentProperties environmentProperties;
 
     static final String ARENA_AKTIVITET_DATOFILTER = "2017-12-04";
 
-    public TiltakHandler(TiltakRepository tiltakRepository, AktivitetDAO aktivitetDAO, PersonIdService personIdService, BrukerRepository brukerRepository, EnvironmentProperties environmentProperties) {
-        this.personIdService = personIdService;
+    public TiltakHandler(TiltakRepository tiltakRepository, AktivitetDAO aktivitetDAO, BrukerService brukerService, BrukerRepository brukerRepository, EnvironmentProperties environmentProperties) {
+        this.brukerService = brukerService;
         this.tiltakrepository = tiltakRepository;
         this.aktivitetDAO = aktivitetDAO;
         this.brukerRepository = brukerRepository;
@@ -148,7 +148,7 @@ public class TiltakHandler {
                 .forEach(brukereBatch -> {
 
                     List<Fnr> fnrs = brukereBatch.toJavaStream().map(Bruker::getPersonident).map(Fnr::of).collect(toList());
-                    Map<Fnr, Optional<PersonId>> personidsMap = personIdService.hentPersonidsForFnrs(fnrs);
+                    Map<Fnr, Optional<PersonId>> personidsMap = brukerService.hentPersonidsForFnrs(fnrs);
                     List<PersonId> personIds = personidsMap.values().stream()
                             .filter(Optional::isPresent)
                             .map(Optional::get).collect(toList());
@@ -282,7 +282,7 @@ public class TiltakHandler {
                 .forEach((brukereSubList) -> {
                     List<Bruker> brukereJavaBatch = brukereSubList.toJavaList();
                     List<Fnr> fnrs = brukereJavaBatch.stream().map(Bruker::getPersonident).filter(Objects::nonNull).map(Fnr::new).collect(toList());
-                    Map<Fnr, Optional<PersonId>> fnrPersonidMap = personIdService.hentPersonidsForFnrs(fnrs);
+                    Map<Fnr, Optional<PersonId>> fnrPersonidMap = brukerService.hentPersonidsForFnrs(fnrs);
                     List<AktivitetStatus> aktivitetStatuses = brukereJavaBatch
                             .stream()
                             .map(bruker -> {
@@ -302,7 +302,7 @@ public class TiltakHandler {
                 .forEach((brukereSubList) -> {
                     List<Bruker> brukereJavaBatch = brukereSubList.toJavaList();
                     List<Fnr> fnrs = brukereJavaBatch.stream().map(Bruker::getPersonident).filter(Objects::nonNull).map(Fnr::new).collect(toList());
-                    Map<Fnr, Optional<PersonId>> fnrPersonidMap = personIdService.hentPersonidsForFnrs(fnrs);
+                    Map<Fnr, Optional<PersonId>> fnrPersonidMap = brukerService.hentPersonidsForFnrs(fnrs);
                     List<AktivitetStatus> aktivitetStatuses = brukereJavaBatch
                             .stream()
                             .map(bruker -> {
@@ -322,7 +322,7 @@ public class TiltakHandler {
                 .forEach((brukereSubList) -> {
                     List<Bruker> brukereJavaBatch = brukereSubList.toJavaList();
                     List<Fnr> fnrs = brukereJavaBatch.stream().map(Bruker::getPersonident).filter(Objects::nonNull).map(Fnr::new).collect(toList());
-                    Map<Fnr, Optional<PersonId>> fnrPersonidMap = personIdService.hentPersonidsForFnrs(fnrs);
+                    Map<Fnr, Optional<PersonId>> fnrPersonidMap = brukerService.hentPersonidsForFnrs(fnrs);
                     List<AktivitetStatus> aktivitetStatuses = brukereJavaBatch
                             .stream()
                             .map(bruker -> {

--- a/src/main/java/no/nav/pto/veilarbportefolje/database/Table.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/database/Table.java
@@ -1,12 +1,50 @@
 package no.nav.pto.veilarbportefolje.database;
 
 public class Table {
-    public static final String AKTOERID_TO_PERSONID = "AKTOERID_TO_PERSONID";
     public static final String METADATA = "METADATA";
-    public static final String VW_PORTEFOLJE_INFO = "VW_PORTEFOLJE_INFO";
 
     public class Kolonner {
         static final String SIST_INDEKSERT_ES = "SIST_INDEKSERT_ES";
+    }
+
+    public static final class AKTOERID_TO_PERSONID {
+        public static final String TABLE_NAME = "AKTOERID_TO_PERSONID";
+        public static final String AKTOERID = "AKTOERID";
+        public static final String PERSONID = "PERSONID";
+        public static final String GJELDENE = "GJELDENE";
+    }
+
+    public static final class OPPFOLGING_DATA {
+        public static final String TABLE_NAME = "OPPFOLGING_DATA";
+        public static final String AKTOERID = "AKTOERID";
+        public static final String VEILEDERIDENT = "VEILEDERIDENT";
+    }
+
+    public static final class OPPFOLGINGSBRUKER {
+        public static final String TABLE_NAME = "OPPFOLGINGSBRUKER";
+        public static final String FODSELSNR = "FODSELSNR";
+        public static final String PERSON_ID = "PERSON_ID";
+        public static final String NAV_KONTOR = "NAV_KONTOR";
+    }
+
+    public static final class ARBEIDSLISTE {
+        public static final String TABLE_NAME = "ARBEIDSLISTE";
+        public static final String FNR = "FNR";
+        public static final String AKTOERID = "AKTOERID";
+        public static final String SIST_ENDRET_AV_VEILEDERIDENT = "SIST_ENDRET_AV_VEILEDERIDENT";
+        public static final String ENDRINGSTIDSPUNKT = "ENDRINGSTIDSPUNKT";
+        public static final String OVERSKRIFT = "OVERSKRIFT";
+        public static final String KOMMENTAR = "KOMMENTAR";
+        public static final String FRIST = "FRIST";
+        public static final String KATEGORI = "KATEGORI";
+        public static final String NAV_KONTOR_FOR_ARBEIDSLISTE = "NAV_KONTOR_FOR_ARBEIDSLISTE";
+    }
+
+    public static final class VW_PORTEFOLJE_INFO {
+        public static final String TABLE_NAME = "VW_PORTEFOLJE_INFO";
+        public static final String AKTOERID = "AKTOERID";
+        public static final String FODSELSNR = "FODSELSNR";
+        public static final String NAV_KONTOR = "NAV_KONTOR";
     }
 
     public static final class BRUKER_DATA {

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingfeed/OppfolgingFeedHandler.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingfeed/OppfolgingFeedHandler.java
@@ -108,7 +108,13 @@ public class OppfolgingFeedHandler implements FeedCallback {
 
         boolean brukerErIkkeUnderOppfolging = brukerErIkkeUnderOppfolging(oppfolgingData);
         boolean eksisterendeVeilederHarIkkeTilgangTilBrukerSinEnhet = eksisterendeVeilederHarIkkeTilgangTilBrukerSinEnhet(hentOppfolgingData, aktoerId);
-        boolean skalSletteArbeidsliste = brukerErIkkeUnderOppfolging || eksisterendeVeilederHarIkkeTilgangTilBrukerSinEnhet;
+
+        boolean skalSletteArbeidsliste;
+        if (unleashService.isEnabled("portefolje.endre_arbeidsliste_logikk")) {
+            skalSletteArbeidsliste = brukerErIkkeUnderOppfolging || brukerHarByttetNavKontor(aktoerId);
+        } else {
+            skalSletteArbeidsliste = brukerErIkkeUnderOppfolging || eksisterendeVeilederHarIkkeTilgangTilBrukerSinEnhet;
+        }
 
         transactor.inTransaction(() -> {
             if (skalSletteArbeidsliste) {
@@ -118,6 +124,21 @@ public class OppfolgingFeedHandler implements FeedCallback {
             oppfolgingRepository.oppdaterOppfolgingData(oppfolgingData);
         });
 
+    }
+
+    private boolean brukerHarByttetNavKontor(AktoerId aktoerId) {
+        String navKontorArbeidslisteErLagretPaa =
+                arbeidslisteService.hentNavKontorForArbeidsliste(aktoerId)
+                        .orElseThrow(IllegalStateException::new);
+
+        String navKontorBrukerErPaa =
+                brukerRepository.hentNavKontor(aktoerId)
+                        .orElseThrow(IllegalStateException::new);
+
+
+        log.info("Bruker {} er på kontor {} mens arbeidslisten er lagret på {}", aktoerId.toString(), navKontorBrukerErPaa, navKontorArbeidslisteErLagretPaa);
+
+        return !navKontorBrukerErPaa.equals(navKontorArbeidslisteErLagretPaa);
     }
 
     public static boolean brukerErIkkeUnderOppfolging(BrukerOppdatertInformasjon oppfolgingData) {
@@ -135,7 +156,7 @@ public class OppfolgingFeedHandler implements FeedCallback {
         return brukerRepository
                 .retrievePersonid(aktoerId)
                 .peek(personId -> log.info("PersonId er {}, {}", personId, aktoerId))
-                .flatMap(brukerRepository::retrieveEnhet)
+                .flatMap(brukerRepository::retrieveNavKontor)
                 .peek(enhet -> log.info("Enhet {}, {} ", enhet, aktoerId))
                 .map(enhet -> veilarbVeilederClient.hentVeilederePaaEnhet(enhet))
                 .peek(veilederePaaEnhet -> log.info("AktoerId {}, Veileder: {} Veileder på enhet: {}", veilederId, veilederePaaEnhet, aktoerId))

--- a/src/main/java/no/nav/pto/veilarbportefolje/scheduled/PersonIdToAktorIdSchedule.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/scheduled/PersonIdToAktorIdSchedule.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.common.leaderelection.LeaderElectionClient;
 import no.nav.pto.veilarbportefolje.domene.AktoerId;
 import no.nav.pto.veilarbportefolje.elastic.ElasticIndexer;
-import no.nav.pto.veilarbportefolje.service.PersonIdService;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,7 +18,7 @@ public class PersonIdToAktorIdSchedule {
     private final JdbcTemplate db;
     private final ElasticIndexer elasticIndexer;
     private final LeaderElectionClient leaderElectionClient;
-    private final PersonIdService personIdService;
+    private final BrukerService brukerService;
 
     private static final String IKKE_MAPPEDE_AKTORIDER = "SELECT AKTOERID "
             + "FROM OPPFOLGING_DATA "
@@ -27,8 +27,8 @@ public class PersonIdToAktorIdSchedule {
             + "(SELECT AKTOERID FROM AKTOERID_TO_PERSONID)";
 
     @Autowired
-    public PersonIdToAktorIdSchedule(PersonIdService personIdService, JdbcTemplate db, ElasticIndexer elasticIndexer, LeaderElectionClient leaderElectionClient) {
-        this.personIdService = personIdService;
+    public PersonIdToAktorIdSchedule(BrukerService brukerService, JdbcTemplate db, ElasticIndexer elasticIndexer, LeaderElectionClient leaderElectionClient) {
+        this.brukerService = brukerService;
         this.db = db;
         this.elasticIndexer = elasticIndexer;
         this.leaderElectionClient = leaderElectionClient;
@@ -46,7 +46,7 @@ public class PersonIdToAktorIdSchedule {
 
         aktoerIder.forEach((id) -> {
             AktoerId aktoerId = AktoerId.of(id);
-            personIdService.hentPersonidFraAktoerid(aktoerId);
+            brukerService.hentPersonidFraAktoerid(aktoerId);
             elasticIndexer.indekser(aktoerId);
         });
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/service/BrukerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/service/BrukerService.java
@@ -7,6 +7,7 @@ import no.nav.pto.veilarbportefolje.database.BrukerRepository;
 import no.nav.pto.veilarbportefolje.domene.AktoerId;
 import no.nav.pto.veilarbportefolje.domene.Fnr;
 import no.nav.pto.veilarbportefolje.domene.PersonId;
+import no.nav.pto.veilarbportefolje.domene.VeilederId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,15 +21,19 @@ import static java.util.stream.Collectors.toList;
 
 @Slf4j
 @Service
-public class PersonIdService {
+public class BrukerService {
 
     private final BrukerRepository brukerRepository;
     private final AktorregisterClient aktorregisterClient;
 
     @Autowired
-    public PersonIdService(BrukerRepository brukerRepository, AktorregisterClient aktorregisterClient) {
+    public BrukerService(BrukerRepository brukerRepository, AktorregisterClient aktorregisterClient) {
         this.brukerRepository = brukerRepository;
         this.aktorregisterClient = aktorregisterClient;
+    }
+
+    public Optional<String> hentNavKontorForBruker(Fnr fnr) {
+        return brukerRepository.hentNavKontor(fnr);
     }
 
     public Map<Fnr, Optional<PersonId>> hentPersonidsForFnrs(List<Fnr> fnrs) {
@@ -69,7 +74,9 @@ public class PersonIdService {
             brukerRepository.setGjeldeneFlaggTilNull(personId);
             brukerRepository.insertAktoeridToPersonidMapping(aktoerId, personId);
         }
+    }
 
-
+    public Optional<VeilederId> hentVeilederForBruker(AktoerId aktoerId) {
+        return brukerRepository.hentVeilederForBruker(aktoerId);
     }
 }

--- a/src/main/resources/db/migration/V2_60__legg_til_nav_kontor_og_fnr_i_arbeidsliste.sql
+++ b/src/main/resources/db/migration/V2_60__legg_til_nav_kontor_og_fnr_i_arbeidsliste.sql
@@ -1,0 +1,16 @@
+ALTER TABLE ARBEIDSLISTE
+    ADD NAV_KONTOR_FOR_ARBEIDSLISTE VARCHAR2(24);
+
+ALTER TABLE ARBEIDSLISTE
+    ADD FNR VARCHAR2(11);
+
+merge into ARBEIDSLISTE arb
+using (
+    select *
+    from VW_PORTEFOLJE_INFO
+) vw
+on (arb.AKTOERID = vw.AKTOERID)
+when matched then
+    update
+    set arb.FNR                         = vw.FODSELSNR,
+        arb.NAV_KONTOR_FOR_ARBEIDSLISTE = vw.NAV_KONTOR;

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetServiceTest.java
@@ -4,7 +4,7 @@ import io.vavr.control.Try;
 import no.nav.pto.veilarbportefolje.database.PersistentOppdatering;
 import no.nav.pto.veilarbportefolje.domene.AktoerId;
 import no.nav.pto.veilarbportefolje.domene.PersonId;
-import no.nav.pto.veilarbportefolje.service.PersonIdService;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.*;
 public class AktivitetServiceTest {
 
     @Mock
-    private PersonIdService personIdService;
+    private BrukerService brukerService;
 
     @Mock
     private AktivitetDAO aktivitetDAO;
@@ -43,7 +43,7 @@ public class AktivitetServiceTest {
 
     @Before
     public void resetMock() {
-        reset(personIdService, persistentOppdatering, aktivitetDAO);
+        reset(brukerService, persistentOppdatering, aktivitetDAO);
     }
 
     private static final String AKTOERID_TEST = "AKTOERID_TEST";
@@ -75,7 +75,7 @@ public class AktivitetServiceTest {
                             .setStatus(ikkeFullfortStatus)));
                 });
 
-        when(personIdService
+        when(brukerService
                 .hentPersonidFraAktoerid(any(AktoerId.class)))
                 .thenAnswer(args -> Try.success(PersonId.of(args.getArgument(0).toString())));
 
@@ -107,7 +107,7 @@ public class AktivitetServiceTest {
 
         when(aktivitetDAO.getDistinctAktoerIdsFromAktivitet()).thenReturn(singletonList(AKTOERID_TEST));
         when(aktivitetDAO.getAktiviteterForAktoerid(any())).thenReturn(aktiviteter);
-        when(personIdService.hentPersonidFraAktoerid(any())).thenReturn(Try.success(PersonId.of(PERSONID_TEST)));
+        when(brukerService.hentPersonidFraAktoerid(any())).thenReturn(Try.success(PersonId.of(PERSONID_TEST)));
 
         aktivitetService.utledOgLagreAlleAktivitetstatuser();
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetUtilsTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetUtilsTest.java
@@ -5,7 +5,7 @@ import lombok.val;
 import no.nav.pto.veilarbportefolje.arenafiler.gr202.tiltak.Brukertiltak;
 import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest;
 import no.nav.pto.veilarbportefolje.domene.*;
-import no.nav.pto.veilarbportefolje.service.PersonIdService;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
 import no.nav.pto.veilarbportefolje.util.DateUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +33,7 @@ public class AktivitetUtilsTest {
     private AktivitetDAO aktivitetDAO;
 
     @Mock
-    private PersonIdService personIdService;
+    private BrukerService brukerService;
 
     @Test
     public void konverterTilBrukerOppdatering_skal_hente_rett_brukerOppdateringer() throws Exception {
@@ -70,8 +70,8 @@ public class AktivitetUtilsTest {
         val aktiviteter = Arrays.asList(aktivitetDTO1, aktivitetDTO2, aktivitetDTO3, aktivitetDTO4, aktivitetDTO5);
         val aktorAktiviteter = new AktoerAktiviteter("123").setAktiviteter(aktiviteter);
 
-        when(personIdService.hentPersonidFraAktoerid(any())).thenReturn(Try.of(() -> PersonId.of("123")));
-        val brukerOppdateringer = konverterTilBrukerOppdatering(aktorAktiviteter, personIdService);
+        when(brukerService.hentPersonidFraAktoerid(any())).thenReturn(Try.of(() -> PersonId.of("123")));
+        val brukerOppdateringer = konverterTilBrukerOppdatering(aktorAktiviteter, brukerService);
 
         assertThat(brukerOppdateringer.getNyesteUtlopteAktivitet()).isEqualTo(YESTERDAY);
         assertThat(brukerOppdateringer.getAktivitetStart()).isEqualTo(TODAY);

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteServiceTest.java
@@ -1,0 +1,123 @@
+package no.nav.pto.veilarbportefolje.arbeidsliste;
+
+import lombok.Value;
+import no.nav.common.client.aktorregister.AktorregisterClient;
+import no.nav.common.metrics.MetricsClient;
+import no.nav.pto.veilarbportefolje.TestUtil;
+import no.nav.pto.veilarbportefolje.database.BrukerRepository;
+import no.nav.pto.veilarbportefolje.database.Table;
+import no.nav.pto.veilarbportefolje.domene.AktoerId;
+import no.nav.pto.veilarbportefolje.domene.Fnr;
+import no.nav.pto.veilarbportefolje.domene.VeilederId;
+import no.nav.pto.veilarbportefolje.elastic.ElasticIndexer;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
+import no.nav.sbl.sql.SqlUtils;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+import java.sql.Timestamp;
+
+import static java.time.Instant.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ArbeidslisteServiceTest {
+
+
+    private static ArbeidslisteService arbeidslisteService;
+    private static JdbcTemplate jdbcTemplate;
+    private static AktorregisterClient aktorregisterClientMock;
+
+    @BeforeClass
+    public static void beforeClass() {
+        SingleConnectionDataSource ds = TestUtil.setupInMemoryDatabase();
+        jdbcTemplate = new JdbcTemplate(ds);
+        NamedParameterJdbcTemplate namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(ds);
+
+        ArbeidslisteRepository arbeidslisteRepository = new ArbeidslisteRepository(jdbcTemplate, namedParameterJdbcTemplate);
+        BrukerRepository brukerRepository = new BrukerRepository(jdbcTemplate, namedParameterJdbcTemplate);
+
+        aktorregisterClientMock = mock(AktorregisterClient.class);
+
+        BrukerService brukerService = new BrukerService(brukerRepository, aktorregisterClientMock);
+
+        arbeidslisteService = new ArbeidslisteService(aktorregisterClientMock, arbeidslisteRepository, brukerService, mock(ElasticIndexer.class), mock(MetricsClient.class));
+    }
+
+    @After
+    public void tearDown() {
+        jdbcTemplate.execute("TRUNCATE TABLE " + Table.ARBEIDSLISTE.TABLE_NAME);
+        jdbcTemplate.execute("TRUNCATE TABLE " + Table.OPPFOLGINGSBRUKER.TABLE_NAME);
+        jdbcTemplate.execute("TRUNCATE TABLE " + Table.AKTOERID_TO_PERSONID.TABLE_NAME);
+    }
+
+    @Test
+    public void skal_inserte_fnr_i_arbeidslisten() {
+        String aktoerId = "00000000000";
+        String excpectedNavKontor = "00000000000";
+        FnrOgNavKontor fnrOgNavKontor = setUpInitialState(aktoerId, excpectedNavKontor);
+
+        String actualFnr = SqlUtils
+                .select(jdbcTemplate, Table.ARBEIDSLISTE.TABLE_NAME, rs -> rs.getString(Table.ARBEIDSLISTE.FNR))
+                .column(Table.ARBEIDSLISTE.FNR)
+                .execute();
+
+        assertThat(actualFnr).isEqualTo(fnrOgNavKontor.getFnr());
+
+        String actualNavKontor = arbeidslisteService.hentNavKontorForArbeidsliste(AktoerId.of(aktoerId)).orElseThrow();
+
+        assertThat(actualNavKontor).isEqualTo(excpectedNavKontor);
+    }
+
+    @Test
+    public void skal_inserte_nav_kontor_i_arbeidsliste() {
+        String aktoerId = "00000000000";
+        String navKontor = "00000000000";
+        FnrOgNavKontor fnrOgNavKontor = setUpInitialState(aktoerId, navKontor);
+    }
+
+    private static FnrOgNavKontor setUpInitialState(String aktoerId, String navKontor) {
+        String fnr = "00000000000";
+        String personId = "00000000000";
+
+        when(aktorregisterClientMock.hentAktorId(anyString())).thenReturn(aktoerId);
+
+        SqlUtils
+                .insert(jdbcTemplate, Table.OPPFOLGINGSBRUKER.TABLE_NAME)
+                .value(Table.OPPFOLGINGSBRUKER.FODSELSNR, fnr)
+                .value(Table.OPPFOLGINGSBRUKER.PERSON_ID, personId)
+                .value(Table.OPPFOLGINGSBRUKER.NAV_KONTOR, navKontor)
+                .execute();
+
+        SqlUtils
+                .insert(jdbcTemplate, Table.AKTOERID_TO_PERSONID.TABLE_NAME)
+                .value(Table.AKTOERID_TO_PERSONID.AKTOERID, aktoerId)
+                .value(Table.AKTOERID_TO_PERSONID.PERSONID, personId)
+                .value(Table.AKTOERID_TO_PERSONID.GJELDENE, true)
+                .execute();
+
+        ArbeidslisteDTO dto = new ArbeidslisteDTO(Fnr.of(fnr))
+                .setNavKontorForArbeidsliste("0000")
+                .setAktoerId(AktoerId.of("0"))
+                .setVeilederId(VeilederId.of("0"))
+                .setFrist(Timestamp.from(now()))
+                .setKategori(Arbeidsliste.Kategori.BLA)
+                .setOverskrift("foo");
+
+        arbeidslisteService.createArbeidsliste(dto);
+        return new FnrOgNavKontor(fnr, navKontor);
+    }
+
+    @Value
+    private static class FnrOgNavKontor {
+        String fnr;
+        String navKontor;
+    }
+
+}

--- a/src/test/java/no/nav/pto/veilarbportefolje/config/ServiceConfigTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/config/ServiceConfigTest.java
@@ -2,14 +2,13 @@ package no.nav.pto.veilarbportefolje.config;
 
 import no.nav.pto.veilarbportefolje.aktiviteter.AktivitetService;
 import no.nav.pto.veilarbportefolje.database.PersistentOppdatering;
-import no.nav.pto.veilarbportefolje.krr.KrrService;
-import no.nav.pto.veilarbportefolje.service.PersonIdService;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
 @Import({
-        PersonIdService.class,
+        BrukerService.class,
         AktivitetService.class,
         PersistentOppdatering.class
 })

--- a/src/test/java/no/nav/pto/veilarbportefolje/database/BrukerRepositoryTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/database/BrukerRepositoryTest.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -32,7 +33,7 @@ import static no.nav.pto.veilarbportefolje.domene.AAPMaxtidUkeFasettMapping.UKE_
 import static no.nav.pto.veilarbportefolje.domene.DagpengerUkeFasettMapping.UKE_UNDER2;
 import static no.nav.pto.veilarbportefolje.util.DateUtils.timestampFromISO8601;
 import static no.nav.sbl.sql.SqlUtils.insert;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -316,9 +317,9 @@ public class BrukerRepositoryTest {
                 .value("NAV_KONTOR", expectedEnhet)
                 .execute();
 
-        Try<String> result = brukerRepository.retrieveEnhet(fnr);
-        assertTrue(result.isSuccess());
-        assertEquals(expectedEnhet, result.get());
+        Optional<String> navKontor = brukerRepository.hentNavKontor(fnr);
+        assertTrue(navKontor.isPresent());
+        assertEquals(expectedEnhet, navKontor.get());
     }
 
     @Test

--- a/src/test/java/no/nav/pto/veilarbportefolje/kafka/AktivitetKafkaConsumerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/kafka/AktivitetKafkaConsumerTest.java
@@ -13,7 +13,7 @@ import no.nav.pto.veilarbportefolje.domene.Fnr;
 import no.nav.pto.veilarbportefolje.domene.PersonId;
 import no.nav.pto.veilarbportefolje.elastic.ElasticIndexer;
 import no.nav.pto.veilarbportefolje.elastic.domene.OppfolgingsBruker;
-import no.nav.pto.veilarbportefolje.service.PersonIdService;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
 import no.nav.pto.veilarbportefolje.util.DateUtils;
 import org.elasticsearch.action.get.GetResponse;
 import org.json.JSONObject;
@@ -46,7 +46,7 @@ public class AktivitetKafkaConsumerTest extends IntegrationTest {
     private static AktivitetDAO aktivitetDAO;
     private static JdbcTemplate jdbcTemplate;
     private static String indexName;
-    private static PersonIdService personIdService;
+    private static BrukerService brukerService;
     private static BrukerRepository brukerRepository;
     static String aktoerId = "123456789";
     static String aktivitetId = "144500";
@@ -66,11 +66,11 @@ public class AktivitetKafkaConsumerTest extends IntegrationTest {
         aktivitetDAO = new AktivitetDAO(jdbcTemplate, namedParameterJdbcTemplate);
         brukerRepository = mock(BrukerRepository.class);
 
-        personIdService = mock(PersonIdService.class);
+        brukerService = mock(BrukerService.class);
 
         PersistentOppdatering persistentOppdatering = new PersistentOppdatering(new ElasticIndexer(aktivitetDAO, brukerRepository, ELASTIC_CLIENT, mock(UnleashService.class), mock(MetricsClient.class), indexName), brukerRepository, aktivitetDAO);
 
-        aktivitetService = new AktivitetService(aktivitetDAO, persistentOppdatering, personIdService);
+        aktivitetService = new AktivitetService(aktivitetDAO, persistentOppdatering, brukerService);
 
 
         new KafkaConsumerRunnable<>(
@@ -91,7 +91,7 @@ public class AktivitetKafkaConsumerTest extends IntegrationTest {
     @Test
     public void skal_inserte_kafka_melding_i_db () throws InterruptedException {
         Fnr fnr1 = Fnr.of("11111111111");
-        when(personIdService.hentPersonidFraAktoerid(AktoerId.of(aktoerId))).thenReturn(Try.success(PersonId.of("1234")));
+        when(brukerService.hentPersonidFraAktoerid(AktoerId.of(aktoerId))).thenReturn(Try.success(PersonId.of("1234")));
         when(brukerRepository.hentBrukere(any(List.class))).thenReturn(Collections.singletonList(new OppfolgingsBruker().setPerson_id("1234").setFnr(fnr1.getFnr())));
 
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingfeed/OppfolgingFeedHandlerIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingfeed/OppfolgingFeedHandlerIntegrationTest.java
@@ -1,0 +1,176 @@
+package no.nav.pto.veilarbportefolje.oppfolgingfeed;
+
+import no.nav.common.client.aktorregister.AktorregisterClient;
+import no.nav.common.featuretoggle.UnleashService;
+import no.nav.common.metrics.MetricsClient;
+import no.nav.pto.veilarbportefolje.TestUtil;
+import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
+import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteDTO;
+import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteRepository;
+import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteService;
+import no.nav.pto.veilarbportefolje.client.VeilarbVeilederClient;
+import no.nav.pto.veilarbportefolje.database.BrukerRepository;
+import no.nav.pto.veilarbportefolje.database.Table;
+import no.nav.pto.veilarbportefolje.domene.AktoerId;
+import no.nav.pto.veilarbportefolje.domene.BrukerOppdatertInformasjon;
+import no.nav.pto.veilarbportefolje.domene.Fnr;
+import no.nav.pto.veilarbportefolje.domene.VeilederId;
+import no.nav.pto.veilarbportefolje.elastic.ElasticIndexer;
+import no.nav.pto.veilarbportefolje.mock.LeaderElectionClientMock;
+import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingRepository;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
+import no.nav.sbl.sql.SqlUtils;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import static java.time.Instant.now;
+import static no.nav.pto.veilarbportefolje.database.Table.ARBEIDSLISTE.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OppfolgingFeedHandlerIntegrationTest {
+
+    private static OppfolgingFeedHandler oppfolgingFeedHandler;
+    private static ArbeidslisteService arbeidslisteService;
+    private static JdbcTemplate jdbcTemplate;
+    private static AktorregisterClient aktorregisterClientMock;
+
+    @BeforeClass
+    public static void beforeClass() {
+        ElasticIndexer elasticIndexerMock = mock(ElasticIndexer.class);
+
+        aktorregisterClientMock = mock(AktorregisterClient.class);
+
+        SingleConnectionDataSource ds = TestUtil.setupInMemoryDatabase();
+        jdbcTemplate = new JdbcTemplate(ds);
+        NamedParameterJdbcTemplate namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(ds);
+
+        BrukerRepository brukerRepository = new BrukerRepository(jdbcTemplate, namedParameterJdbcTemplate);
+        ArbeidslisteRepository arbeidslisteRepository = new ArbeidslisteRepository(jdbcTemplate, namedParameterJdbcTemplate);
+
+        BrukerService brukerService = new BrukerService(brukerRepository, aktorregisterClientMock);
+
+        arbeidslisteService = new ArbeidslisteService(
+                aktorregisterClientMock,
+                arbeidslisteRepository,
+                brukerService,
+                elasticIndexerMock,
+                mock(MetricsClient.class)
+        );
+
+        OppfolgingRepository oppfolgingRepository = new OppfolgingRepository(jdbcTemplate);
+
+        UnleashService unleashMock = mock(UnleashService.class);
+        when(unleashMock.isEnabled(anyString())).thenReturn(true);
+
+        oppfolgingFeedHandler = new OppfolgingFeedHandler(
+                arbeidslisteService,
+                brukerRepository,
+                elasticIndexerMock,
+                oppfolgingRepository,
+                mock(VeilarbVeilederClient.class),
+                new TestTransactor(),
+                new LeaderElectionClientMock(),
+                unleashMock
+        );
+
+    }
+
+    @After
+    public void tearDown() {
+        jdbcTemplate.execute("TRUNCATE TABLE " + Table.ARBEIDSLISTE.TABLE_NAME);
+        jdbcTemplate.execute("TRUNCATE TABLE " + Table.OPPFOLGINGSBRUKER.TABLE_NAME);
+        jdbcTemplate.execute("TRUNCATE TABLE " + Table.AKTOERID_TO_PERSONID.TABLE_NAME);
+    }
+
+    @Test
+    public void skal_ikke_slette_arbeidsliste_om_bruker_har_samme_nav_kontor_i_arena_som_vi_har_lagret_paa_arbeidslisten() {
+        String aktoerId = "11111111111";
+        String navKontor = "0000";
+
+        setUpInitialState(aktoerId, navKontor, navKontor);
+        sendMeldingPaaFeed(aktoerId);
+
+        Arbeidsliste arbeidsliste = arbeidslisteService.getArbeidsliste(AktoerId.of(aktoerId))
+                .getOrElseThrow(() -> new RuntimeException());
+
+        assertThat(arbeidsliste).isNotNull();
+    }
+
+
+    @Test
+    public void skal_slette_arbeidsliste_om_bruker_ikke_har_samme_nav_kontor_i_arena_som_vi_har_lagret_paa_arbeidslisten() {
+        String aktoerId = "11111111111";
+        String navKontorArena = "0000";
+        String navKontorArbeidsliste = "1111";
+
+        setUpInitialState(aktoerId, navKontorArena, navKontorArbeidsliste);
+        sendMeldingPaaFeed(aktoerId);
+
+        Arbeidsliste arbeidsliste = arbeidslisteService.getArbeidsliste(AktoerId.of(aktoerId))
+                .getOrElseThrow(() -> new RuntimeException());
+
+        assertThat(arbeidsliste).isNull();
+    }
+
+    private static void sendMeldingPaaFeed(String aktoerId) {
+        List<BrukerOppdatertInformasjon> feedData =
+                List.of(new BrukerOppdatertInformasjon()
+                        .setOppfolging(true)
+                        .setAktoerid(aktoerId)
+                );
+
+        oppfolgingFeedHandler.call("", feedData);
+    }
+
+    private static void setUpInitialState(String aktoerId, String navKontorArena, String navKontorArbeidsliste) {
+        String fnr = "00000000000";
+        String personId = "0";
+
+        when(aktorregisterClientMock.hentAktorId(anyString())).thenReturn(aktoerId);
+
+        SqlUtils
+                .insert(jdbcTemplate, Table.OPPFOLGINGSBRUKER.TABLE_NAME)
+                .value(Table.OPPFOLGINGSBRUKER.FODSELSNR, fnr)
+                .value(Table.OPPFOLGINGSBRUKER.PERSON_ID, personId)
+                .value(Table.OPPFOLGINGSBRUKER.NAV_KONTOR, navKontorArena)
+                .execute();
+
+        SqlUtils
+                .insert(jdbcTemplate, Table.AKTOERID_TO_PERSONID.TABLE_NAME)
+                .value(Table.AKTOERID_TO_PERSONID.AKTOERID, aktoerId)
+                .value(Table.AKTOERID_TO_PERSONID.PERSONID, personId)
+                .value(Table.AKTOERID_TO_PERSONID.GJELDENE, true)
+                .execute();
+
+        ArbeidslisteDTO dto = new ArbeidslisteDTO(Fnr.of(fnr))
+                .setNavKontorForArbeidsliste(navKontorArbeidsliste)
+                .setAktoerId(AktoerId.of(aktoerId))
+                .setVeilederId(VeilederId.of("0"))
+                .setFrist(Timestamp.from(now()))
+                .setKategori(Arbeidsliste.Kategori.BLA)
+                .setOverskrift("foo");
+
+        SqlUtils
+                .insert(jdbcTemplate, TABLE_NAME)
+                .value(AKTOERID, dto.getAktoerId().toString())
+                .value(FNR, dto.getFnr().toString())
+                .value(SIST_ENDRET_AV_VEILEDERIDENT, dto.getVeilederId().toString())
+                .value(ENDRINGSTIDSPUNKT, Timestamp.from(now()))
+                .value(OVERSKRIFT, dto.getOverskrift())
+                .value(KOMMENTAR, dto.getKommentar())
+                .value(FRIST, dto.getFrist())
+                .value(KATEGORI, dto.getKategori().name())
+                .value(NAV_KONTOR_FOR_ARBEIDSLISTE, dto.getNavKontorForArbeidsliste())
+                .execute();
+    }
+}

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingfeed/OppfolgingFeedHandlerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingfeed/OppfolgingFeedHandlerTest.java
@@ -28,21 +28,6 @@ import static org.mockito.Mockito.*;
 
 public class OppfolgingFeedHandlerTest {
 
-
-    private class TestTransactor extends Transactor {
-
-        public TestTransactor() {
-            super(null);
-        }
-
-        @Override
-        @SneakyThrows
-        public void inTransaction(InTransaction inTransaction) {
-            inTransaction.run();
-        }
-
-    }
-
     private ArbeidslisteService arbeidslisteService;
     private BrukerRepository brukerRepository;
     private ElasticIndexer elasticIndexer;
@@ -174,14 +159,14 @@ public class OppfolgingFeedHandlerTest {
 
     private void givenBrukerHarVeilederFraAnnenEnhet() {
         when(brukerRepository.retrievePersonid(any())).thenReturn(Try.success(PersonId.of("dummy")));
-        when(brukerRepository.retrieveEnhet(any(PersonId.class))).thenReturn(Try.success("enhet"));
+        when(brukerRepository.retrieveNavKontor(any(PersonId.class))).thenReturn(Try.success("enhet"));
         when(veilarbVeilederClient.hentVeilederePaaEnhet(any())).thenReturn(Collections.singletonList("whatever"));
 
     }
 
     private void givenBrukerHarVeilederFraSammeEnhet() {
         when(brukerRepository.retrievePersonid(any())).thenReturn(Try.success(PersonId.of("dummy")));
-        when(brukerRepository.retrieveEnhet(any(PersonId.class))).thenReturn(Try.success("enhet"));
+        when(brukerRepository.retrieveNavKontor(any(PersonId.class))).thenReturn(Try.success("enhet"));
         when(veilarbVeilederClient.hentVeilederePaaEnhet(any()))
                 .thenReturn(Collections.singletonList((eksisterendeInformasjon.getVeileder())));
 
@@ -190,7 +175,7 @@ public class OppfolgingFeedHandlerTest {
     private void givenBrukerManglerEnhet(){
         when(oppfolgingRepository.retrieveOppfolgingData(AKTOER_ID)).thenReturn(Try.success(eksisterendeInformasjon));
         when(brukerRepository.retrievePersonid(any())).thenReturn(Try.success(PersonId.of("dummy")));
-        when(brukerRepository.retrieveEnhet(any(PersonId.class))).thenReturn(Try.failure(new RuntimeException()));
+        when(brukerRepository.retrieveNavKontor(any(PersonId.class))).thenReturn(Try.failure(new RuntimeException()));
     }
 
     private void givenBrukerManglerPersonId(){

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingfeed/TestTransactor.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingfeed/TestTransactor.java
@@ -1,0 +1,18 @@
+package no.nav.pto.veilarbportefolje.oppfolgingfeed;
+
+import lombok.SneakyThrows;
+import no.nav.pto.veilarbportefolje.database.Transactor;
+
+class TestTransactor extends Transactor {
+
+    public TestTransactor() {
+        super(null);
+    }
+
+    @Override
+    @SneakyThrows
+    public void inTransaction(InTransaction inTransaction) {
+        inTransaction.run();
+    }
+
+}

--- a/src/test/java/no/nav/pto/veilarbportefolje/scheduled/PersonIdToAktorIdScheduleTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/scheduled/PersonIdToAktorIdScheduleTest.java
@@ -6,7 +6,7 @@ import no.nav.common.leaderelection.LeaderElectionClient;
 import no.nav.pto.veilarbportefolje.database.BrukerRepository;
 import no.nav.pto.veilarbportefolje.elastic.ElasticIndexer;
 import no.nav.pto.veilarbportefolje.mock.AktorregisterClientMock;
-import no.nav.pto.veilarbportefolje.service.PersonIdService;
+import no.nav.pto.veilarbportefolje.service.BrukerService;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 public class PersonIdToAktorIdScheduleTest {
 
     private JdbcTemplate db;
-    private PersonIdService personIdService;
+    private BrukerService brukerService;
     private PersonIdToAktorIdSchedule scheduler;
 
     private BrukerRepository brukerRepository;
@@ -39,10 +39,10 @@ public class PersonIdToAktorIdScheduleTest {
         aktorregisterClient = new AktorregisterClientMock();
 
         brukerRepository = new BrukerRepository(db, null);
-        personIdService = new PersonIdService(brukerRepository, aktorregisterClient);
+        brukerService = new BrukerService(brukerRepository, aktorregisterClient);
 
         LeaderElectionClient leaderElectionClient = mock(LeaderElectionClient.class);
-        scheduler = new PersonIdToAktorIdSchedule(personIdService, db, mock(ElasticIndexer.class), leaderElectionClient);
+        scheduler = new PersonIdToAktorIdSchedule(brukerService, db, mock(ElasticIndexer.class), leaderElectionClient);
 
         when(leaderElectionClient.isLeader()).thenReturn(true);
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/service/BrukerServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/service/BrukerServiceTest.java
@@ -11,9 +11,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import java.util.Optional;
 
-import static java.util.Optional.ofNullable;
 import static no.nav.pto.veilarbportefolje.TestUtil.setupInMemoryDatabase;
 import static no.nav.sbl.sql.SqlUtils.insert;
 import static org.junit.Assert.assertEquals;
@@ -24,13 +22,13 @@ import static org.mockito.Mockito.never;
 
 
 @RunWith(SpringJUnit4ClassRunner.class)
-public class PersonIdServiceTest {
+public class BrukerServiceTest {
 
     private static final String AKTOER_ID = "aktoerid1";
     private static final String FNR = "10108000398";
     private static final String PERSON_ID = "111111";
 
-    private PersonIdService personIdService;
+    private BrukerService brukerService;
 
     private JdbcTemplate db;
 
@@ -48,7 +46,7 @@ public class PersonIdServiceTest {
         db = new JdbcTemplate(setupInMemoryDatabase());
         brukerRepository = new BrukerRepository(db, null);
         aktorregisterClient = mock(AktorregisterClient.class);
-        personIdService = new PersonIdService(brukerRepository, aktorregisterClient);
+        brukerService = new BrukerService(brukerRepository, aktorregisterClient);
 
         db.execute("TRUNCATE TABLE OPPFOLGINGSBRUKER");
         db.execute("truncate table AKTOERID_TO_PERSONID");
@@ -73,7 +71,7 @@ public class PersonIdServiceTest {
 
         assertTrue(updated > 0);
 
-        Try<PersonId> result = personIdService.hentPersonidFraAktoerid(aktoerId);
+        Try<PersonId> result = brukerService.hentPersonidFraAktoerid(aktoerId);
         verify(aktorregisterClient, never()).hentFnr(anyString());
         assertTrue(result.isSuccess());
         Assertions.assertEquals(personId, result.get());
@@ -93,7 +91,7 @@ public class PersonIdServiceTest {
         when(aktorregisterClient.hentFnr(nyAktoerId.toString())).thenReturn(FNR);
         when(aktorregisterClient.hentAktorId(FNR)).thenReturn(nyAktoerId.toString());
 
-        personIdService.hentPersonidFraAktoerid(nyAktoerId);
+        brukerService.hentPersonidFraAktoerid(nyAktoerId);
 
         Try<String> gamleAktorId = getGamleAktoerId(PERSON_ID);
         assertEquals(gamleAktorId.get(), AKTOER_ID);
@@ -113,7 +111,7 @@ public class PersonIdServiceTest {
         when(aktorregisterClient.hentFnr(aktoerId.toString())).thenReturn(FNR);
         when(aktorregisterClient.hentAktorId(FNR)).thenReturn(nyAktoerId.toString());
 
-        personIdService.hentPersonidFraAktoerid(aktoerId);
+        brukerService.hentPersonidFraAktoerid(aktoerId);
 
         Try<String> gamleAktorId = getGamleAktoerId(PERSON_ID);
         assertEquals(gamleAktorId.get(), aktoerId.toString());


### PR DESCRIPTION
Vi har opplevd at arbeidslister slettes tilsynelatende uten årsak ved
overføring av oppfølgingsdata og endrer derfor på hvordan logikken for
sjekk om arbeidssliste skal slettes fungerer:

Ved overføring av oppfølgingsdata fra veilarboppfolging skal
arbeidslisten slettes hvis:

1. Brukeren ikke lenger er under oppfølging
2. Bruker har annet nav kontor lagret på arbeidsliste enn det vi får fra
   arena (Bruker har byttet kontor)

Med en slik endring fjerner vi avhengigheter til veilarbveileder/norg og
vil antagelig unngå at arbeidslister forsvinner