### PR TITLE
Bump opensearch-rest-high-level-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
         <dependency>
             <groupId>org.opensearch.client</groupId>
             <artifactId>opensearch-rest-high-level-client</artifactId>
-            <version>1.3.5</version>
+            <version>1.3.6</version>
         </dependency>
 
         <!--Diverse-->

--- a/src/test/java/no/nav/pto/veilarbportefolje/config/OpenSearchContainer.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/config/OpenSearchContainer.java
@@ -13,9 +13,13 @@ public class OpenSearchContainer extends GenericContainer<OpenSearchContainer>{
                 .withTag(opensearchVersion));
     }
 
+    /**
+     * Denne versjonen bør samsvare med versjon av instans i Aiven. Versjon kan sjekkes ved å spørre i
+     * <a href="https://nav-it.slack.com/archives/C5KUST8N6/p1665564633449399">#nais</a>.
+     */
     public OpenSearchContainer() {
         super(DockerImageName.parse("opensearchproject/opensearch")
-                .withTag(OpenSearchClient.class.getPackage().getImplementationVersion()));
+                .withTag("1.2.4"));
         log.info("Starter opensearch med versjon: {}", OpenSearchClient.class.getPackage().getImplementationVersion());
     }
 


### PR DESCRIPTION
Bruk samme versjon som for org.opensearch.opensearch. Setter også versjon av OpenSearch container slik at den samsvarer med instans i Aiven.