### PR TITLE
Tc 270 skjerming og adressebeskyttelse tilpasning

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetService.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.EnhetId;
 import no.nav.pto.veilarbportefolje.arenapakafka.aktiviteter.TiltakService;
-import no.nav.pto.veilarbportefolje.auth.BrukerInnsynTilganger;
+import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.domene.Motedeltaker;
 import no.nav.pto.veilarbportefolje.domene.Moteplan;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
@@ -97,13 +97,13 @@ public class AktivitetService extends KafkaCommonConsumerService<KafkaAktivitetM
         );
     }
 
-    public List<Moteplan> hentMoteplan(VeilederId veilederIdent, EnhetId enhet, BrukerInnsynTilganger brukerInnsynTilganger) {
+    public List<Moteplan> hentMoteplan(VeilederId veilederIdent, EnhetId enhet, BrukerinnsynTilganger brukerInnsynTilganger) {
         List<Moteplan> moteplans = aktiviteterRepositoryV2.hentFremtidigeMoter(veilederIdent, enhet);
 
         return sensurerMoteplaner(moteplans, brukerInnsynTilganger);
     }
 
-    private List<Moteplan> sensurerMoteplaner(List<Moteplan> moteplans, BrukerInnsynTilganger brukerInnsynTilganger) {
+    private List<Moteplan> sensurerMoteplaner(List<Moteplan> moteplans, BrukerinnsynTilganger brukerInnsynTilganger) {
         List<Moteplan> sensurertListe = new ArrayList<>();
 
         List<String> fnrs = moteplans.stream().map(Moteplan::deltaker).map(Motedeltaker::fnr).toList();

--- a/src/main/java/no/nav/pto/veilarbportefolje/auth/AuthService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/auth/AuthService.java
@@ -144,13 +144,13 @@ public class AuthService {
         return abacResponse;
     }
 
-    public BrukerInnsynTilganger hentVeilederBrukerInnsynTilganger() {
+    public BrukerinnsynTilganger hentVeilederBrukerInnsynTilganger() {
         String veilederId = getInnloggetVeilederIdent().toString();
         boolean tilgangTilAdressebeskyttelseStrengtFortrolig = harVeilederTilgangTilKode6(NavIdent.of(veilederId));
         boolean tilgangTilAdressebeskyttelseFortrolig = harVeilederTilgangTilKode7(NavIdent.of(veilederId));
         boolean tilgangEgenAnsatt = harVeilederTilgangTilEgenAnsatt(NavIdent.of(veilederId));
 
-        return new BrukerInnsynTilganger(tilgangTilAdressebeskyttelseStrengtFortrolig, tilgangTilAdressebeskyttelseFortrolig, tilgangEgenAnsatt);
+        return new BrukerinnsynTilganger(tilgangTilAdressebeskyttelseStrengtFortrolig, tilgangTilAdressebeskyttelseFortrolig, tilgangEgenAnsatt);
     }
 
     public String getOboToken(String tokenScope) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/auth/BrukerInnsynTilganger.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/auth/BrukerInnsynTilganger.java
@@ -1,4 +1,4 @@
 package no.nav.pto.veilarbportefolje.auth;
 
-public record BrukerInnsynTilganger(boolean tilgangTilAdressebeskyttelseStrengtFortrolig, boolean tilgangTilAdressebeskyttelseFortrolig, boolean tilgangTilSkjerming) {
+public record BrukerinnsynTilganger(boolean tilgangTilAdressebeskyttelseStrengtFortrolig, boolean tilgangTilAdressebeskyttelseFortrolig, boolean tilgangTilSkjerming) {
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/config/FeatureToggle.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/config/FeatureToggle.java
@@ -38,7 +38,7 @@ public class FeatureToggle {
         return unleashService.isEnabled(FeatureToggle.STOPP_INDEKSERING_AV_TILTAKSAKTIVITETER);
     }
 
-    public static boolean brukFilterForBrukerInnsynTilganger(UnleashService unleashService) {
+    public static boolean brukFilterForBrukerinnsynTilganger(UnleashService unleashService) {
         return unleashService.isEnabled(FeatureToggle.BRUK_FILTER_FOR_BRUKERINNSYN_TILGANGER);
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/EnhetController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/EnhetController.java
@@ -19,7 +19,8 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static no.nav.common.client.utils.CacheUtils.tryCacheFirst;
-import static no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
+import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
+import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ;
 
 @RestController
 @RequiredArgsConstructor
@@ -79,11 +80,22 @@ public class EnhetController {
     }
 
     @GetMapping("/{enhet}/statustall")
-    public EnhetPortefoljeStatusTall hentStatusTall(@PathVariable("enhet") String enhet) {
+    public Statustall hentStatusTall(@PathVariable("enhet") String enhet) {
         ValideringsRegler.sjekkEnhet(enhet);
         authService.tilgangTilEnhet(enhet);
 
         return opensearchService.hentStatusTallForEnhet(enhet);
+    }
+
+    @GetMapping("/{enhet}/portefolje/statustall")
+    public EnhetPortefoljeStatustallRespons hentEnhetPortefoljeStatustall(@PathVariable("enhet") String enhet) {
+        ValideringsRegler.sjekkEnhet(enhet);
+        authService.tilgangTilEnhet(enhet);
+
+        return new EnhetPortefoljeStatustallRespons(
+                opensearchService.hentStatusTallForEnhetPortefolje(enhet, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ),
+                opensearchService.hentStatusTallForEnhetPortefolje(enhet, BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ)
+        );
     }
 
     @GetMapping("/{enhet}/tiltak")

--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/EnhetController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/EnhetController.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static no.nav.common.client.utils.CacheUtils.tryCacheFirst;
+import static no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
 
 @RestController
 @RequiredArgsConstructor
@@ -60,7 +61,7 @@ public class EnhetController {
         authService.tilgangTilOppfolging();
         authService.tilgangTilEnhet(enhet);
 
-        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.empty(), sortDirection, sortField, filtervalg, fra, antall);
+        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.empty(), sortDirection, sortField, filtervalg, fra, antall, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         List<Bruker> sensurerteBrukereSublist = authService.sensurerBrukere(brukereMedAntall.getBrukere());
 
         return PortefoljeUtils.buildPortefolje(brukereMedAntall.getAntall(),

--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Optional;
 
+import static no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -45,7 +47,7 @@ public class VeilederController {
         authService.tilgangTilOppfolging();
         authService.tilgangTilEnhet(enhet);
 
-        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.of(veilederIdent), sortDirection, sortField, filtervalg, fra, antall);
+        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.of(veilederIdent), sortDirection, sortField, filtervalg, fra, antall, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         List<Bruker> sensurerteBrukereSublist = authService.sensurerBrukere(brukereMedAntall.getBrukere());
 
         return PortefoljeUtils.buildPortefolje(brukereMedAntall.getAntall(),

--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
@@ -10,6 +10,7 @@ import no.nav.pto.veilarbportefolje.auth.AuthService;
 import no.nav.pto.veilarbportefolje.auth.BrukerInnsynTilganger;
 import no.nav.pto.veilarbportefolje.domene.*;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
+import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.util.PortefoljeUtils;
 import no.nav.pto.veilarbportefolje.util.ValideringsRegler;
@@ -62,7 +63,7 @@ public class VeilederController {
         ValideringsRegler.sjekkVeilederIdent(veilederIdent, false);
         authService.tilgangTilEnhet(enhet);
 
-        return opensearchService.hentStatusTallForVeileder(veilederIdent, enhet);
+        return opensearchService.hentStatusTallForVeileder(veilederIdent, enhet, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
     }
 
     @GetMapping("/{veilederident}/hentArbeidslisteForVeileder")

--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
@@ -7,10 +7,10 @@ import no.nav.pto.veilarbportefolje.aktiviteter.AktivitetService;
 import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteService;
 import no.nav.pto.veilarbportefolje.auth.AuthService;
-import no.nav.pto.veilarbportefolje.auth.BrukerInnsynTilganger;
+import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.domene.*;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
-import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
+import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.util.PortefoljeUtils;
 import no.nav.pto.veilarbportefolje.util.ValideringsRegler;
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Optional;
 
-import static no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
+import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
 
 @Slf4j
 @RestController
@@ -63,7 +63,20 @@ public class VeilederController {
         ValideringsRegler.sjekkVeilederIdent(veilederIdent, false);
         authService.tilgangTilEnhet(enhet);
 
-        return opensearchService.hentStatusTallForVeileder(veilederIdent, enhet, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        return opensearchService.hentStatusTallForVeileder(veilederIdent, enhet, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+    }
+
+    @GetMapping("/{veilederident}/portefolje/statustall")
+    public VeilederPortefoljeStatustallRespons hentVeilederportefoljeStatustall(@PathVariable("veilederident") String veilederIdent, @RequestParam("enhet") String enhet) {
+        ValideringsRegler.sjekkEnhet(enhet);
+        ValideringsRegler.sjekkVeilederIdent(veilederIdent, false);
+        authService.tilgangTilEnhet(enhet);
+
+        return new VeilederPortefoljeStatustallRespons(
+                opensearchService.hentStatustallForVeilederPortefolje(
+                        veilederIdent, enhet, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ
+                )
+        );
     }
 
     @GetMapping("/{veilederident}/hentArbeidslisteForVeileder")
@@ -81,7 +94,7 @@ public class VeilederController {
         ValideringsRegler.sjekkVeilederIdent(veilederIdent.getValue(), false);
 
         authService.tilgangTilEnhet(enhet.get());
-        BrukerInnsynTilganger tilgangTilSkjermeteBrukere = authService.hentVeilederBrukerInnsynTilganger();
+        BrukerinnsynTilganger tilgangTilSkjermeteBrukere = authService.hentVeilederBrukerInnsynTilganger();
 
         return aktivitetService.hentMoteplan(veilederIdent, enhet, tilgangTilSkjermeteBrukere);
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/EnhetPortefoljeStatusTall.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/EnhetPortefoljeStatusTall.java
@@ -26,9 +26,6 @@ public class EnhetPortefoljeStatusTall {
     public long minArbeidslisteLilla;
     public long minArbeidslisteGronn;
     public long minArbeidslisteGul;
-    public long adressebeskyttelseEllerSkjermingTotalt;
-    public long adressebeskyttelseEllerSkjermingUfordelte;
-    public long adressebeskyttelseEllerSkjermingVenterPaSvarFraNAV;
 
     public EnhetPortefoljeStatusTall(StatustallBuckets buckets, boolean vedtakstottePilotErPa) {
         this.totalt = buckets.getTotalt().getDoc_count();
@@ -50,8 +47,5 @@ public class EnhetPortefoljeStatusTall {
         this.minArbeidslisteGronn = buckets.getMinArbeidslisteGronn().getDoc_count();
         this.minArbeidslisteGul = buckets.getMinArbeidslisteGul().getDoc_count();
         this.underVurdering = vedtakstottePilotErPa ? buckets.getUnderVurdering().getDoc_count() : 0;
-        this.adressebeskyttelseEllerSkjermingTotalt = buckets.getAdressebeskyttelseEllerSkjermingTotalt().getDoc_count();
-        this.adressebeskyttelseEllerSkjermingUfordelte = buckets.getAdressebeskyttelseEllerSkjermingUfordelte().getDoc_count();
-        this.adressebeskyttelseEllerSkjermingVenterPaSvarFraNAV = buckets.getAdressebeskyttelseEllerSkjermingVenterPaSvarFraNAV().getDoc_count();
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/EnhetPortefoljeStatustallRespons.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/EnhetPortefoljeStatustallRespons.java
@@ -1,0 +1,7 @@
+package no.nav.pto.veilarbportefolje.domene;
+
+public record EnhetPortefoljeStatustallRespons(
+        Statustall statustallMedBrukerinnsyn,
+        Statustall statustallUtenBrukerinnsyn
+) {
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Statustall.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Statustall.java
@@ -1,0 +1,49 @@
+package no.nav.pto.veilarbportefolje.domene;
+
+import no.nav.pto.veilarbportefolje.opensearch.domene.StatustallResponse;
+
+public record Statustall(
+        long totalt,
+        long ufordelteBrukere,
+        long trengerVurdering,
+        long nyeBrukereForVeileder,
+        long inaktiveBrukere,
+        long venterPaSvarFraNAV,
+        long venterPaSvarFraBruker,
+        long iavtaltAktivitet,
+        long iAktivitet,
+        long ikkeIavtaltAktivitet,
+        long utlopteAktiviteter,
+        long minArbeidsliste,
+        long erSykmeldtMedArbeidsgiver,
+        long moterMedNAVIdag,
+        long underVurdering,
+        long minArbeidslisteBla,
+        long minArbeidslisteLilla,
+        long minArbeidslisteGronn,
+        long minArbeidslisteGul
+) {
+    public static Statustall of(StatustallResponse.StatustallAggregation.StatustallFilter.StatustallBuckets buckets, boolean vedtakstottePilotErPa) {
+        return new Statustall(
+                buckets.getTotalt().getDoc_count(),
+                buckets.getUfordelteBrukere().getDoc_count(),
+                buckets.getTrengerVurdering().getDoc_count(),
+                buckets.getNyeBrukereForVeileder().getDoc_count(),
+                buckets.getInaktiveBrukere().getDoc_count(),
+                buckets.getVenterPaSvarFraNAV().getDoc_count(),
+                buckets.getVenterPaSvarFraBruker().getDoc_count(),
+                buckets.getIavtaltAktivitet().getDoc_count(),
+                buckets.getIAktivitet().getDoc_count(),
+                buckets.getIkkeIavtaltAktivitet().getDoc_count(),
+                buckets.getUtlopteAktiviteter().getDoc_count(),
+                buckets.getMinArbeidsliste().getDoc_count(),
+                buckets.getErSykmeldtMedArbeidsgiver().getDoc_count(),
+                buckets.getMoterMedNAVIdag().getDoc_count(),
+                buckets.getMinArbeidslisteBla().getDoc_count(),
+                buckets.getMinArbeidslisteLilla().getDoc_count(),
+                buckets.getMinArbeidslisteGronn().getDoc_count(),
+                buckets.getMinArbeidslisteGul().getDoc_count(),
+                vedtakstottePilotErPa ? buckets.getUnderVurdering().getDoc_count() : 0
+        );
+    }
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/VeilederPortefoljeStatustallRespons.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/VeilederPortefoljeStatustallRespons.java
@@ -1,0 +1,6 @@
+package no.nav.pto.veilarbportefolje.domene;
+
+public record VeilederPortefoljeStatustallRespons(
+        Statustall statustall
+) {
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/BrukerinnsynTilgangFilterType.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/BrukerinnsynTilgangFilterType.java
@@ -1,5 +1,5 @@
 package no.nav.pto.veilarbportefolje.opensearch;
-public enum InnsynsrettFilterType {
+public enum BrukerinnsynTilgangFilterType {
     /**
      * Alle brukere som veileder har innsynsrett på
      */

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/InnsynsrettFilterType.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/InnsynsrettFilterType.java
@@ -1,0 +1,17 @@
+package no.nav.pto.veilarbportefolje.opensearch;
+public enum InnsynsrettFilterType {
+    /**
+     * Alle brukere som veileder har innsynsrett på
+     */
+    ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ,
+
+    /**
+     * Alle brukere inkludert de som veileder eventuelt ikke har innsynsrett på
+     */
+    ALLE_BRUKERE,
+
+    /**
+     * Kun brukere som veileder eventuelt ikke har innsynsrett på
+     */
+    BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -2,11 +2,11 @@ package no.nav.pto.veilarbportefolje.opensearch;
 
 import lombok.extern.slf4j.Slf4j;
 import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
+import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.domene.*;
+import no.nav.pto.veilarbportefolje.persononinfo.domene.Adressebeskyttelse;
 import no.nav.pto.veilarbportefolje.sisteendring.SisteEndringsKategori;
 import no.nav.pto.veilarbportefolje.util.ValideringsRegler;
-import org.apache.commons.lang3.ArrayUtils;
-import org.jetbrains.annotations.NotNull;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -42,6 +42,57 @@ import static org.opensearch.search.sort.SortMode.MIN;
 
 @Slf4j
 public class OpensearchQueryBuilder {
+
+    static String byggVeilederPaaEnhetScript(List<String> veilederePaaEnhet) {
+        String veiledere = veilederePaaEnhet.stream()
+                .map(id -> format("\"%s\"", id))
+                .collect(joining(","));
+
+        String veilederListe = format("[%s]", veiledere);
+        return format("(doc.veileder_id.size() != 0 && %s.contains(doc.veileder_id.value)).toString()", veilederListe);
+    }
+
+    static BoolQueryBuilder leggTilBrukerinnsynTilgangFilter(BoolQueryBuilder boolQuery, BrukerinnsynTilganger brukerInnsynTilganger, BrukerinnsynTilgangFilterType filterType) {
+        return switch (filterType) {
+            case ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ -> {
+                if (!brukerInnsynTilganger.tilgangTilAdressebeskyttelseStrengtFortrolig()) {
+                    boolQuery.mustNot(matchQuery("diskresjonskode", Adressebeskyttelse.STRENGT_FORTROLIG.diskresjonskode));
+                }
+
+                if (!brukerInnsynTilganger.tilgangTilAdressebeskyttelseFortrolig()) {
+                    boolQuery.mustNot(matchQuery("diskresjonskode", Adressebeskyttelse.FORTROLIG.diskresjonskode));
+                }
+
+                if (!brukerInnsynTilganger.tilgangTilSkjerming()) {
+                    boolQuery.mustNot(matchQuery("egen_ansatt", true));
+                }
+
+                yield boolQuery;
+            }
+
+            case BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ -> {
+                BoolQueryBuilder shouldBoolQuery = boolQuery();
+
+                if (!brukerInnsynTilganger.tilgangTilAdressebeskyttelseStrengtFortrolig()) {
+                    shouldBoolQuery.should(matchQuery("diskresjonskode", Adressebeskyttelse.STRENGT_FORTROLIG.diskresjonskode));
+                }
+
+                if (!brukerInnsynTilganger.tilgangTilAdressebeskyttelseFortrolig()) {
+                    shouldBoolQuery.should(matchQuery("diskresjonskode", Adressebeskyttelse.FORTROLIG.diskresjonskode));
+                }
+
+                if (!brukerInnsynTilganger.tilgangTilSkjerming()) {
+                    shouldBoolQuery.should(matchQuery("egen_ansatt", true));
+                }
+
+                boolQuery.must(shouldBoolQuery);
+
+                yield boolQuery;
+            }
+
+            case ALLE_BRUKERE -> boolQuery;
+        };
+    }
 
     static void leggTilManuelleFilter(BoolQueryBuilder queryBuilder, Filtervalg filtervalg) {
         if (!filtervalg.alder.isEmpty()) {
@@ -214,34 +265,6 @@ public class OpensearchQueryBuilder {
         }
     }
 
-    private static void byggUlestEndringsFilter(List<String> sisteEndringKategori, BoolQueryBuilder queryBuilder) {
-        if (sisteEndringKategori != null && sisteEndringKategori.size() > 1) {
-            log.error("Det ble filtrert på flere ulike siste endringer (ulest): {}", sisteEndringKategori.size());
-            throw new IllegalStateException("Filtrering på flere siste_endringer er ikke tilatt.");
-        }
-        List<String> relvanteKategorier = sisteEndringKategori;
-        if (sisteEndringKategori == null || sisteEndringKategori.isEmpty()) {
-            relvanteKategorier = (Arrays.stream(SisteEndringsKategori.values()).map(SisteEndringsKategori::name)).collect(toList());
-        }
-
-        BoolQueryBuilder orQuery = boolQuery();
-        relvanteKategorier.forEach(kategori -> orQuery.should(
-                QueryBuilders.matchQuery("siste_endringer." + kategori + ".er_sett", "N")
-        ));
-        queryBuilder.must(orQuery);
-    }
-
-    private static void byggSisteEndringFilter(List<String> sisteEndringKategori, BoolQueryBuilder queryBuilder) {
-        if (sisteEndringKategori.size() == 0) {
-            return;
-        }
-        if (sisteEndringKategori.size() != 1) {
-            log.error("Det ble filtrert på flere ulike siste endringer: {}", sisteEndringKategori.size());
-            throw new IllegalStateException("Filtrering på flere siste_endringer er ikke tilatt.");
-        }
-        queryBuilder.must(existsQuery("siste_endringer." + sisteEndringKategori.get(0)));
-    }
-
     static List<BoolQueryBuilder> byggAktivitetFilterQuery(Filtervalg filtervalg, BoolQueryBuilder queryBuilder) {
         return filtervalg.aktiviteter.entrySet().stream()
                 .map(
@@ -311,56 +334,6 @@ public class OpensearchQueryBuilder {
         return searchSourceBuilder;
     }
 
-
-    private static void defaultSort(String sortField, SearchSourceBuilder searchSourceBuilder, SortOrder order) {
-        if (ValideringsRegler.sortFields.contains(sortField)) {
-            searchSourceBuilder.sort(sortField, order);
-        } else {
-            throw new IllegalStateException();
-        }
-    }
-
-    private static void sorterEnsligeForsorgereUtlopsDato(SearchSourceBuilder builder, SortOrder order) {
-        String expresion = """
-                if (doc.containsKey('enslige_forsorgere_overgangsstonad.utlopsDato') && !doc['enslige_forsorgere_overgangsstonad.utlopsDato'].empty) {
-                    return doc['enslige_forsorgere_overgangsstonad.utlopsDato'].value.toInstant().toEpochMilli();
-                }
-                else {
-                  return 0;
-                }
-                """;
-        Script script = new Script(expresion);
-        ScriptSortBuilder scriptBuilder = new ScriptSortBuilder(script, ScriptSortBuilder.ScriptSortType.NUMBER);
-        scriptBuilder.order(order);
-        builder.sort(scriptBuilder);
-
-    }
-
-    private static void sorterEnsligeForsorgereOmBarnet(SearchSourceBuilder builder, SortOrder order) {
-        String expresion = """
-                if (doc.containsKey('enslige_forsorgere_overgangsstonad.yngsteBarnsFødselsdato') && !doc['enslige_forsorgere_overgangsstonad.yngsteBarnsFødselsdato'].empty) {
-                    return doc['enslige_forsorgere_overgangsstonad.yngsteBarnsFødselsdato'].value.toInstant().toEpochMilli();
-                }
-                else {
-                    return 0;
-                }
-                """;
-        Script script = new Script(expresion);
-        ScriptSortBuilder scriptBuilder = new ScriptSortBuilder(script, ScriptSortBuilder.ScriptSortType.NUMBER);
-        scriptBuilder.order(order);
-        builder.sort(scriptBuilder);
-    }
-
-
-    private static void sorterEnsligeForsorgereVedtaksPeriode(SearchSourceBuilder builder, SortOrder order) {
-        builder.sort("enslige_forsorgere_overgangsstonad.vedtaksPeriodetype", order);
-    }
-
-    private static void sorterEnsligeForsorgereAktivitetsPlikt(SearchSourceBuilder builder, SortOrder order) {
-        builder.sort("enslige_forsorgere_overgangsstonad.harAktivitetsplikt", order);
-    }
-
-
     static void sorterSisteEndringTidspunkt(SearchSourceBuilder builder, SortOrder order, Filtervalg filtervalg) {
         if (filtervalg.sisteEndringKategori.size() == 0) {
             return;
@@ -402,7 +375,6 @@ public class OpensearchQueryBuilder {
             searchSourceBuilder.sort("tegnspraaktolk", order);
         }
     }
-
 
     static SearchSourceBuilder sorterPaaNyForEnhet(SearchSourceBuilder builder, List<String> veilederePaaEnhet) {
         Script script = new Script(byggVeilederPaaEnhetScript(veilederePaaEnhet));
@@ -498,13 +470,6 @@ public class OpensearchQueryBuilder {
         return queryBuilder;
     }
 
-    private static RangeQueryBuilder byggMoteMedNavIdag() {
-        LocalDate localDate = LocalDate.now();
-        return rangeQuery("alle_aktiviteter_mote_startdato")
-                .gte(toIsoUTC(localDate.atStartOfDay()))
-                .lt(toIsoUTC(localDate.plusDays(1).atStartOfDay()));
-    }
-
     // Brukere med veileder uten tilgang til denne enheten ansees som ufordelte brukere
     static QueryBuilder byggTrengerVurderingFilter(boolean erVedtakstottePilotPa) {
         if (erVedtakstottePilotPa) {
@@ -527,7 +492,6 @@ public class OpensearchQueryBuilder {
         return matchQuery("er_sykmeldt_med_arbeidsgiver", true);
 
     }
-
 
     // Brukere med veileder uten tilgang til denne enheten ansees som ufordelte brukere
     static BoolQueryBuilder byggUfordeltBrukereQuery(List<String> veiledereMedTilgangTilEnhet) {
@@ -596,7 +560,6 @@ public class OpensearchQueryBuilder {
         );
     }
 
-
     static SearchSourceBuilder byggPortefoljestorrelserQuery(String enhetId) {
         String name = "portefoljestorrelser";
 
@@ -616,25 +579,8 @@ public class OpensearchQueryBuilder {
                 );
     }
 
-    static SearchSourceBuilder byggStatusTallQuery(FiltersAggregator.KeyedFilter[] statusTallFiltre) {
-        return new SearchSourceBuilder()
-                .size(0)
-                .aggregation(filters("statustall", statusTallFiltre));
-    }
-
-    @NotNull
-    static FiltersAggregator.KeyedFilter[] getEnhetStatusTallFiltre(BoolQueryBuilder filtrereVeilederOgEnhet, List<String> veiledereMedTilgangTilEnhet, boolean vedtakstottePilotErPa) {
-        return ArrayUtils.addAll(
-                getVeilederStatusTallFiltre(filtrereVeilederOgEnhet, veiledereMedTilgangTilEnhet, vedtakstottePilotErPa),
-                adressebeskyttelseEllerSkjermingTotalt(filtrereVeilederOgEnhet),
-                adressebeskyttelseEllerSkjermingUfordelte(filtrereVeilederOgEnhet, veiledereMedTilgangTilEnhet),
-                adressebeskyttelseEllerSkjermingVenterPaSvarFraNAV(filtrereVeilederOgEnhet)
-        );
-    }
-
-    @NotNull
-    static FiltersAggregator.KeyedFilter[] getVeilederStatusTallFiltre(BoolQueryBuilder filtrereVeilederOgEnhet, List<String> veiledereMedTilgangTilEnhet, boolean vedtakstottePilotErPa) {
-        return new FiltersAggregator.KeyedFilter[]{
+    static SearchSourceBuilder byggStatustallQuery(BoolQueryBuilder filtrereVeilederOgEnhet, List<String> veiledereMedTilgangTilEnhet, boolean vedtakstottePilotErPa) {
+        FiltersAggregator.KeyedFilter[] filtre = new FiltersAggregator.KeyedFilter[]{
                 erSykemeldtMedArbeidsgiverFilter(filtrereVeilederOgEnhet, vedtakstottePilotErPa),
                 mustExistFilter(filtrereVeilederOgEnhet, "iavtaltAktivitet", "aktiviteter"),
                 mustExistFilter(filtrereVeilederOgEnhet, "iAktivitet", "alleAktiviteter"),
@@ -656,6 +602,92 @@ public class OpensearchQueryBuilder {
                 mustMatchQuery(filtrereVeilederOgEnhet, "minArbeidslisteGronn", "arbeidsliste_kategori", Arbeidsliste.Kategori.GRONN.name()),
                 mustMatchQuery(filtrereVeilederOgEnhet, "minArbeidslisteGul", "arbeidsliste_kategori", Arbeidsliste.Kategori.GUL.name())
         };
+
+        return new SearchSourceBuilder()
+                .size(0)
+                .aggregation(filters("statustall", filtre));
+    }
+
+    private static void byggUlestEndringsFilter(List<String> sisteEndringKategori, BoolQueryBuilder queryBuilder) {
+        if (sisteEndringKategori != null && sisteEndringKategori.size() > 1) {
+            log.error("Det ble filtrert på flere ulike siste endringer (ulest): {}", sisteEndringKategori.size());
+            throw new IllegalStateException("Filtrering på flere siste_endringer er ikke tilatt.");
+        }
+        List<String> relvanteKategorier = sisteEndringKategori;
+        if (sisteEndringKategori == null || sisteEndringKategori.isEmpty()) {
+            relvanteKategorier = (Arrays.stream(SisteEndringsKategori.values()).map(SisteEndringsKategori::name)).collect(toList());
+        }
+
+        BoolQueryBuilder orQuery = boolQuery();
+        relvanteKategorier.forEach(kategori -> orQuery.should(
+                QueryBuilders.matchQuery("siste_endringer." + kategori + ".er_sett", "N")
+        ));
+        queryBuilder.must(orQuery);
+    }
+
+    private static void byggSisteEndringFilter(List<String> sisteEndringKategori, BoolQueryBuilder queryBuilder) {
+        if (sisteEndringKategori.size() == 0) {
+            return;
+        }
+        if (sisteEndringKategori.size() != 1) {
+            log.error("Det ble filtrert på flere ulike siste endringer: {}", sisteEndringKategori.size());
+            throw new IllegalStateException("Filtrering på flere siste_endringer er ikke tilatt.");
+        }
+        queryBuilder.must(existsQuery("siste_endringer." + sisteEndringKategori.get(0)));
+    }
+
+    private static void defaultSort(String sortField, SearchSourceBuilder searchSourceBuilder, SortOrder order) {
+        if (ValideringsRegler.sortFields.contains(sortField)) {
+            searchSourceBuilder.sort(sortField, order);
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+
+    private static void sorterEnsligeForsorgereUtlopsDato(SearchSourceBuilder builder, SortOrder order) {
+        String expresion = """
+                if (doc.containsKey('enslige_forsorgere_overgangsstonad.utlopsDato') && !doc['enslige_forsorgere_overgangsstonad.utlopsDato'].empty) {
+                    return doc['enslige_forsorgere_overgangsstonad.utlopsDato'].value.toInstant().toEpochMilli();
+                }
+                else {
+                  return 0;
+                }
+                """;
+        Script script = new Script(expresion);
+        ScriptSortBuilder scriptBuilder = new ScriptSortBuilder(script, ScriptSortBuilder.ScriptSortType.NUMBER);
+        scriptBuilder.order(order);
+        builder.sort(scriptBuilder);
+
+    }
+
+    private static void sorterEnsligeForsorgereOmBarnet(SearchSourceBuilder builder, SortOrder order) {
+        String expresion = """
+                if (doc.containsKey('enslige_forsorgere_overgangsstonad.yngsteBarnsFødselsdato') && !doc['enslige_forsorgere_overgangsstonad.yngsteBarnsFødselsdato'].empty) {
+                    return doc['enslige_forsorgere_overgangsstonad.yngsteBarnsFødselsdato'].value.toInstant().toEpochMilli();
+                }
+                else {
+                    return 0;
+                }
+                """;
+        Script script = new Script(expresion);
+        ScriptSortBuilder scriptBuilder = new ScriptSortBuilder(script, ScriptSortBuilder.ScriptSortType.NUMBER);
+        scriptBuilder.order(order);
+        builder.sort(scriptBuilder);
+    }
+
+    private static void sorterEnsligeForsorgereVedtaksPeriode(SearchSourceBuilder builder, SortOrder order) {
+        builder.sort("enslige_forsorgere_overgangsstonad.vedtaksPeriodetype", order);
+    }
+
+    private static void sorterEnsligeForsorgereAktivitetsPlikt(SearchSourceBuilder builder, SortOrder order) {
+        builder.sort("enslige_forsorgere_overgangsstonad.harAktivitetsplikt", order);
+    }
+
+    private static RangeQueryBuilder byggMoteMedNavIdag() {
+        LocalDate localDate = LocalDate.now();
+        return rangeQuery("alle_aktiviteter_mote_startdato")
+                .gte(toIsoUTC(localDate.atStartOfDay()))
+                .lt(toIsoUTC(localDate.plusDays(1).atStartOfDay()));
     }
 
     private static FiltersAggregator.KeyedFilter trengerVurderingFilter(BoolQueryBuilder filtrereVeilederOgEnhet, boolean vedtakstottePilotErPa) {
@@ -766,53 +798,6 @@ public class OpensearchQueryBuilder {
                         .must(filtrereVeilederOgEnhet)
                         .must(existsQuery(value))
         );
-    }
-
-    private static FiltersAggregator.KeyedFilter adressebeskyttelseEllerSkjermingTotalt(BoolQueryBuilder filtrereEnhet) {
-        return new FiltersAggregator.KeyedFilter(
-                "adressebeskyttelseEllerSkjermingTotalt",
-                boolQuery()
-                        .must(filtrereEnhet)
-                        .must(boolQuery()
-                                .should(existsQuery("diskresjonskode"))
-                                .should(termQuery("egen_ansatt", true))
-                        )
-        );
-    }
-
-    private static FiltersAggregator.KeyedFilter adressebeskyttelseEllerSkjermingUfordelte(BoolQueryBuilder filtrereEnhet, List<String> veiledereMedTilgangTilEnhet) {
-        return new FiltersAggregator.KeyedFilter(
-                "adressebeskyttelseEllerSkjermingUfordelte",
-                boolQuery()
-                        .must(filtrereEnhet)
-                        .must(boolQuery()
-                                .should(existsQuery("diskresjonskode"))
-                                .should(termQuery("egen_ansatt", true))
-                        )
-                        .must(byggUfordeltBrukereQuery(veiledereMedTilgangTilEnhet))
-        );
-    }
-
-    private static FiltersAggregator.KeyedFilter adressebeskyttelseEllerSkjermingVenterPaSvarFraNAV(BoolQueryBuilder filtrereEnhet) {
-        return new FiltersAggregator.KeyedFilter(
-                "adressebeskyttelseEllerSkjermingVenterPaSvarFraNAV",
-                boolQuery()
-                        .must(filtrereEnhet)
-                        .must(boolQuery()
-                                .should(existsQuery("diskresjonskode"))
-                                .should(termQuery("egen_ansatt", true))
-                        )
-                        .must(existsQuery("venterpasvarfranav"))
-        );
-    }
-
-    public static String byggVeilederPaaEnhetScript(List<String> veilederePaaEnhet) {
-        String veiledere = veilederePaaEnhet.stream()
-                .map(id -> format("\"%s\"", id))
-                .collect(joining(","));
-
-        String veilederListe = format("[%s]", veiledere);
-        return format("(doc.veileder_id.size() != 0 && %s.contains(doc.veileder_id.value)).toString()", veilederListe);
     }
 
     private static void addSecondarySort(SearchSourceBuilder searchSourceBuilder) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -616,31 +616,14 @@ public class OpensearchQueryBuilder {
                 );
     }
 
-    static SearchSourceBuilder byggStatusTallForEnhetQuery(String enhetId, List<String> veiledereMedTilgangTilEnhet, boolean vedtakstottePilotErPa) {
-        BoolQueryBuilder enhetQuery = boolQuery()
-                .must(termQuery("oppfolging", true))
-                .must(termQuery("enhet_id", enhetId));
-
-        return byggStatusTallQuery(getEnhetStatusTallFiltre(enhetQuery, veiledereMedTilgangTilEnhet, vedtakstottePilotErPa));
-    }
-
-    static SearchSourceBuilder byggStatusTallForVeilederQuery(String enhetId, String veilederId, List<String> veiledereMedTilgangTilEnhet, boolean vedtakstottePilotErPa) {
-        BoolQueryBuilder veilederOgEnhetQuery = boolQuery()
-                .must(termQuery("oppfolging", true))
-                .must(termQuery("enhet_id", enhetId))
-                .must(termQuery("veileder_id", veilederId));
-
-        return byggStatusTallQuery(getVeilederStatusTallFiltre(veilederOgEnhetQuery, veiledereMedTilgangTilEnhet, vedtakstottePilotErPa));
-    }
-
-    private static SearchSourceBuilder byggStatusTallQuery(FiltersAggregator.KeyedFilter[] statusTallFiltre) {
+    static SearchSourceBuilder byggStatusTallQuery(FiltersAggregator.KeyedFilter[] statusTallFiltre) {
         return new SearchSourceBuilder()
                 .size(0)
                 .aggregation(filters("statustall", statusTallFiltre));
     }
 
     @NotNull
-    private static FiltersAggregator.KeyedFilter[] getEnhetStatusTallFiltre(BoolQueryBuilder filtrereVeilederOgEnhet, List<String> veiledereMedTilgangTilEnhet, boolean vedtakstottePilotErPa) {
+    static FiltersAggregator.KeyedFilter[] getEnhetStatusTallFiltre(BoolQueryBuilder filtrereVeilederOgEnhet, List<String> veiledereMedTilgangTilEnhet, boolean vedtakstottePilotErPa) {
         return ArrayUtils.addAll(
                 getVeilederStatusTallFiltre(filtrereVeilederOgEnhet, veiledereMedTilgangTilEnhet, vedtakstottePilotErPa),
                 adressebeskyttelseEllerSkjermingTotalt(filtrereVeilederOgEnhet),
@@ -650,7 +633,7 @@ public class OpensearchQueryBuilder {
     }
 
     @NotNull
-    private static FiltersAggregator.KeyedFilter[] getVeilederStatusTallFiltre(BoolQueryBuilder filtrereVeilederOgEnhet, List<String> veiledereMedTilgangTilEnhet, boolean vedtakstottePilotErPa) {
+    static FiltersAggregator.KeyedFilter[] getVeilederStatusTallFiltre(BoolQueryBuilder filtrereVeilederOgEnhet, List<String> veiledereMedTilgangTilEnhet, boolean vedtakstottePilotErPa) {
         return new FiltersAggregator.KeyedFilter[]{
                 erSykemeldtMedArbeidsgiverFilter(filtrereVeilederOgEnhet, vedtakstottePilotErPa),
                 mustExistFilter(filtrereVeilederOgEnhet, "iavtaltAktivitet", "aktiviteter"),

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
@@ -99,13 +99,17 @@ public class OpensearchService {
         return new BrukereMedAntall(totalHits, brukere);
     }
 
-    public VeilederPortefoljeStatusTall hentStatusTallForVeileder(String veilederId, String enhetId) {
+    public VeilederPortefoljeStatusTall hentStatusTallForVeileder(String veilederId, String enhetId, InnsynsrettFilterType innsynsrettFilterType) {
         boolean vedtakstottePilotErPa = this.erVedtakstottePilotPa(EnhetId.of(enhetId));
 
         BoolQueryBuilder veilederOgEnhetQuery = boolQuery()
                 .must(termQuery("oppfolging", true))
                 .must(termQuery("enhet_id", enhetId))
                 .must(termQuery("veileder_id", veilederId));
+
+        if (FeatureToggle.brukFilterForBrukerInnsynTilganger(unleashService)) {
+            leggTilInnsynsrettFilter(veilederOgEnhetQuery, authService.hentVeilederBrukerInnsynTilganger(), innsynsrettFilterType);
+        }
 
         SearchSourceBuilder request =
                 byggStatusTallQuery(getVeilederStatusTallFiltre(veilederOgEnhetQuery, emptyList(), vedtakstottePilotErPa));

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
@@ -119,8 +119,13 @@ public class OpensearchService {
     public VeilederPortefoljeStatusTall hentStatusTallForVeileder(String veilederId, String enhetId) {
         boolean vedtakstottePilotErPa = this.erVedtakstottePilotPa(EnhetId.of(enhetId));
 
+        BoolQueryBuilder veilederOgEnhetQuery = boolQuery()
+                .must(termQuery("oppfolging", true))
+                .must(termQuery("enhet_id", enhetId))
+                .must(termQuery("veileder_id", veilederId));
+
         SearchSourceBuilder request =
-                byggStatusTallForVeilederQuery(enhetId, veilederId, emptyList(), vedtakstottePilotErPa);
+                byggStatusTallQuery(getVeilederStatusTallFiltre(veilederOgEnhetQuery, emptyList(), vedtakstottePilotErPa));
 
         StatustallResponse response = search(request, indexName.getValue(), StatustallResponse.class);
         StatustallBuckets buckets = response.getAggregations().getFilters().getBuckets();
@@ -132,8 +137,12 @@ public class OpensearchService {
 
         boolean vedtakstottePilotErPa = this.erVedtakstottePilotPa(EnhetId.of(enhetId));
 
+        BoolQueryBuilder enhetQuery = boolQuery()
+                .must(termQuery("oppfolging", true))
+                .must(termQuery("enhet_id", enhetId));
+
         SearchSourceBuilder request =
-                byggStatusTallForEnhetQuery(enhetId, veilederPaaEnhet, vedtakstottePilotErPa);
+                byggStatusTallQuery(getEnhetStatusTallFiltre(enhetQuery, veilederPaaEnhet, vedtakstottePilotErPa));
 
         StatustallResponse response = search(request, indexName.getValue(), StatustallResponse.class);
         StatustallBuckets buckets = response.getAggregations().getFilters().getBuckets();

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerRepositoryV3.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerRepositoryV3.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.Fnr;
-import no.nav.pto.veilarbportefolje.auth.BrukerInnsynTilganger;
+import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLIdent;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -154,7 +154,7 @@ public class OppfolgingsbrukerRepositoryV3 {
                 rs.getBoolean(SPERRET_ANSATT), rs.getBoolean(ER_DOED), toZonedDateTime(rs.getTimestamp(ENDRET_DATO)));
     }
 
-    public List<String> finnSkjulteBrukere(List<String> fnrListe, BrukerInnsynTilganger brukerInnsynTilganger) {
+    public List<String> finnSkjulteBrukere(List<String> fnrListe, BrukerinnsynTilganger brukerInnsynTilganger) {
         var params = new MapSqlParameterSource();
         params.addValue("fnrListe", fnrListe.stream().collect(Collectors.joining(",", "{", "}")));
         params.addValue("tilgangTilKode6", brukerInnsynTilganger.tilgangTilAdressebeskyttelseStrengtFortrolig());

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterOpensearchIntegrasjon.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterOpensearchIntegrasjon.java
@@ -4,14 +4,14 @@ import no.nav.common.json.JsonUtils;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.EnhetId;
 import no.nav.common.types.identer.Fnr;
-import no.nav.pto.veilarbportefolje.auth.BrukerInnsynTilganger;
+import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.Moteplan;
 import no.nav.pto.veilarbportefolje.domene.StillingFraNAVFilter;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
-import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
+import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerEntity;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerRepositoryV3;
@@ -84,7 +84,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of(I_AKTIVITET)),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(1);
                 }
@@ -118,7 +118,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setNavnEllerFnrQuery(fodselsnummer.toString()).setFerdigfilterListe(new ArrayList<>()),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(1);
                     assertThat(responseBrukere.getBrukere().get(0).getNesteCvKanDelesStatus()).isEqualTo("JA");
@@ -169,7 +169,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg().setFerdigfilterListe(List.of(I_AKTIVITET)),
                     null,
-                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             assertThat(responseBrukere.getAntall()).isEqualTo(2);
         });
@@ -183,7 +183,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg().setStillingFraNavFilter(List.of(StillingFraNAVFilter.CV_KAN_DELES_STATUS_JA)).setFerdigfilterListe(new ArrayList<>()),
                 null,
-                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         System.out.println(JsonUtils.toJson( new Filtervalg().setStillingFraNavFilter(List.of(StillingFraNAVFilter.CV_KAN_DELES_STATUS_JA)).setFerdigfilterListe(new ArrayList<>())));
         assertThat(responseBrukere.getAntall()).isEqualTo(1);
@@ -230,8 +230,8 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                 .setAktivitetStatus(KafkaAktivitetMelding.AktivitetStatus.GJENNOMFORES)
                 .setVersion(1L)
                 .setAvtalt(true));
-        List<Moteplan> moteplaner = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerInnsynTilganger(false, false, false));
-        List<Moteplan> ingenMotePlaner = aktivitetService.hentMoteplan(annenVeileder, EnhetId.of(navKontor.getValue()), new BrukerInnsynTilganger(false, false, false));
+        List<Moteplan> moteplaner = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerinnsynTilganger(false, false, false));
+        List<Moteplan> ingenMotePlaner = aktivitetService.hentMoteplan(annenVeileder, EnhetId.of(navKontor.getValue()), new BrukerinnsynTilganger(false, false, false));
 
         assertThat(moteplaner.size()).isEqualTo(2);
         assertThat(ingenMotePlaner.size()).isEqualTo(0);
@@ -255,8 +255,8 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                 .setAktivitetStatus(KafkaAktivitetMelding.AktivitetStatus.GJENNOMFORES)
                 .setVersion(1L)
                 .setAvtalt(false));
-        List<Moteplan> medTilgang = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerInnsynTilganger(false, false, true));
-        List<Moteplan> utenTilgang = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerInnsynTilganger(false, false, false));
+        List<Moteplan> medTilgang = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerinnsynTilganger(false, false, true));
+        List<Moteplan> utenTilgang = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerinnsynTilganger(false, false, false));
 
         assertThat(medTilgang.stream().noneMatch(moteplan -> moteplan.deltaker().equals(skjermetDeltaker))).isTrue();
         assertThat(utenTilgang.stream().allMatch(moteplan -> moteplan.deltaker().equals(skjermetDeltaker))).isTrue();
@@ -296,10 +296,10 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                 .setAktivitetStatus(KafkaAktivitetMelding.AktivitetStatus.GJENNOMFORES)
                 .setVersion(1L)
                 .setAvtalt(false));
-        List<Moteplan> medTilgang_alt = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerInnsynTilganger(true, true, false));
-        List<Moteplan> medTilgang_6 = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerInnsynTilganger(true, false, false));
-        List<Moteplan> medTilgang_7 = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerInnsynTilganger(false, true, false));
-        List<Moteplan> utenTilgang = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerInnsynTilganger(false, false, false));
+        List<Moteplan> medTilgang_alt = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerinnsynTilganger(true, true, false));
+        List<Moteplan> medTilgang_6 = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerinnsynTilganger(true, false, false));
+        List<Moteplan> medTilgang_7 = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerinnsynTilganger(false, true, false));
+        List<Moteplan> utenTilgang = aktivitetService.hentMoteplan(veileder, EnhetId.of(navKontor.getValue()), new BrukerinnsynTilganger(false, false, false));
 
         assertThat(medTilgang_alt.stream().noneMatch(moteplan -> moteplan.deltaker().equals(skjermetDeltaker))).isTrue();
         assertThat(medTilgang_6.stream().filter(moteplan -> moteplan.deltaker().equals(skjermetDeltaker)).toList().size()).isEqualTo(1);

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterOpensearchIntegrasjon.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterOpensearchIntegrasjon.java
@@ -11,6 +11,7 @@ import no.nav.pto.veilarbportefolje.domene.Moteplan;
 import no.nav.pto.veilarbportefolje.domene.StillingFraNAVFilter;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
+import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerEntity;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerRepositoryV3;
@@ -83,7 +84,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of(I_AKTIVITET)),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(1);
                 }
@@ -117,7 +118,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setNavnEllerFnrQuery(fodselsnummer.toString()).setFerdigfilterListe(new ArrayList<>()),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(1);
                     assertThat(responseBrukere.getBrukere().get(0).getNesteCvKanDelesStatus()).isEqualTo("JA");
@@ -168,7 +169,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg().setFerdigfilterListe(List.of(I_AKTIVITET)),
                     null,
-                    null);
+                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             assertThat(responseBrukere.getAntall()).isEqualTo(2);
         });
@@ -182,7 +183,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg().setStillingFraNavFilter(List.of(StillingFraNAVFilter.CV_KAN_DELES_STATUS_JA)).setFerdigfilterListe(new ArrayList<>()),
                 null,
-                null);
+                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         System.out.println(JsonUtils.toJson( new Filtervalg().setStillingFraNavFilter(List.of(StillingFraNAVFilter.CV_KAN_DELES_STATUS_JA)).setFerdigfilterListe(new ArrayList<>())));
         assertThat(responseBrukere.getAntall()).isEqualTo(1);

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
@@ -15,6 +15,7 @@ import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
 import no.nav.pto.veilarbportefolje.domene.EnhetTiltak;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
+import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.postgres.AktivitetEntityDto;
 import no.nav.pto.veilarbportefolje.postgres.utils.TiltakaktivitetEntity;
@@ -200,7 +201,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response1.getAntall()).isEqualTo(1);
 
@@ -211,7 +212,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response2.getAntall()).isEqualTo(0);
                 }
@@ -308,7 +309,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response1.getAntall()).isEqualTo(1);
 
@@ -319,7 +320,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response2.getAntall()).isEqualTo(1);
                 }
@@ -361,7 +362,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response1.getAntall()).isEqualTo(1);
                 }
@@ -458,7 +459,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response1.getAntall()).isEqualTo(0);
 
@@ -469,7 +470,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response2.getAntall()).isEqualTo(1);
                 }
@@ -815,7 +816,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     BrukereMedAntall responseBrukereLONNTILS = opensearchService.hentBrukere(
                             navKontor.getValue(),
@@ -824,7 +825,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukereMIDLONTIL.getAntall()).isEqualTo(1);
                     assertThat(responseBrukereLONNTILS.getAntall()).isEqualTo(0);

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
@@ -15,7 +15,7 @@ import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
 import no.nav.pto.veilarbportefolje.domene.EnhetTiltak;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
-import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
+import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.postgres.AktivitetEntityDto;
 import no.nav.pto.veilarbportefolje.postgres.utils.TiltakaktivitetEntity;
@@ -201,7 +201,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response1.getAntall()).isEqualTo(1);
 
@@ -212,7 +212,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response2.getAntall()).isEqualTo(0);
                 }
@@ -309,7 +309,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response1.getAntall()).isEqualTo(1);
 
@@ -320,7 +320,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response2.getAntall()).isEqualTo(1);
                 }
@@ -362,7 +362,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response1.getAntall()).isEqualTo(1);
                 }
@@ -459,7 +459,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response1.getAntall()).isEqualTo(0);
 
@@ -470,7 +470,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(response2.getAntall()).isEqualTo(1);
                 }
@@ -816,7 +816,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     BrukereMedAntall responseBrukereLONNTILS = opensearchService.hentBrukere(
                             navKontor.getValue(),
@@ -825,7 +825,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukereMIDLONTIL.getAntall()).isEqualTo(1);
                     assertThat(responseBrukereLONNTILS.getAntall()).isEqualTo(0);

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslistaSorteringOpensearch.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslistaSorteringOpensearch.java
@@ -7,7 +7,7 @@ import no.nav.pto.veilarbportefolje.domene.Brukerstatus;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
-import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
+import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.util.EndToEndTest;
@@ -80,7 +80,7 @@ public class ArbeidslistaSorteringOpensearch extends EndToEndTest {
                     "ikke_satt",
                     getArbeidslisteFilter(),
                     null,
-                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 3;
         });
@@ -92,7 +92,7 @@ public class ArbeidslistaSorteringOpensearch extends EndToEndTest {
                 "arbeidsliste_overskrift",
                 getArbeidslisteFilter(),
                 null,
-                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         var sortertResponsDescending = opensearchService.hentBrukere(
                 enhetId.getValue(),
@@ -101,7 +101,7 @@ public class ArbeidslistaSorteringOpensearch extends EndToEndTest {
                 "arbeidsliste_overskrift",
                 getArbeidslisteFilter(),
                 null,
-                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(sortertResponsAscending.getBrukere().get(0).getArbeidsliste().getKategori())
                 .isEqualTo(arbeidsliste2_kategori);

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslistaSorteringOpensearch.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslistaSorteringOpensearch.java
@@ -7,6 +7,7 @@ import no.nav.pto.veilarbportefolje.domene.Brukerstatus;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
+import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.util.EndToEndTest;
@@ -79,7 +80,7 @@ public class ArbeidslistaSorteringOpensearch extends EndToEndTest {
                     "ikke_satt",
                     getArbeidslisteFilter(),
                     null,
-                    null);
+                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 3;
         });
@@ -91,7 +92,7 @@ public class ArbeidslistaSorteringOpensearch extends EndToEndTest {
                 "arbeidsliste_overskrift",
                 getArbeidslisteFilter(),
                 null,
-                null);
+                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         var sortertResponsDescending = opensearchService.hentBrukere(
                 enhetId.getValue(),
@@ -100,7 +101,7 @@ public class ArbeidslistaSorteringOpensearch extends EndToEndTest {
                 "arbeidsliste_overskrift",
                 getArbeidslisteFilter(),
                 null,
-                null);
+                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(sortertResponsAscending.getBrukere().get(0).getArbeidsliste().getKategori())
                 .isEqualTo(arbeidsliste2_kategori);

--- a/src/test/java/no/nav/pto/veilarbportefolje/controller/EnhetControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/controller/EnhetControllerTest.java
@@ -16,7 +16,6 @@ import no.nav.pto.veilarbportefolje.auth.AuthService;
 import no.nav.pto.veilarbportefolje.auth.PoaoTilgangWrapper;
 import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
-import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.persononinfo.bosted.BostedService;
 import no.nav.pto.veilarbportefolje.persononinfo.personopprinelse.PersonOpprinnelseService;

--- a/src/test/java/no/nav/pto/veilarbportefolje/controller/EnhetControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/controller/EnhetControllerTest.java
@@ -16,6 +16,7 @@ import no.nav.pto.veilarbportefolje.auth.AuthService;
 import no.nav.pto.veilarbportefolje.auth.PoaoTilgangWrapper;
 import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
+import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.persononinfo.bosted.BostedService;
 import no.nav.pto.veilarbportefolje.persononinfo.personopprinelse.PersonOpprinnelseService;
@@ -59,40 +60,40 @@ public class EnhetControllerTest {
     public void skal_hent_portefolje_fra_indeks_dersom_tilgang() {
         when(poaoTilgangWrapper.harVeilederTilgangTilModia()).thenReturn(Decision.Permit.INSTANCE);
         when(pep.harVeilederTilgangTilEnhet(any(NavIdent.class), any(EnhetId.class))).thenReturn(true);
-        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
+        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
 
         authContextHolder.withContext(
                 new AuthContext(UserRole.INTERN, TestDataUtils.generateJWT("A111111")),
                 () -> enhetController.hentPortefoljeForEnhet("0001", 0, 0, "ikke_satt", "ikke_satt", new Filtervalg())
         );
-        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), any(), any());
+        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
     public void skal_hente_hele_portefolje_fra_indeks_dersom_man_mangle_antall() {
         when(pep.harVeilederTilgangTilEnhet(any(), any())).thenReturn(true);
         when(poaoTilgangWrapper.harVeilederTilgangTilModia()).thenReturn(Decision.Permit.INSTANCE);
-        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
+        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
 
         authContextHolder.withContext(
                 new AuthContext(UserRole.INTERN, TestDataUtils.generateJWT("A111111")),
                 () -> enhetController.hentPortefoljeForEnhet("0001", 0, null, "ikke_satt", "ikke_satt", new Filtervalg())
         );
-        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), any(), any());
+        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
     public void skal_hente_hele_portefolje_fra_indeks_dersom_man_mangle_fra() {
         when(pep.harVeilederTilgangTilEnhet(any(), any())).thenReturn(true);
         when(poaoTilgangWrapper.harVeilederTilgangTilModia()).thenReturn(Decision.Permit.INSTANCE);
-        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
+        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
         authContextHolder
                 .withContext(
                         new AuthContext(UserRole.INTERN, TestDataUtils.generateJWT("A111111")),
                         () -> enhetController.hentPortefoljeForEnhet("0001", null, 20, "ikke_satt", "ikke_satt", new Filtervalg())
                 );
 
-        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), isNull(), any());
+        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), isNull(), any(), any());
     }
 
     @Test(expected = ResponseStatusException.class)

