### PR TITLE
TC-270 Fikse feil i mapping fra bucket til respons-felt

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Statustall.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Statustall.java
@@ -1,49 +1,51 @@
 package no.nav.pto.veilarbportefolje.domene;
 
+import lombok.Data;
+import lombok.experimental.Accessors;
 import no.nav.pto.veilarbportefolje.opensearch.domene.StatustallResponse;
 
-public record Statustall(
-        long totalt,
-        long ufordelteBrukere,
-        long trengerVurdering,
-        long nyeBrukereForVeileder,
-        long inaktiveBrukere,
-        long venterPaSvarFraNAV,
-        long venterPaSvarFraBruker,
-        long iavtaltAktivitet,
-        long iAktivitet,
-        long ikkeIavtaltAktivitet,
-        long utlopteAktiviteter,
-        long minArbeidsliste,
-        long erSykmeldtMedArbeidsgiver,
-        long moterMedNAVIdag,
-        long underVurdering,
-        long minArbeidslisteBla,
-        long minArbeidslisteLilla,
-        long minArbeidslisteGronn,
-        long minArbeidslisteGul
-) {
-    public static Statustall of(StatustallResponse.StatustallAggregation.StatustallFilter.StatustallBuckets buckets, boolean vedtakstottePilotErPa) {
-        return new Statustall(
-                buckets.getTotalt().getDoc_count(),
-                buckets.getUfordelteBrukere().getDoc_count(),
-                buckets.getTrengerVurdering().getDoc_count(),
-                buckets.getNyeBrukereForVeileder().getDoc_count(),
-                buckets.getInaktiveBrukere().getDoc_count(),
-                buckets.getVenterPaSvarFraNAV().getDoc_count(),
-                buckets.getVenterPaSvarFraBruker().getDoc_count(),
-                buckets.getIavtaltAktivitet().getDoc_count(),
-                buckets.getIAktivitet().getDoc_count(),
-                buckets.getIkkeIavtaltAktivitet().getDoc_count(),
-                buckets.getUtlopteAktiviteter().getDoc_count(),
-                buckets.getMinArbeidsliste().getDoc_count(),
-                buckets.getErSykmeldtMedArbeidsgiver().getDoc_count(),
-                buckets.getMoterMedNAVIdag().getDoc_count(),
-                buckets.getMinArbeidslisteBla().getDoc_count(),
-                buckets.getMinArbeidslisteLilla().getDoc_count(),
-                buckets.getMinArbeidslisteGronn().getDoc_count(),
-                buckets.getMinArbeidslisteGul().getDoc_count(),
-                vedtakstottePilotErPa ? buckets.getUnderVurdering().getDoc_count() : 0
-        );
+@Data
+@Accessors(chain = true)
+public class Statustall {
+    private long totalt;
+    private long ufordelteBrukere;
+    private long trengerVurdering;
+    private long nyeBrukereForVeileder;
+    private long inaktiveBrukere;
+    private long venterPaSvarFraNAV;
+    private long venterPaSvarFraBruker;
+    private long iavtaltAktivitet;
+    private long iAktivitet;
+    private long ikkeIavtaltAktivitet;
+    private long utlopteAktiviteter;
+    private long minArbeidsliste;
+    private long erSykmeldtMedArbeidsgiver;
+    private long moterMedNAVIdag;
+    private long underVurdering;
+    private long minArbeidslisteBla;
+    private long minArbeidslisteLilla;
+    private long minArbeidslisteGronn;
+    private long minArbeidslisteGul;
+
+    public Statustall(StatustallResponse.StatustallAggregation.StatustallFilter.StatustallBuckets buckets, boolean vedtakstottePilotErPa) {
+        this.totalt = buckets.getTotalt().getDoc_count();
+        this.ufordelteBrukere = buckets.getUfordelteBrukere().getDoc_count();
+        this.trengerVurdering = buckets.getTrengerVurdering().getDoc_count();
+        this.nyeBrukereForVeileder = buckets.getNyeBrukereForVeileder().getDoc_count();
+        this.inaktiveBrukere = buckets.getInaktiveBrukere().getDoc_count();
+        this.venterPaSvarFraNAV = buckets.getVenterPaSvarFraNAV().getDoc_count();
+        this.venterPaSvarFraBruker = buckets.getVenterPaSvarFraBruker().getDoc_count();
+        this.iavtaltAktivitet = buckets.getIavtaltAktivitet().getDoc_count();
+        this.iAktivitet = buckets.getIAktivitet().getDoc_count();
+        this.ikkeIavtaltAktivitet = buckets.getIkkeIavtaltAktivitet().getDoc_count();
+        this.utlopteAktiviteter = buckets.getUtlopteAktiviteter().getDoc_count();
+        this.minArbeidsliste = buckets.getMinArbeidsliste().getDoc_count();
+        this.erSykmeldtMedArbeidsgiver = buckets.getErSykmeldtMedArbeidsgiver().getDoc_count();
+        this.moterMedNAVIdag = buckets.getMoterMedNAVIdag().getDoc_count();
+        this.minArbeidslisteBla = buckets.getMinArbeidslisteBla().getDoc_count();
+        this.minArbeidslisteLilla = buckets.getMinArbeidslisteLilla().getDoc_count();
+        this.minArbeidslisteGronn = buckets.getMinArbeidslisteGronn().getDoc_count();
+        this.minArbeidslisteGul = buckets.getMinArbeidslisteGul().getDoc_count();
+        this.underVurdering = vedtakstottePilotErPa ? buckets.getUnderVurdering().getDoc_count() : 0;
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
@@ -134,7 +134,7 @@ public class OpensearchService {
 
         StatustallResponse response = search(request, indexName.getValue(), StatustallResponse.class);
         StatustallBuckets buckets = response.getAggregations().getFilters().getBuckets();
-        return Statustall.of(buckets, vedtakstottePilotErPa);
+        return new Statustall(buckets, vedtakstottePilotErPa);
     }
 
     public Statustall hentStatusTallForEnhet(String enhetId, BrukerinnsynTilgangFilterType brukerinnsynTilgangFilterType) {
@@ -155,7 +155,7 @@ public class OpensearchService {
 
         StatustallResponse response = search(request, indexName.getValue(), StatustallResponse.class);
         StatustallBuckets buckets = response.getAggregations().getFilters().getBuckets();
-        return Statustall.of(buckets, vedtakstottePilotErPa);
+        return new Statustall(buckets, vedtakstottePilotErPa);
     }
 
     public Statustall hentStatusTallForEnhetPortefolje(String enhetId, BrukerinnsynTilgangFilterType brukerinnsynTilgangFilterType) {
@@ -176,7 +176,7 @@ public class OpensearchService {
 
         StatustallResponse response = search(request, indexName.getValue(), StatustallResponse.class);
         StatustallBuckets buckets = response.getAggregations().getFilters().getBuckets();
-        return Statustall.of(buckets, vedtakstottePilotErPa);
+        return new Statustall(buckets, vedtakstottePilotErPa);
     }
 
     public FacetResults hentPortefoljestorrelser(String enhetId) {

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -633,9 +633,9 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
 
         Statustall respons = opensearchService.hentStatusTallForEnhetPortefolje(TEST_ENHET, BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ);
 
-        assertThat(respons.totalt()).isEqualTo(12);
-        assertThat(respons.ufordelteBrukere()).isEqualTo(4);
-        assertThat(respons.venterPaSvarFraNAV()).isEqualTo(4);
+        assertThat(respons.getTotalt()).isEqualTo(12);
+        assertThat(respons.getUfordelteBrukere()).isEqualTo(4);
+        assertThat(respons.getVenterPaSvarFraNAV()).isEqualTo(4);
     }
 
     @Test
@@ -692,8 +692,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
 
         Statustall respons = opensearchService.hentStatusTallForEnhetPortefolje(TEST_ENHET, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
-        assertThat(respons.totalt()).isEqualTo(3);
-        assertThat(respons.venterPaSvarFraNAV()).isEqualTo(1);
+        assertThat(respons.getTotalt()).isEqualTo(3);
+        assertThat(respons.getVenterPaSvarFraNAV()).isEqualTo(1);
     }
 
     @Test
@@ -722,7 +722,7 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
         when(veilarbVeilederClientMock.hentVeilederePaaEnhet(any())).thenReturn(List.of(TEST_VEILEDER_0));
 
         var statustall = opensearchService.hentStatusTallForEnhet(TEST_ENHET, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
-        assertThat(statustall.ufordelteBrukere()).isEqualTo(1);
+        assertThat(statustall.getUfordelteBrukere()).isEqualTo(1);
     }
 
     @Test
@@ -980,7 +980,7 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
         assertThat(veilederExistsInResponse(LITE_PRIVILEGERT_VEILEDER, response)).isTrue();
 
         Statustall statustall = opensearchService.hentStatusTallForEnhet(TEST_ENHET, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
-        assertThat(statustall.ufordelteBrukere()).isEqualTo(1);
+        assertThat(statustall.getUfordelteBrukere()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
## Describe your changes

Hadde en feil i mappingen fra bucket til respons-felt (hadde mappet `underVurdering`-antallet til `minArbeidsListeBla` og omvendt). Går over til å bruke vanlig class i stedet for record, da det blir lettere å se hvilket felt som mappes til hva.

## Trello ticket number and link

[TC-270](https://trello.com/c/eegtUQrl/270-fjerne-mulighet-for-%C3%A5-kunne-identifisere-navn-og-stedslokaliserende-informasjon-for-egen-ansatt-og-kode-6-og-7)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
