### PR TITLE
TC-306 Fikse feil i utlopte aktiviteter filter

### DIFF
--- a/.intelliJ_ddl/DDL.sql
+++ b/.intelliJ_ddl/DDL.sql
@@ -181,7 +181,8 @@ CREATE TABLE public.brukertiltak_v2 (
     tiltakskode character varying(10),
     tildato timestamp without time zone,
     fradato timestamp without time zone,
-    version bigint
+    version bigint,
+    status character varying(255)
 );
 
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetService.java
@@ -41,11 +41,11 @@ public class AktivitetService extends KafkaCommonConsumerService<KafkaAktivitetM
         boolean erTiltaksaktivitet = KafkaAktivitetMelding.AktivitetTypeData.TILTAK == aktivitetData.aktivitetType;
 
         if (erTiltaksaktivitet) {
-            //Midlertidig loggmelding ifbm overgang til ny datakilde for lønnstilskudd
+            // Midlertidig loggmelding ifbm overgang til ny datakilde for lønnstilskudd
             log.info("Behandler tiltaksaktivitet fra ny kilde");
             behandleTiltaksaktivitetMelding(aktivitetData, aktorId);
         } else {
-            //Midlertidig loggmelding ifbm overgang til ny datakilde for lønnstilskudd
+            // Midlertidig loggmelding ifbm overgang til ny datakilde for lønnstilskudd
             log.info("Behandler aktivitetsplanaktivitet");
             behandleAktivitetsplanAktivitetMelding(aktivitetData, aktorId);
         }

--- a/src/main/java/no/nav/pto/veilarbportefolje/arenapakafka/aktiviteter/TiltakService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arenapakafka/aktiviteter/TiltakService.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static no.nav.common.client.utils.CacheUtils.tryCacheFirst;
@@ -54,7 +55,7 @@ public class TiltakService {
                 kafkaMelding.partition(),
                 kafkaMelding.topic()
         );
-            behandleKafkaMelding(melding);
+        behandleKafkaMelding(melding);
     }
 
 
@@ -151,14 +152,15 @@ public class TiltakService {
                 .setTilDato(ArenaDato.of(kafkaMelding.getTilDato()))
                 .setTiltakskode(kafkaMelding.getTiltakskode())
                 .setTiltaksnavn(TiltakkodeverkMapper.mapTilTiltaknavn(kafkaMelding.getTiltakskode()))
-                .setVersion(kafkaMelding.getVersion());
+                .setVersion(kafkaMelding.getVersion())
+                .setStatus(Optional.ofNullable(kafkaMelding.getAktivitetStatus()).map(status -> status.name().toLowerCase()).orElse(null));
     }
 
     public EnhetTiltak hentEnhettiltak(EnhetId enhet) {
         return tryCacheFirst(enhetTiltakCachePostgres, enhet,
                 () ->
                         tiltakRepositoryV3.hentTiltakPaEnhet(enhet)
-                );
+        );
     }
 
     private boolean erGammelMelding(TiltakDTO kafkaMelding, TiltakInnhold innhold) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexer.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexer.java
@@ -15,7 +15,6 @@ import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.common.xcontent.XContentType;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StopWatch;
 
 import java.io.IOException;
 import java.util.List;