--- a/src/test/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereServiceTest.java
@@ -11,7 +11,7 @@ import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.ensligforsorger.dto.input.*;
 import no.nav.pto.veilarbportefolje.ensligforsorger.dto.output.EnsligeForsorgerOvergangsstønadTiltakDto;
-import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
+import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OppfolgingsBruker;
 import no.nav.pto.veilarbportefolje.util.EndToEndTest;
@@ -79,7 +79,7 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                             "ikke_satt",
                             filtervalg,
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(1);
                     assertThat(responseBrukere.getBrukere().get(0).getEnsligeForsorgereOvergangsstonad().vedtaksPeriodetype()).isEqualTo("Ny periode for nytt barn");
@@ -119,7 +119,7 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                             "ikke_satt",
                             filtervalg,
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(0);
                 }
@@ -180,7 +180,7 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                 filterValg,
                 null,
                 null,
-                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         Assertions.assertThat(response.getAntall()).isEqualTo(2);
         Assertions.assertThat(response.getBrukere().get(0).getFnr().equals(bruker2.getFnr()));

--- a/src/test/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereServiceTest.java
@@ -11,6 +11,7 @@ import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.ensligforsorger.dto.input.*;
 import no.nav.pto.veilarbportefolje.ensligforsorger.dto.output.EnsligeForsorgerOvergangsstønadTiltakDto;
