### PR TITLE
Legger til ny topic: teampam.cv-endret-ekstern-v2

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/cv/CVService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/cv/CVService.java
@@ -31,6 +31,21 @@ public class CVService extends KafkaCommonConsumerService<Melding> {
         opensearchIndexerV2.updateCvEksistere(aktoerId, cvEksisterer);
     }
 
+    public void behandleKafkaMeldingLogikkV2(ConsumerRecord<String, Melding> kafkarecord) {
+        log.info(
+                "Behandler kafka-melding med key: {} og offset: {}, og partition: {} på topic {}",
+                kafkarecord.key(),
+                kafkarecord.offset(),
+                kafkarecord.partition(),
+                kafkarecord.topic()
+        );
+        var kafkaMelding = kafkarecord.value();
+        AktorId aktoerId = AktorId.of(kafkaMelding.getAktoerId());
+        boolean cvEksisterer = cvEksistere(kafkaMelding);
+
+        cvRepositoryV2.upsertCVEksisterer(aktoerId, cvEksisterer);
+    }
+
     public void behandleKafkaMeldingCVHjemmel(ConsumerRecord<String, CVMelding> kafkaMelding) {
         log.info(
                 "Behandler kafka-melding med key {} og offset {} på topic {}",

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaConfigCommon.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaConfigCommon.java
@@ -94,6 +94,7 @@ public class KafkaConfigCommon {
         SIST_LEST("aapen-fo-veilederHarLestAktivitetsplanen-v1"),
         ENDRING_PAA_OPPFOLGINGSBRUKER("pto.endring-paa-oppfolgingsbruker-v2"),
 
+        CV_ENDRET_V2("teampam.cv-endret-ekstern-v2"),
         CV_ENDRET_AIVEN("teampam.cv-endret-avro-v1"),
         CV_TOPIC("teampam.samtykke-status-1"),
         OPPFOLGING_PERIODE("pto.siste-oppfolgingsperiode-v1"),
@@ -275,6 +276,16 @@ public class KafkaConfigCommon {
                                         Deserializers.stringDeserializer(),
                                         new AivenAvroDeserializer<Melding>().getDeserializer(),
                                         cvService::behandleKafkaRecord
+                                ),
+                        new KafkaConsumerClientBuilder.TopicConfig<String, Melding>()
+                                .withLogging()
+                                .withMetrics(prometheusMeterRegistry)
+                                .withStoreOnFailure(consumerRepository)
+                                .withConsumerConfig(
+                                        Topic.CV_ENDRET_V2.topicName,
+                                        Deserializers.stringDeserializer(),
+                                        new AivenAvroDeserializer<Melding>().getDeserializer(),
+                                        cvService::behandleKafkaMeldingLogikkV2
                                 ),
                         new KafkaConsumerClientBuilder.TopicConfig<String, VeilederTilordnetDTO>()
                                 .withLogging()


### PR DESCRIPTION
Starter å konsumere ny topic: teampam.cv-endret-ekstern-v2
Vi starter med å kunsumere ny topic i parallell med den gamle. Dette gjøres for å hindre tap av meldinger i overgansfasen
Når begge topiene har kjørt litt sammtidig vil vi være klare for å fjerne koblingen til v1 topicen