### PR TITLE
Impl av npid

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/util/FodselsnummerUtils.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/util/FodselsnummerUtils.java
@@ -18,7 +18,12 @@ public class FodselsnummerUtils {
             fnr = konverterDNummerTilFodselsnummer(fnr);
         }
 
-        String maaned = fnr.substring(2, 4);
+        String maaned;
+        if (erBoostNummer(fnr)) {
+            maaned = konverterBoostNummerTilMoned(fnr);
+        } else {
+            maaned = fnr.substring(2, 4);
+        }
 
         return lagAarstallFraFodselsnummer(fnr) + "-" + maaned + "-" + lagFodselsdagIMnd(fnr) + DATO_POSTFIX;
     }
@@ -35,11 +40,22 @@ public class FodselsnummerUtils {
         return Integer.parseInt(fnr.substring(0, 1)) > 3;
     }
 
+    static boolean erBoostNummer(String fnr) {
+        return Integer.parseInt(fnr.substring(2, 4)) > 20;
+    }
+
     static String konverterDNummerTilFodselsnummer(String dnr) {
         int forsteSiffer = Integer.parseInt(dnr.substring(0, 1));
         forsteSiffer -= 4;
         return forsteSiffer + dnr.substring(1);
     }
+
+    private static String konverterBoostNummerTilMoned(String boostNr) {
+        int moned = Integer.parseInt(boostNr.substring(2, 4));
+        moned -= 20;
+        return (moned > 9) ? String.valueOf(moned) : "0" + moned;
+    }
+
 
     static int lagAarstallFraFodselsnummer(String fnr) {
         int individnummer = Integer.parseInt(fnr.substring(6, 9));

--- a/src/test/java/no/nav/pto/veilarbportefolje/util/FodselsnummerUtilsTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/util/FodselsnummerUtilsTest.java
@@ -54,6 +54,14 @@ public class FodselsnummerUtilsTest {
     }
 
     @Test
+    public void skalLageFodselsdatoStringFraBoostNr() {
+        String fodselsnummer1 = "10308000399"; //TESTFAMILIE BOOST
+        String fodselsnummer2 = "10218000399"; //TESTFAMILIE BOOST
+        assertThat(FodselsnummerUtils.lagFodselsdato(fodselsnummer1)).isEqualTo("1980-10-10T00:00:00Z");
+        assertThat(FodselsnummerUtils.lagFodselsdato(fodselsnummer2)).isEqualTo("1980-01-10T00:00:00Z");
+    }
+
+    @Test
     public void skalLageAarstallFraFodselsnummer() {
         String fodselsnummer1900a = "00001849900";
         String fodselsnummer1900b = "00000249900";


### PR DESCRIPTION
Litt info om NPID BOST-nummer (også kalt B-nummer] fra TPS er migrert til PDL, og har fått betegnelsen NPID. NPID består av 11 siffer, hvor tall på plass 3 og 4 (måned på FNR) er mellom 21 og 32. Dette er en intern identifikator som hovedsakelig er blitt benyttet på bidragsområdet. I dag kan det opprettes en NPID i de tilfeller man ikke har god nok dokumentasjon til å rekvirere d-nummer, eller man mangler en opplysningstype som er obligatorisk ved rekvisisjon av d-nummer. Det er en del begrensninger i bruken av denne identifikatoren, da ikke alle fagsystemer har åpnet for den. Per juni 2021 er det 19222 personer med NPID i PDL.