+import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OppfolgingsBruker;
 import no.nav.pto.veilarbportefolje.util.EndToEndTest;
@@ -78,7 +79,7 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                             "ikke_satt",
                             filtervalg,
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(1);
                     assertThat(responseBrukere.getBrukere().get(0).getEnsligeForsorgereOvergangsstonad().vedtaksPeriodetype()).isEqualTo("Ny periode for nytt barn");
@@ -118,7 +119,7 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                             "ikke_satt",
                             filtervalg,
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(0);
                 }
@@ -178,8 +179,8 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         Assertions.assertThat(response.getAntall()).isEqualTo(2);
         Assertions.assertThat(response.getBrukere().get(0).getFnr().equals(bruker2.getFnr()));

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -317,8 +317,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg(),
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(brukereMedAntall.getAntall()).isEqualTo(2);
     }
@@ -355,8 +355,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filtervalg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
 
         assertThat(response.getAntall()).isEqualTo(2);
@@ -407,7 +407,7 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
 
         pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == brukere.size());
 
-        var response = opensearchService.hentBrukere(TEST_ENHET, empty(), "asc", "ikke_satt", filtervalg, null, null);
+        var response = opensearchService.hentBrukere(TEST_ENHET, empty(), "asc", "ikke_satt", filtervalg, null, null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(2);
     }
