### PR TITLE
Legg til ny enum-verdi for InnsenderData

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/KafkaAktivitetMelding.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/KafkaAktivitetMelding.java
@@ -66,7 +66,8 @@ public class KafkaAktivitetMelding {
         NAV,
         ARBEIDSGIVER,
         TILTAKSARRANGOER,
-        ARENAIDENT
+        ARENAIDENT,
+        SYSTEM
     }
 
     public enum CvKanDelesStatus {


### PR DESCRIPTION
## Describe your changes

Team DAB har tatt i bruk en ny enum-verdi for `InnsenderData` som vi mangler. Vi må legge denne til slik at vi ikke får feil ved prosessering av kafka-meldinger på `pto.aktivitet-portefolje-v1`-topicet.

## Trello ticket number and link

Ikke relevant.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
