### PR TITLE
Oppdaterte veilarbveileder url til å være uavhengig av namespace

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/client/VeilarbVeilederClient.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/client/VeilarbVeilederClient.java
@@ -2,11 +2,9 @@ package no.nav.pto.veilarbportefolje.client;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import no.nav.common.auth.subject.SsoToken;
-import no.nav.common.auth.subject.SubjectHandler;
 import no.nav.common.rest.client.RestClient;
 import no.nav.common.rest.client.RestUtils;
-import no.nav.pto.veilarbportefolje.domene.VeilederId;
+import no.nav.common.utils.EnvironmentUtils;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -25,7 +23,10 @@ public class VeilarbVeilederClient {
     private final OkHttpClient client;
 
     public VeilarbVeilederClient() {
-        url = format("http://veilarbveileder.%s.svc.nais.local/veilarbveileder", requireNamespace());
+        url = EnvironmentUtils.isProduction().orElseThrow()
+                ? "https://veilarbveileder.nais.adeo.no/veilarbveileder"
+                : format("https://veilarbveileder-%s.nais.preprod.local/veilarbveileder", requireNamespace());
+
         this.client = RestClient.baseClient();
     }
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteServiceTest.java
@@ -13,6 +13,7 @@ import no.nav.pto.veilarbportefolje.elastic.ElasticIndexer;
 import no.nav.pto.veilarbportefolje.service.BrukerService;
 import no.nav.sbl.sql.SqlUtils;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -50,6 +51,7 @@ public class ArbeidslisteServiceTest {
         arbeidslisteService = new ArbeidslisteService(aktorregisterClientMock, arbeidslisteRepository, brukerService, mock(ElasticIndexer.class), mock(MetricsClient.class));
     }
 
+    @Before
     @After
     public void tearDown() {
         jdbcTemplate.execute("TRUNCATE TABLE " + Table.ARBEIDSLISTE.TABLE_NAME);


### PR DESCRIPTION
Når veilarbveileder bytter namespace til 'pto' så vil service urler brekke.