@@ -446,7 +446,7 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
         pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == brukere.size());
 
         var filtervalg = new Filtervalg().setFerdigfilterListe(List.of(UFORDELTE_BRUKERE));
-        var response = opensearchService.hentBrukere(TEST_ENHET, empty(), "asc", "ikke_satt", filtervalg, null, null);
+        var response = opensearchService.hentBrukere(TEST_ENHET, empty(), "asc", "ikke_satt", filtervalg, null, null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         assertThat(response.getAntall()).isEqualTo(2);
     }
 
@@ -563,8 +563,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg().setFerdigfilterListe(List.of()),
                 null,
-                null
-        ).getAntall() == liste.size());
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ).getAntall() == liste.size());
 
         var statustall = opensearchService.hentStatusTallForVeileder(TEST_VEILEDER_0, TEST_ENHET);
         assertThat(statustall.erSykmeldtMedArbeidsgiver).isEqualTo(0);
@@ -696,8 +696,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "arbeidslistekategori",
                 new Filtervalg(),
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         List<Bruker> brukere = brukereMedAntall.getBrukere();
 
@@ -756,8 +756,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "valgteaktiviteter",
                 filtervalg1,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         BrukereMedAntall brukereMedAntall2 = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.empty(),
@@ -765,8 +765,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "valgteaktiviteter",
                 filtervalg2,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         List<Bruker> brukere1 = brukereMedAntall.getBrukere();
         List<Bruker> brukere2 = brukereMedAntall2.getBrukere();
