### PR TITLE
TC-260 Legg til felt for §14a-vedtak avvik i OpenSearch

### DIFF
--- a/src/main/resources/opensearch_settings.json
+++ b/src/main/resources/opensearch_settings.json
@@ -204,6 +204,9 @@
       },
       "bostedSistOppdatert": {
         "type": "date"
+      },
+      "avvik14aVedtak": {
+        "type": "keyword"
       }
     }
   }


### PR DESCRIPTION
Oppdaterer OpenSearch med nytt felt som vi senere skal bruke for å kunne filtrere på avvikstype ifm. §14a-vedtak.
"Avvik" i denne sammenhengen refererer til potensielle avvik mellom Arena og vedtaksstotte som vi ønsker å avdekke og synliggjøre for veileder i overgangsfasen.