@@ -52,12 +51,8 @@ public class OpensearchIndexer {
             postgresOpensearchMapper.flettInnSisteEndringerData(List.of(bruker));
             postgresOpensearchMapper.flettInnStatsborgerskapData(List.of(bruker));
 
-            if(FeatureToggle.mapAvvik14aVedtak(unleashService)) {
-                StopWatch sw = new StopWatch();
-                sw.start();
+            if (FeatureToggle.mapAvvik14aVedtak(unleashService)) {
                 postgresOpensearchMapper.flettInnAvvik14aVedtak(List.of(bruker));
-                sw.stop();
-                log.info(sw.shortSummary());
             }
 
             syncronIndekseringsRequest(bruker);

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/utils/TiltakaktivitetEntity.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/utils/TiltakaktivitetEntity.java
@@ -15,4 +15,5 @@ public class TiltakaktivitetEntity {
     ArenaDato tilDato;
     ArenaDato fraDato;
     Long version;
+    String status;
 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
@@ -52,7 +52,16 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
 
 
     @Autowired
-    public LonnstilskuddUtAvArenaTest(JdbcTemplate jdbcTemplatePostgres, TiltakRepositoryV2 tiltakRepositoryV2, TiltakRepositoryV3 tiltakRepositoryV3, TiltakService tiltakService, UnleashService unleashService, AktorClient aktorClient, AktivitetService aktivitetService, AktiviteterRepositoryV2 aktiviteterRepositoryV2, OpensearchService opensearchService) {
+    public LonnstilskuddUtAvArenaTest(
+            JdbcTemplate jdbcTemplatePostgres,
+            TiltakRepositoryV2 tiltakRepositoryV2,
+            TiltakRepositoryV3 tiltakRepositoryV3,
+            TiltakService tiltakService,
+            UnleashService unleashService,
+            AktorClient aktorClient,
+            AktivitetService aktivitetService,
+            OpensearchService opensearchService
+    ) {
         this.jdbcTemplatePostgres = jdbcTemplatePostgres;
         this.tiltakRepositoryV2 = tiltakRepositoryV2;
         this.tiltakRepositoryV3 = tiltakRepositoryV3;
@@ -73,6 +82,126 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
         jdbcTemplatePostgres.update("TRUNCATE brukertiltak_v2");
         jdbcTemplatePostgres.update("TRUNCATE tiltakkodeverket");
         jdbcTemplatePostgres.update("TRUNCATE lest_arena_hendelse_aktivitet");
+    }
+
+    @Test
+    public void skal_ikke_returnere_tiltaksdata_naar_status_er_av_type_AktivitetIkkeAktivStatuser() {
+        Mockito.when(unleashService.isEnabled(FeatureToggle.STOPP_INDEKSERING_AV_TILTAKSAKTIVITETER)).thenReturn(false);
+        NavKontor navKontor = randomNavKontor();
+        AktorId aktorId1 = randomAktorId();
+        AktorId aktorId2 = randomAktorId();
+        Fnr fnr1 = randomFnr();
+        Fnr fnr2 = randomFnr();
+        when(aktorClient.hentAktorId(fnr1)).thenReturn(aktorId1);
+        when(aktorClient.hentAktorId(fnr2)).thenReturn(aktorId2);
+        testDataClient.lagreBrukerUnderOppfolging(aktorId1, fnr1, navKontor.getValue());
+        testDataClient.lagreBrukerUnderOppfolging(aktorId2, fnr2, navKontor.getValue());
+
+        Map.Entry<String, String> til1 = Map.entry("MIDLONTIL", "Midlertidig lønnstilskudd");
+        Map.Entry<String, String> til2 = Map.entry("VARLONTIL", "Varig lønnstilskudd");
+
+        KafkaAktivitetMelding k1 = new KafkaAktivitetMelding()
+                .setAktivitetId("TA-123456789")
+                .setAktorId(aktorId1.get())
+                .setAktivitetType(KafkaAktivitetMelding.AktivitetTypeData.TILTAK)
+                .setEndretDato(ZonedDateTime.parse("2021-01-01T00:00:00+02:00"))
+                .setFraDato(ZonedDateTime.parse("2018-10-03T00:00:00+02:00"))
+                .setTilDato(ZonedDateTime.parse("2024-11-01T00:00:00+02:00"))
+                .setAktivitetStatus(KafkaAktivitetMelding.AktivitetStatus.GJENNOMFORES)
+                .setTiltakskode(til1.getKey())
+                .setVersion(1L)
+                .setAvtalt(true)
+                .setHistorisk(false);
+
+        KafkaAktivitetMelding k2 = new KafkaAktivitetMelding()
+                .setAktivitetId("TA-223456789")
+                .setAktorId(aktorId2.get())
+                .setAktivitetType(KafkaAktivitetMelding.AktivitetTypeData.TILTAK)
+                .setEndretDato(ZonedDateTime.parse("2021-01-01T00:00:00+02:00"))
+                .setFraDato(ZonedDateTime.parse("2017-10-03T00:00:00+02:00"))
+                .setTilDato(ZonedDateTime.parse("2023-11-01T00:00:00+02:00"))
+                .setAktivitetStatus(KafkaAktivitetMelding.AktivitetStatus.AVBRUTT)
+                .setTiltakskode(til2.getKey())
+                .setVersion(1L)
+                .setAvtalt(true)
+                .setHistorisk(false);
+
+        aktivitetService.behandleKafkaMeldingLogikk(k1);
+        aktivitetService.behandleKafkaMeldingLogikk(k2);
+
+        EnhetTiltak tiltak = tiltakService.hentEnhettiltak(EnhetId.of(navKontor.getValue()));
+        assertThat(tiltak.getTiltak()).containsExactlyInAnyOrderEntriesOf(Map.of("MIDLONTIL", "Midlertidig lønnstilskudd"));
+    }
+
+    @Test
+    public void skal_ikke_indeksere_bruker_med_tiltaksaktivitet_data_naar_status_er_av_type_AktivitetIkkeAktivStatuser() {
+        Mockito.when(unleashService.isEnabled(FeatureToggle.STOPP_INDEKSERING_AV_TILTAKSAKTIVITETER)).thenReturn(false);
+        NavKontor navKontor = randomNavKontor();
+        AktorId aktorId1 = randomAktorId();
+        AktorId aktorId2 = randomAktorId();
+        Fnr fnr1 = randomFnr();
+        Fnr fnr2 = randomFnr();
+        when(aktorClient.hentAktorId(fnr1)).thenReturn(aktorId1);
+        when(aktorClient.hentAktorId(fnr2)).thenReturn(aktorId2);
+        testDataClient.lagreBrukerUnderOppfolging(aktorId1, fnr1, navKontor.getValue());
+        testDataClient.lagreBrukerUnderOppfolging(aktorId2, fnr2, navKontor.getValue());
+
+        Map.Entry<String, String> til1 = Map.entry("MIDLONTIL", "Midlertidig lønnstilskudd");
+        Map.Entry<String, String> til2 = Map.entry("VARLONTIL", "Varig lønnstilskudd");
+
+        KafkaAktivitetMelding k1 = new KafkaAktivitetMelding()
+                .setAktivitetId("TA-123456789")
+                .setAktorId(aktorId1.get())
+                .setAktivitetType(KafkaAktivitetMelding.AktivitetTypeData.TILTAK)
+                .setEndretDato(ZonedDateTime.parse("2021-01-01T00:00:00+02:00"))
+                .setFraDato(ZonedDateTime.parse("2018-10-03T00:00:00+02:00"))
+                .setTilDato(ZonedDateTime.parse("2024-11-01T00:00:00+02:00"))
+                .setAktivitetStatus(KafkaAktivitetMelding.AktivitetStatus.GJENNOMFORES)
+                .setTiltakskode(til1.getKey())
+                .setVersion(1L)
+                .setAvtalt(true)
+                .setHistorisk(false);
+
+        KafkaAktivitetMelding k2 = new KafkaAktivitetMelding()
+                .setAktivitetId("TA-223456789")
+                .setAktorId(aktorId2.get())
+                .setAktivitetType(KafkaAktivitetMelding.AktivitetTypeData.TILTAK)
+                .setEndretDato(ZonedDateTime.parse("2021-01-01T00:00:00+02:00"))
+                .setFraDato(ZonedDateTime.parse("2017-10-03T00:00:00+02:00"))
+                .setTilDato(ZonedDateTime.parse("2023-11-01T00:00:00+02:00"))
+                .setAktivitetStatus(KafkaAktivitetMelding.AktivitetStatus.AVBRUTT)
+                .setTiltakskode(til2.getKey())
+                .setVersion(1L)
+                .setAvtalt(true)
+                .setHistorisk(false);
+
+        aktivitetService.behandleKafkaMeldingLogikk(k1);
+        aktivitetService.behandleKafkaMeldingLogikk(k2);
+
+        verifiserAsynkront(5, TimeUnit.SECONDS, () -> {
+                    BrukereMedAntall response1 = opensearchService.hentBrukere(
+                            navKontor.getValue(),
+                            empty(),
+                            "asc",
+                            "ikke_satt",
+                            new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
+                            null,
+                            null);
+
+                    assertThat(response1.getAntall()).isEqualTo(1);
+
+                    BrukereMedAntall response2 = opensearchService.hentBrukere(
+                            navKontor.getValue(),
+                            empty(),
+                            "asc",
+                            "ikke_satt",
+                            new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
+                            null,
+                            null);
+
+                    assertThat(response2.getAntall()).isEqualTo(0);
+                }
+        );
     }
 
     @Test
@@ -102,7 +231,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setAktivitetperiodeFra(new ArenaDato("2018-10-03"))
                 .setAktivitetperiodeTil(new ArenaDato("2024-11-01"))
                 .setAktivitetid("TA-123456789");
-        tiltakService.behandleKafkaRecord(new ConsumerRecord(TILTAK_TOPIC.getTopicName(), 1, 0, "melding1", new TiltakDTO().setBefore(null).setAfter(i1a)));
+        tiltakService.behandleKafkaRecord(new ConsumerRecord<>(TILTAK_TOPIC.getTopicName(), 1, 0, "melding1", new TiltakDTO().setBefore(null).setAfter(i1a)));
 
         TiltakInnhold i1b = new TiltakInnhold()
                 .setFnr(fnr1.get())
@@ -111,7 +240,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setAktivitetperiodeFra(new ArenaDato("2018-10-03"))
                 .setAktivitetperiodeTil(new ArenaDato("2024-11-01"))
                 .setAktivitetid("TA-567891011");
-        tiltakService.behandleKafkaRecord(new ConsumerRecord(TILTAK_TOPIC.getTopicName(), 1, 0, "melding2", new TiltakDTO().setBefore(null).setAfter(i1b)));
+        tiltakService.behandleKafkaRecord(new ConsumerRecord<>(TILTAK_TOPIC.getTopicName(), 1, 0, "melding2", new TiltakDTO().setBefore(null).setAfter(i1b)));
 
 
         KafkaAktivitetMelding k1 = new KafkaAktivitetMelding()
@@ -180,8 +309,6 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
 
                     assertThat(response2.getAntall()).isEqualTo(1);
                 }
-
-
         );
     }
 
@@ -254,7 +381,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setAktivitetperiodeFra(new ArenaDato("2018-10-03"))
                 .setAktivitetperiodeTil(new ArenaDato("2024-11-01"))
                 .setAktivitetid("TA-123456789");
-        tiltakService.behandleKafkaRecord(new ConsumerRecord(TILTAK_TOPIC.getTopicName(), 1, 0, "melding1", new TiltakDTO().setBefore(null).setAfter(i1a)));
+        tiltakService.behandleKafkaRecord(new ConsumerRecord<>(TILTAK_TOPIC.getTopicName(), 1, 0, "melding1", new TiltakDTO().setBefore(null).setAfter(i1a)));
 
         TiltakInnhold i1b = new TiltakInnhold()
                 .setFnr(fnr1.get())
@@ -263,7 +390,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setAktivitetperiodeFra(new ArenaDato("2018-10-03"))
                 .setAktivitetperiodeTil(new ArenaDato("2024-11-01"))
                 .setAktivitetid("TA-567891011");
-        tiltakService.behandleKafkaRecord(new ConsumerRecord(TILTAK_TOPIC.getTopicName(), 1, 0, "melding2", new TiltakDTO().setBefore(null).setAfter(i1b)));
+        tiltakService.behandleKafkaRecord(new ConsumerRecord<>(TILTAK_TOPIC.getTopicName(), 1, 0, "melding2", new TiltakDTO().setBefore(null).setAfter(i1b)));
 
 
         KafkaAktivitetMelding k1 = new KafkaAktivitetMelding()
@@ -363,7 +490,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setAktivitetperiodeFra(new ArenaDato("2018-10-03"))
                 .setAktivitetperiodeTil(new ArenaDato("2024-11-01"))
                 .setAktivitetid("TA-123456789");
-        tiltakService.behandleKafkaRecord(new ConsumerRecord(TILTAK_TOPIC.getTopicName(), 1, 0, "melding1", new TiltakDTO().setBefore(null).setAfter(i1a)));
+        tiltakService.behandleKafkaRecord(new ConsumerRecord<>(TILTAK_TOPIC.getTopicName(), 1, 0, "melding1", new TiltakDTO().setBefore(null).setAfter(i1a)));
 
         TiltakInnhold i1b = new TiltakInnhold()
                 .setFnr(fnr1.get())
@@ -372,7 +499,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setAktivitetperiodeFra(new ArenaDato("2018-10-03"))
                 .setAktivitetperiodeTil(new ArenaDato("2024-11-01"))
                 .setAktivitetid("TA-456789101");
-        tiltakService.behandleKafkaRecord(new ConsumerRecord(TILTAK_TOPIC.getTopicName(), 1, 1, "melding2", new TiltakDTO().setBefore(null).setAfter(i1b)));
+        tiltakService.behandleKafkaRecord(new ConsumerRecord<>(TILTAK_TOPIC.getTopicName(), 1, 1, "melding2", new TiltakDTO().setBefore(null).setAfter(i1b)));
 
         TiltakInnhold i2 = new TiltakInnhold()
                 .setFnr(fnr2.get())
@@ -381,7 +508,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setAktivitetperiodeFra(new ArenaDato("2017-10-03"))
                 .setAktivitetperiodeTil(new ArenaDato("2023-11-01"))
                 .setAktivitetid("TA-223456789");
-        tiltakService.behandleKafkaRecord(new ConsumerRecord(TILTAK_TOPIC.getTopicName(), 1, 2, "melding3", new TiltakDTO().setBefore(null).setAfter(i2)));
+        tiltakService.behandleKafkaRecord(new ConsumerRecord<>(TILTAK_TOPIC.getTopicName(), 1, 2, "melding3", new TiltakDTO().setBefore(null).setAfter(i2)));
 
         TiltakInnhold i3 = new TiltakInnhold()
                 .setFnr(fnr3.get())
@@ -390,7 +517,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setAktivitetperiodeFra(new ArenaDato("2016-10-03"))
                 .setAktivitetperiodeTil(new ArenaDato("2022-11-01"))
                 .setAktivitetid("TA-323456789");
-        tiltakService.behandleKafkaRecord(new ConsumerRecord(TILTAK_TOPIC.getTopicName(), 1, 3, "melding4", new TiltakDTO().setBefore(null).setAfter(i3)));
+        tiltakService.behandleKafkaRecord(new ConsumerRecord<>(TILTAK_TOPIC.getTopicName(), 1, 3, "melding4", new TiltakDTO().setBefore(null).setAfter(i3)));
 
         tiltakRepositoryV3.leggTilTiltak(aktoerIder, result);
 
@@ -482,7 +609,8 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setTiltaksnavn(til1.getValue())
                 .setFraDato(new ArenaDato("2018-10-03"))
                 .setTilDato(new ArenaDato("2024-11-01"))
-                .setAktivitetId("TA-123456789");
+                .setAktivitetId("TA-123456789")
+                .setStatus("GJENNOMFORES");
         tiltakRepositoryV3.upsert(d1a, aktorId1);
 
         TiltakaktivitetEntity d2 = new TiltakaktivitetEntity()
@@ -490,7 +618,8 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setTiltaksnavn(til2.getValue())
                 .setFraDato(new ArenaDato("2017-10-03"))
                 .setTilDato(new ArenaDato("2023-11-01"))
-                .setAktivitetId("TA-223456789");
+                .setAktivitetId("TA-223456789")
+                .setStatus("GJENNOMFORES");
         tiltakRepositoryV3.upsert(d2, aktorId2);
 
         EnhetTiltak et2 = tiltakRepositoryV3.hentTiltakPaEnhet(EnhetId.of(navKontor.getValue()));
@@ -565,14 +694,16 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setTiltakskode(til1.getKey())
                 .setFraDato(new ArenaDato("2018-10-03"))
                 .setTilDato(new ArenaDato("2024-11-01"))
-                .setAktivitetId("TA-123456789");
+                .setAktivitetId("TA-123456789")
+                .setStatus("GJENNOMFORES");
         tiltakRepositoryV3.upsert(d1a, a1);
 
         TiltakaktivitetEntity d2 = new TiltakaktivitetEntity()
                 .setTiltakskode(til2.getKey())
                 .setFraDato(new ArenaDato("2017-10-03"))
                 .setTilDato(new ArenaDato("2023-11-01"))
-                .setAktivitetId("TA-223456789");
+                .setAktivitetId("TA-223456789")
+                .setStatus("GJENNOMFORES");
         tiltakRepositoryV3.upsert(d2, a2);
 
         tiltakRepositoryV3.leggTilTiltak(aktoerIder, result2);
@@ -614,14 +745,16 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setTiltakskode(til1.getKey())
                 .setFraDato(new ArenaDato("2018-10-03"))
                 .setTilDato(new ArenaDato("2024-11-01"))
-                .setAktivitetId("1122");
+                .setAktivitetId("1122")
+                .setStatus("GJENNOMFORES");
         tiltakRepositoryV3.upsert(d1, a1);
 
         TiltakaktivitetEntity d2 = new TiltakaktivitetEntity()
                 .setTiltakskode(til2.getKey())
                 .setFraDato(new ArenaDato("2017-10-03"))
                 .setTilDato(new ArenaDato("2023-11-01"))
-                .setAktivitetId("2233");
+                .setAktivitetId("2233")
+                .setStatus("GJENNOMFORES");
         tiltakRepositoryV3.upsert(d2, a1);
 
         tiltakRepositoryV3.leggTilTiltak(aktoerIder, result);

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
@@ -175,8 +175,22 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                 .setAvtalt(true)
                 .setHistorisk(false);
 
+        KafkaAktivitetMelding k3 = new KafkaAktivitetMelding()
+                .setAktivitetId("TA-323456789")
+                .setAktorId(aktorId2.get())
+                .setAktivitetType(KafkaAktivitetMelding.AktivitetTypeData.TILTAK)
+                .setEndretDato(ZonedDateTime.parse("2021-01-01T00:00:00+02:00"))
+                .setFraDato(ZonedDateTime.parse("2017-10-03T00:00:00+02:00"))
+                .setTilDato(ZonedDateTime.parse("2023-11-01T00:00:00+02:00"))
+                .setAktivitetStatus(null)
+                .setTiltakskode(til1.getKey())
+                .setVersion(1L)
+                .setAvtalt(true)
+                .setHistorisk(false);
+
         aktivitetService.behandleKafkaMeldingLogikk(k1);
         aktivitetService.behandleKafkaMeldingLogikk(k2);
+        aktivitetService.behandleKafkaMeldingLogikk(k3);
 
         verifiserAsynkront(5, TimeUnit.SECONDS, () -> {
                     BrukereMedAntall response1 = opensearchService.hentBrukere(


### PR DESCRIPTION
**Hva**:
Denne endringen løser inkonsistente data/feil i filtrene i Modia oversikten som følger av at brukere ble indeksert med data om blant annet avbrutte aktiviteter. Feilen har oppstått i forbindelse med overgang til ny datakilde for aktiviteter av typen "Midlertidig lønnstilskudd" og "Varig lønnstilskudd" da håndtering av aktiviteter gjøres noe annerledes mellom gammel og ny kilde.

I praksis vil endringen resultere i at vi _kun_ viser data om "Lønnstilskudd"-aktiviteter for bruker/enhet dersom status er enten `PLANLAGT` eller `GJENNOMFORES`.

**Hvorfor**:
Endringen er nødvendig for å gjenopprette konsistens i dataene/filtrene i Modia oversikten. 

**Hvordan**:
Løsningen tar i bruk et nyopprettet databasefelt, `STATUS`, på tabellen `BRUKERTILTAK_V2`, som populeres med statusen til aktiviteten som vi leser fra Kafka-topicen `pto.aktivitet-portefolje-v1`. Når vi deretter leser data fra tabellen ved indeksering av bruker så bruker vi tilsvarende filter i SQL-queryet som ved lesing fra `AKTIVITETER`-tabellen.

Vi vil også måtte lese inn alle meldinger på `pto.aktivitet-portefolje-v1`-topicet fra tidspunktet der "Midlertidig lønnstilskudd" og "Varig lønnstilskudd" aktiviteter ble begynt å publiseres her.

**Løser**:
- [TC-306](https://trello.com/c/0QOZIemD/306-filtrere-l%C3%B8nnstilskudd-aktiviteter-basert-p%C3%A5-aktivitetsstatus)
- [FAGSYSTEM-262369](https://jira.adeo.no/browse/FAGSYSTEM-262369)

**Før merge**:
- [x] Ta en avsjekk med Kari