@@ -813,8 +813,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg().setFerdigfilterListe(List.of(TRENGER_VURDERING)),
                 null,
-                null
-        ).getAntall() == liste.size());
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ).getAntall() == liste.size());
 
         List<Brukerstatus> ferdigFiltere = List.of(
                 UFORDELTE_BRUKERE,
@@ -828,8 +828,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg().setFerdigfilterListe(ferdigFiltere),
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(userExistsInResponse(nyForEnhet, response)).isTrue();
@@ -862,8 +862,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg(),
                 null,
-                null
-        ).getAntall() == 1);
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ).getAntall() == 1);
 
 
         var response = opensearchService.hentBrukere(
@@ -873,8 +873,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg(),
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(userExistsInResponse(brukerVeilederHarTilgangTil, response)).isTrue();
@@ -912,8 +912,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg().setFerdigfilterListe(List.of(UFORDELTE_BRUKERE)),
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(veilederExistsInResponse(LITE_PRIVILEGERT_VEILEDER, response)).isTrue();
@@ -957,9 +957,9 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
+                null,
 
-        );
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().anyMatch(it -> it.getFodselsdagIMnd() == 7)).isTrue();
@@ -999,8 +999,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().anyMatch(bruker -> "K".equals(bruker.getKjonn()))).isTrue();
@@ -1041,8 +1041,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(userExistsInResponse(brukerMedAAP, response)).isTrue();
@@ -1106,8 +1106,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(userExistsInResponse(brukerMedDagpengerMedPermittering, response)).isTrue();
@@ -1157,8 +1157,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(userExistsInResponse(brukerMedSokeAvtale, response)).isTrue();
@@ -1206,8 +1206,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(userExistsInResponse(brukerMedBehandling, response)).isTrue();
@@ -1257,8 +1257,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(userExistsInResponse(brukerMedTiltak, response)).isTrue();
@@ -1309,8 +1309,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(userExistsInResponse(brukerMedBehandling, response)).isTrue();
@@ -1384,8 +1384,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "utkast_14a_ansvarlig_veileder",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(4);
         assertThat(userExistsInResponse(brukerMedVedtak, response)).isTrue();
