### PR TITLE
TC-270 Fikse feil der brukere som ikke skulle inkluderes kom med i statustall

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -742,8 +742,10 @@ public class OpensearchQueryBuilder {
                 "adressebeskyttelseEllerSkjermingTotalt",
                 boolQuery()
                         .must(filtrereEnhet)
-                        .should(existsQuery("diskresjonskode"))
-                        .should(termQuery("egen_ansatt", true))
+                        .must(boolQuery()
+                                .should(existsQuery("diskresjonskode"))
+                                .should(termQuery("egen_ansatt", true))
+                        )
         );
     }
 
@@ -752,8 +754,10 @@ public class OpensearchQueryBuilder {
                 "adressebeskyttelseEllerSkjermingUfordelte",
                 boolQuery()
                         .must(filtrereEnhet)
-                        .should(existsQuery("diskresjonskode"))
-                        .should(termQuery("egen_ansatt", true))
+                        .must(boolQuery()
+                                .should(existsQuery("diskresjonskode"))
+                                .should(termQuery("egen_ansatt", true))
+                        )
                         .must(byggUfordeltBrukereQuery(veiledereMedTilgangTilEnhet))
         );
     }
@@ -763,8 +767,10 @@ public class OpensearchQueryBuilder {
                 "adressebeskyttelseEllerSkjermingVenterPaSvarFraNAV",
                 boolQuery()
                         .must(filtrereEnhet)
-                        .should(existsQuery("diskresjonskode"))
-                        .should(termQuery("egen_ansatt", true))
+                        .must(boolQuery()
+                                .should(existsQuery("diskresjonskode"))
+                                .should(termQuery("egen_ansatt", true))
+                        )
                         .must(existsQuery("venterpasvarfranav"))
         );
     }

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -602,6 +602,10 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
         OppfolgingsBruker egen_ansatt_og_kode_7_bruker_med_tilordnet_veileder = genererRandomBruker(true, TEST_ENHET, TEST_VEILEDER_3, "7", true);
         OppfolgingsBruker egen_ansatt_og_kode_7_bruker_som_venter_pa_svar_fra_nav = genererRandomBruker(true, TEST_ENHET, TEST_VEILEDER_3, "7", true).setVenterpasvarfranav(toIsoUTC(LocalDateTime.now()));
 
+        OppfolgingsBruker fordelt_bruker_som_ikke_skal_inkluderes = genererRandomBruker(true, TEST_ENHET, TEST_VEILEDER_3, null, false);
+        OppfolgingsBruker ufordelt_bruker_som_ikke_skal_inkluderes = genererRandomBruker(true, TEST_ENHET, null, null, false);
+        OppfolgingsBruker bruker_som_venter_pa_svar_fra_nav_som_ikke_skal_inkluderes = genererRandomBruker(true, TEST_ENHET, null, null, false).setVenterpasvarfranav(toIsoUTC(LocalDateTime.now()));
+
         List<OppfolgingsBruker> brukere = List.of(
                 kode_6_bruker,
                 kode_6_bruker_med_tilordnet_veileder,
@@ -614,7 +618,10 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 egen_ansatt_bruker_som_venter_pa_svar_fra_nav,
                 egen_ansatt_og_kode_7_bruker,
                 egen_ansatt_og_kode_7_bruker_med_tilordnet_veileder,
-                egen_ansatt_og_kode_7_bruker_som_venter_pa_svar_fra_nav
+                egen_ansatt_og_kode_7_bruker_som_venter_pa_svar_fra_nav,
+                fordelt_bruker_som_ikke_skal_inkluderes,
+                ufordelt_bruker_som_ikke_skal_inkluderes,
+                bruker_som_venter_pa_svar_fra_nav_som_ikke_skal_inkluderes
         );
 
         skrivBrukereTilTestindeks(brukere);


### PR DESCRIPTION
## Describe your changes

Det var en logisk feil i måten agggregation-filtrene ble bygget opp når vi henter statustall for brukere med adressebeskyttelse/ skjerming. Feilen resulterte i at brukere uten adressebeskyttelse/ skjerming ble inkludert i statustallene, noe de ikke skal. 

**Endrer aggregation-filteret slik at vi nå wrapper alle "should"-clausene i en egen "must"-clause.**

Rotårsaken til feilen kan forøvrig leses fra dokumentasjonen til `should`-funksjonen i `BoolQueryBuilder.java`:

> Adds a clause that should be matched by the returned documents. **For a boolean query with no MUST clauses one** or more SHOULD clauses must match a document for the BooleanQuery to match. No null value allowed.

## Trello ticket number and link

[TC-270](https://trello.com/c/eegtUQrl/270-fjerne-mulighet-for-%C3%A5-kunne-identifisere-navn-og-stedslokaliserende-informasjon-for-egen-ansatt-og-kode-6-og-7)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