@@ -1459,8 +1459,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(response.getBrukere().stream().filter(x -> x.getTalespraaktolk().equals("JPN")).anyMatch(x -> x.getTolkBehovSistOppdatert().equals("2022-02-22")));
@@ -1478,8 +1478,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().filter(x -> x.getTalespraaktolk().equals("SWE")).anyMatch(x -> x.getTolkBehovSistOppdatert().equals("2021-03-23")));
 
@@ -1494,8 +1494,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(response.getBrukere().stream().filter(x -> x.getTalespraaktolk().equals("JPN")).anyMatch(x -> x.getTolkBehovSistOppdatert().equals("2022-02-22")));
@@ -1514,8 +1514,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().filter(x -> x.getTalespraaktolk().equals("JPN")).anyMatch(x -> x.getTolkBehovSistOppdatert().equals("2022-02-22")));
 
@@ -1531,8 +1531,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().filter(x -> x.getTalespraaktolk().equals("JPN")).anyMatch(x -> x.getTolkBehovSistOppdatert().equals("2022-02-22")));
     }
@@ -1615,8 +1615,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(response.getBrukere().stream().filter(x -> x.getFoedeland().equals("Aserbajdsjan")).findFirst().isPresent());
@@ -1634,8 +1634,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().filter(x -> x.getFoedeland().equals("Norge")).findFirst().isPresent());
 
@@ -1651,8 +1651,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().noneMatch(x -> x.getFoedeland() != null));
 
@@ -1667,8 +1667,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         assertThat(response.getAntall()).isEqualTo(3);
         assertThat(response.getBrukere().stream().filter(x -> x.getFoedeland() != null).anyMatch(x -> x.getFoedeland().equals("SGP")));
         assertThat(response.getBrukere().stream().filter(x -> x.getFoedeland() != null).anyMatch(x -> x.getFoedeland().equals("AZE")));
@@ -1759,8 +1759,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "fodeland",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(6);
         assertThat(response.getBrukere().get(0).getFoedeland().equals("Aserbajdsjan"));
@@ -1777,8 +1777,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "fodeland",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(6);
         assertThat(response.getBrukere().get(0).getFoedeland().equals("Singapore"));
@@ -1795,8 +1795,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "statsborgerskap",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(6);
         assertThat(response.getBrukere().get(0).getHovedStatsborgerskap().getStatsborgerskap().equals("Estland"));
@@ -1870,8 +1870,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(response.getBrukere().stream().allMatch(x -> x.getBostedKommune().equals("10")));
@@ -1888,8 +1888,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().allMatch(x -> x.getBostedBydel().equals("1233")));
 
@@ -1905,8 +1905,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         assertThat(response.getAntall()).isEqualTo(3);
         assertThat(response.getBrukere().stream().filter(x -> x.getBostedKommune().equalsIgnoreCase("10")).count()).isEqualTo(2);
         assertThat(response.getBrukere().stream().anyMatch(x -> x.getBostedBydel().equalsIgnoreCase("1233")));
@@ -1978,8 +1978,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "kommunenummer",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getBostedKommune().equals("10"));
@@ -1995,8 +1995,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "bydelsnummer",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getBostedBydel().equals("1010"));
@@ -2061,8 +2061,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getBrukere())
                 .hasSize(2)
@@ -2124,8 +2124,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getBrukere())
                 .hasSize(5)
@@ -2185,8 +2185,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getBrukere()).hasSize(5);
     }
@@ -2234,8 +2234,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "etternavn",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getBrukere()).hasSize(3);
         assertThat(response.getBrukere().get(0).getEtternavn()).isEqualTo("C");
@@ -2282,8 +2282,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "etternavn",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getBrukere()).hasSize(3);
         assertThat(response.getBrukere().get(0).getEtternavn()).isEqualTo("C");
@@ -2352,8 +2352,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "enslige_forsorgere_utlop_ytelse",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getFnr().equals(bruker3.getFnr()));
@@ -2368,8 +2368,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "enslige_forsorgere_om_barnet",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getFnr().equals(bruker3.getFnr()));
@@ -2384,8 +2384,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "enslige_forsorgere_aktivitetsplikt",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getFnr().equals(bruker1.getFnr()));
@@ -2400,8 +2400,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "enslige_forsorgere_vedtaksperiodetype",
                 filterValg,
                 null,
-                null
-        );
+                null,
+                InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getFnr().equals(bruker2.getFnr()));
@@ -2442,8 +2442,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                         "ikke_satt",
                         new Filtervalg(),
                         null,
-                        null
-                )
+                        null,
+                        InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ)
         );
     }
 
@@ -2457,8 +2457,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                         "ikke_satt",
                         new Filtervalg(),
                         null,
-                        null
-                )
+                        null,
+                        InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ)
         );
     }
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolginsbrukerRepositoryTestV3.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolginsbrukerRepositoryTestV3.java
@@ -1,7 +1,7 @@
 package no.nav.pto.veilarbportefolje.oppfolgingsbruker;
 
 import no.nav.common.types.identer.Fnr;
-import no.nav.pto.veilarbportefolje.auth.BrukerInnsynTilganger;
+import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,10 +74,10 @@ public class OppfolginsbrukerRepositoryTestV3 {
         settSperretAnsatt(sperretAnsattFnr, true);
         settSperretAnsatt(kontrollFnr, false);
 
-        List<String> medTilgang = oppfolgingsbrukerRepository.finnSkjulteBrukere(List.of(sperretAnsattFnr, kontrollFnr), new BrukerInnsynTilganger(
+        List<String> medTilgang = oppfolgingsbrukerRepository.finnSkjulteBrukere(List.of(sperretAnsattFnr, kontrollFnr), new BrukerinnsynTilganger(
                 false, false, true));
         List<String> utenTilgang = oppfolgingsbrukerRepository.finnSkjulteBrukere(List.of(sperretAnsattFnr, kontrollFnr),
-                new BrukerInnsynTilganger(false, false, false));
+                new BrukerinnsynTilganger(false, false, false));
         assertThat(medTilgang.size()).isEqualTo(0);
         assertThat(utenTilgang.size()).isEqualTo(1);
         assertThat(utenTilgang.stream().anyMatch(x -> x.equals(sperretAnsattFnr))).isTrue();
@@ -94,13 +94,13 @@ public class OppfolginsbrukerRepositoryTestV3 {
         settDiskresjonskode(kontrollFnr, null);
 
         List<String> medAlleTilgang = oppfolgingsbrukerRepository.finnSkjulteBrukere(List.of(kode6Fnr, kode7Fnr, kontrollFnr),
-                new BrukerInnsynTilganger(true, true, false));
+                new BrukerinnsynTilganger(true, true, false));
         List<String> medKode6Tilgang = oppfolgingsbrukerRepository.finnSkjulteBrukere(List.of(kode6Fnr, kode7Fnr, kontrollFnr),
-                new BrukerInnsynTilganger(true, false, false));
+                new BrukerinnsynTilganger(true, false, false));
         List<String> medKode7Tilgang = oppfolgingsbrukerRepository.finnSkjulteBrukere(List.of(kode6Fnr, kode7Fnr, kontrollFnr),
-                new BrukerInnsynTilganger(false, true, false));
+                new BrukerinnsynTilganger(false, true, false));
         List<String> utenTilgang = oppfolgingsbrukerRepository.finnSkjulteBrukere(List.of(kode6Fnr, kode7Fnr, kontrollFnr),
-                new BrukerInnsynTilganger(false, false, false));
+                new BrukerinnsynTilganger(false, false, false));
 
         assertThat(medAlleTilgang.size()).isEqualTo(0);
         assertThat(medKode6Tilgang.size()).isEqualTo(1);

--- a/src/test/java/no/nav/pto/veilarbportefolje/registrering/RegistreringServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/registrering/RegistreringServiceTest.java
@@ -9,7 +9,7 @@ import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
-import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
+import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OppfolgingsBruker;
@@ -84,7 +84,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgBestatt(),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere2.getAntall()).isEqualTo(1);
                 }
@@ -98,7 +98,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgGodkjent(),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere3.getAntall()).isEqualTo(2);
                 }
@@ -112,7 +112,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgUtdanning(),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere4.getAntall()).isEqualTo(2);
                 }
@@ -126,7 +126,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgMix(),
                             null,
-                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere5.getAntall()).isEqualTo(1);
                 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/registrering/RegistreringServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/registrering/RegistreringServiceTest.java
@@ -9,6 +9,7 @@ import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
+import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OppfolgingsBruker;
@@ -83,7 +84,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgBestatt(),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere2.getAntall()).isEqualTo(1);
                 }
@@ -97,7 +98,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgGodkjent(),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere3.getAntall()).isEqualTo(2);
                 }
@@ -111,7 +112,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgUtdanning(),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere4.getAntall()).isEqualTo(2);
                 }
@@ -125,7 +126,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgMix(),
                             null,
-                            null);
+                            null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
                     assertThat(responseBrukere5.getAntall()).isEqualTo(1);
                 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/sisteendring/SisteEndringIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/sisteendring/SisteEndringIntegrationTest.java
@@ -12,6 +12,7 @@ import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.mal.MalEndringKafkaDTO;
 import no.nav.pto.veilarbportefolje.mal.MalService;
+import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerRepositoryV3;
@@ -165,7 +166,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
-                    null);
+                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
             return brukereMedAntall.getAntall() == 1;
         });
         verifiserAsynkront(2, TimeUnit.SECONDS, () -> {
@@ -177,7 +178,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
-                    null);
+                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             assertThat(responseBrukere.getAntall()).isEqualTo(1);
             assertThat(responseBrukere.getBrukere().get(0).getSisteEndringTidspunkt()).isEqualTo(zonedDateTime.toLocalDateTime());
@@ -198,7 +199,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg(),
                     null,
-                    null);
+                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 1;
         });
@@ -210,7 +211,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 getFiltervalg(FULLFORT_IJOBB, true),
                 null,
-                null);
+                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(responseBrukere.getAntall()).isEqualTo(0);
     }
@@ -233,7 +234,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg(),
                     null,
-                    null);
+                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 1;
         });
@@ -255,7 +256,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(NY_IJOBB),
                     null,
-                    null);
+                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
             return brukereMedAntall.getAntall() == 1;
         });
 
@@ -269,7 +270,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB, true),
                     null,
-                    null);
+                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
             return brukereMedAntall.getAntall() == 0;
         });
 
@@ -280,7 +281,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 getFiltervalg(NY_IJOBB, true),
                 null,
-                null);
+                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(responseBrukere1.getAntall()).isEqualTo(1);
 
@@ -291,7 +292,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 getFiltervalg(FULLFORT_IJOBB, true),
                 null,
-                null);
+                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(responseBrukere2.getAntall()).isEqualTo(0);
     }
@@ -321,7 +322,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg(),
                     null,
-                    null);
+                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 3;
         });
@@ -354,7 +355,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
-                    null);
+                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 2;
         });
@@ -367,7 +368,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_EGEN),
                     null,
-                    null);
+                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 3;
         });
@@ -379,7 +380,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "siste_endring_tidspunkt",
                 getFiltervalg(FULLFORT_IJOBB),
                 null,
-                null);
+                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(responseSortertFULLFORT_IJOBB.getAntall()).isEqualTo(2);
         assertThat(responseSortertFULLFORT_IJOBB.getBrukere().get(0).getSisteEndringTidspunkt().getYear()).isEqualTo(endret_Tid_IJOBB_bruker_2_i_2025.getYear());
@@ -392,7 +393,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "siste_endring_tidspunkt",
                 getFiltervalg(FULLFORT_EGEN),
                 null,
-                null);
+                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(responseSortertFULLFORT_EGEN.getAntall()).isEqualTo(3);
         assertThat(responseSortertFULLFORT_EGEN.getBrukere().get(0).getSisteEndringTidspunkt().getYear()).isEqualTo(endret_Tid_EGEN_bruker_3_i_2019.getYear());
@@ -406,7 +407,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "siste_endring_tidspunkt",
                 getFiltervalg(NY_IJOBB),
                 null,
-                null);
+                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         assertThat(responseSortertTomRes1.getAntall()).isEqualTo(0);
     }
 
@@ -420,7 +421,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                         "siste_endring_tidspunkt",
                         getFiltervalg(FULLFORT_IJOBB, FULLFORT_EGEN),
                         null,
-                        null));
+                        null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ));
         assertThat(exception).isNotNull();
     }
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/sisteendring/SisteEndringIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/sisteendring/SisteEndringIntegrationTest.java
@@ -12,7 +12,7 @@ import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.mal.MalEndringKafkaDTO;
 import no.nav.pto.veilarbportefolje.mal.MalService;
-import no.nav.pto.veilarbportefolje.opensearch.InnsynsrettFilterType;
+import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerRepositoryV3;
@@ -166,7 +166,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
-                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
             return brukereMedAntall.getAntall() == 1;
         });
         verifiserAsynkront(2, TimeUnit.SECONDS, () -> {
@@ -178,7 +178,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
-                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             assertThat(responseBrukere.getAntall()).isEqualTo(1);
             assertThat(responseBrukere.getBrukere().get(0).getSisteEndringTidspunkt()).isEqualTo(zonedDateTime.toLocalDateTime());
@@ -199,7 +199,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg(),
                     null,
-                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 1;
         });
@@ -211,7 +211,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 getFiltervalg(FULLFORT_IJOBB, true),
                 null,
-                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(responseBrukere.getAntall()).isEqualTo(0);
     }
@@ -234,7 +234,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg(),
                     null,
-                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 1;
         });
@@ -256,7 +256,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(NY_IJOBB),
                     null,
-                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
             return brukereMedAntall.getAntall() == 1;
         });
 
@@ -270,7 +270,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB, true),
                     null,
-                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
             return brukereMedAntall.getAntall() == 0;
         });
 
@@ -281,7 +281,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 getFiltervalg(NY_IJOBB, true),
                 null,
-                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(responseBrukere1.getAntall()).isEqualTo(1);
 
@@ -292,7 +292,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 getFiltervalg(FULLFORT_IJOBB, true),
                 null,
-                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(responseBrukere2.getAntall()).isEqualTo(0);
     }
@@ -322,7 +322,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg(),
                     null,
-                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 3;
         });
@@ -355,7 +355,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
-                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 2;
         });
@@ -368,7 +368,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_EGEN),
                     null,
-                    null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
             return brukereMedAntall.getAntall() == 3;
         });
@@ -380,7 +380,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "siste_endring_tidspunkt",
                 getFiltervalg(FULLFORT_IJOBB),
                 null,
-                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(responseSortertFULLFORT_IJOBB.getAntall()).isEqualTo(2);
         assertThat(responseSortertFULLFORT_IJOBB.getBrukere().get(0).getSisteEndringTidspunkt().getYear()).isEqualTo(endret_Tid_IJOBB_bruker_2_i_2025.getYear());
@@ -393,7 +393,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "siste_endring_tidspunkt",
                 getFiltervalg(FULLFORT_EGEN),
                 null,
-                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(responseSortertFULLFORT_EGEN.getAntall()).isEqualTo(3);
         assertThat(responseSortertFULLFORT_EGEN.getBrukere().get(0).getSisteEndringTidspunkt().getYear()).isEqualTo(endret_Tid_EGEN_bruker_3_i_2019.getYear());
@@ -407,7 +407,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "siste_endring_tidspunkt",
                 getFiltervalg(NY_IJOBB),
                 null,
-                null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         assertThat(responseSortertTomRes1.getAntall()).isEqualTo(0);
     }
 
@@ -421,7 +421,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                         "siste_endring_tidspunkt",
                         getFiltervalg(FULLFORT_IJOBB, FULLFORT_EGEN),
                         null,
-                        null, InnsynsrettFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ));
+                        null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ));
         assertThat(exception).isNotNull();
     }
 


### PR DESCRIPTION
## Describe your changes

TL;DR: Statustallene må gjenspeile ny tilgangsbegrensning for uthenting av portefølje.

Ifm. at vi strammer inn på hvilke brukere som inkluderes i uthenting av portefølje så blir vi nødt til å gjenspeile dette i statustallene. Ved uthenting av portefølje så vil vi bare inkludere brukere med spesielle innsynsregler _dersom_ veileder har tilsvarende innsynsrett. 

Eksempel: Gitt at en veileder ikke har noen form for spesiell innsynsrett (hverken adressebeskyttelse eller skjermede brukere). Da vil uthenting av portefølje _ikke_ inkludere disse brukerne. Dette gjelder både når man henter ut "Enhetens portefølje" og "Min portefølje". **Dette er noe statustallene må gjenspeile**. Dvs. at vi må ha statustall som reflekterer brukerne i en veileders portefølje, men også staustall som sier noe overordnet om brukere på enheten. I tillegg trenger vi statustall som sier noe om brukere på enheten _som veileder ikke har innsynsrett på_ (dette for å gjøre det mulig å "fange opp"/unngå at noen brukere ikke blir fanget opp).

For å løse dette har jeg valgt å "gå tilbake" på min opprinnelige idè der jeg inkluderte tall om brukere som veileder ikke hadde innsynsrett på som egne og nye felter på payloaden. Nå har jeg valgt å omgjøre payloaden for enhetsstatustallene til å inneholde to varianter av `Statustall`, der den ene (`statustallMedBrukerinnsyn`) gjenspeiler brukere som veileder faktisk får se i porteføljen og den andre (`statustallUtenBrukerinnsyn`) gjenspeiler brukere som som veileder ikke får se i porteføljen.

Jeg kommer til å måtte gjøre en litt større tilpasning i frontenden. For å gjøre overgangen enklere så har jeg valgt å trekke dette ut i nye separate endepunkter, og beholdt de gamle. Da kan jeg ta ut endringen i backenden, uten å være redd for at frontenden skal knekke. Når jeg deretter har gjort endringen i frontenden så kan jeg fjerne de gamle endepunktene i backenden. Jeg valgte å legge de nye endepunktene som sub-paths av `/portefolje`, da jeg føler semantikken `/portefolje/statustall` gir mer mening i og med at statustallene er sterkt koblet til porteføljen(e).

## Trello ticket number and link

- [TC-270](https://trello.com/c/eegtUQrl/270-fjerne-mulighet-for-%C3%A5-kunne-identifisere-navn-og-stedslokaliserende-informasjon-for-egen-ansatt-og-kode-6-og-7)

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
