### PR TITLE
TC-270 Legg til default-oppførsel for hentBrukere/-statustall

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/auth/BrukerinnsynTilganger.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/auth/BrukerinnsynTilganger.java
@@ -1,4 +1,12 @@
 package no.nav.pto.veilarbportefolje.auth;
 
-public record BrukerinnsynTilganger(boolean tilgangTilAdressebeskyttelseStrengtFortrolig, boolean tilgangTilAdressebeskyttelseFortrolig, boolean tilgangTilSkjerming) {
+public record BrukerinnsynTilganger(
+        boolean tilgangTilAdressebeskyttelseStrengtFortrolig,
+        boolean tilgangTilAdressebeskyttelseFortrolig,
+        boolean tilgangTilSkjerming
+) {
+
+    public boolean harAlle() {
+        return tilgangTilAdressebeskyttelseStrengtFortrolig && tilgangTilAdressebeskyttelseFortrolig && tilgangTilSkjerming;
+    }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/EnhetController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/EnhetController.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static no.nav.common.client.utils.CacheUtils.tryCacheFirst;
-import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
+import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
 import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ;
 
 @RestController
@@ -84,7 +84,7 @@ public class EnhetController {
         ValideringsRegler.sjekkEnhet(enhet);
         authService.tilgangTilEnhet(enhet);
 
-        return opensearchService.hentStatusTallForEnhet(enhet, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        return opensearchService.hentStatusTallForEnhet(enhet);
     }
 
     @GetMapping("/{enhet}/portefolje/statustall")
@@ -93,7 +93,7 @@ public class EnhetController {
         authService.tilgangTilEnhet(enhet);
 
         return new EnhetPortefoljeStatustallRespons(
-                opensearchService.hentStatusTallForEnhetPortefolje(enhet, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ),
+                opensearchService.hentStatusTallForEnhetPortefolje(enhet, BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ),
                 opensearchService.hentStatusTallForEnhetPortefolje(enhet, BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ)
         );
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/EnhetController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/EnhetController.java
@@ -62,7 +62,7 @@ public class EnhetController {
         authService.tilgangTilOppfolging();
         authService.tilgangTilEnhet(enhet);
 
-        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.empty(), sortDirection, sortField, filtervalg, fra, antall, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.empty(), sortDirection, sortField, filtervalg, fra, antall);
         List<Bruker> sensurerteBrukereSublist = authService.sensurerBrukere(brukereMedAntall.getBrukere());
 
         return PortefoljeUtils.buildPortefolje(brukereMedAntall.getAntall(),

--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
@@ -10,7 +10,6 @@ import no.nav.pto.veilarbportefolje.auth.AuthService;
 import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.domene.*;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
-import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.util.PortefoljeUtils;
 import no.nav.pto.veilarbportefolje.util.ValideringsRegler;
@@ -61,7 +60,7 @@ public class VeilederController {
         ValideringsRegler.sjekkVeilederIdent(veilederIdent, false);
         authService.tilgangTilEnhet(enhet);
 
-        return opensearchService.hentStatusTallForVeileder(veilederIdent, enhet, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        return opensearchService.hentStatusTallForVeileder(veilederIdent, enhet);
     }
 
     @GetMapping("/{veilederident}/portefolje/statustall")
@@ -71,9 +70,7 @@ public class VeilederController {
         authService.tilgangTilEnhet(enhet);
 
         return new VeilederPortefoljeStatustallRespons(
-                opensearchService.hentStatustallForVeilederPortefolje(
-                        veilederIdent, enhet, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ
-                )
+                opensearchService.hentStatustallForVeilederPortefolje(veilederIdent, enhet)
         );
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
@@ -19,8 +19,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Optional;
 
-import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
-
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -48,7 +46,7 @@ public class VeilederController {
         authService.tilgangTilOppfolging();
         authService.tilgangTilEnhet(enhet);
 
-        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.of(veilederIdent), sortDirection, sortField, filtervalg, fra, antall, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.of(veilederIdent), sortDirection, sortField, filtervalg, fra, antall);
         List<Bruker> sensurerteBrukereSublist = authService.sensurerBrukere(brukereMedAntall.getBrukere());
 
         return PortefoljeUtils.buildPortefolje(brukereMedAntall.getAntall(),

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Statustall.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Statustall.java
@@ -27,6 +27,28 @@ public class Statustall {
     private long minArbeidslisteGronn;
     private long minArbeidslisteGul;
 
+    public Statustall() {
+        this.totalt = 0;
+        this.ufordelteBrukere = 0;
+        this.trengerVurdering = 0;
+        this.nyeBrukereForVeileder = 0;
+        this.inaktiveBrukere = 0;
+        this.venterPaSvarFraNAV = 0;
+        this.venterPaSvarFraBruker = 0;
+        this.iavtaltAktivitet = 0;
+        this.iAktivitet = 0;
+        this.ikkeIavtaltAktivitet = 0;
+        this.utlopteAktiviteter = 0;
+        this.minArbeidsliste = 0;
+        this.erSykmeldtMedArbeidsgiver = 0;
+        this.moterMedNAVIdag = 0;
+        this.minArbeidslisteBla = 0;
+        this.minArbeidslisteLilla = 0;
+        this.minArbeidslisteGronn = 0;
+        this.minArbeidslisteGul = 0;
+        this.underVurdering = 0;
+    }
+
     public Statustall(StatustallResponse.StatustallAggregation.StatustallFilter.StatustallBuckets buckets, boolean vedtakstottePilotErPa) {
         this.totalt = buckets.getTotalt().getDoc_count();
         this.ufordelteBrukere = buckets.getUfordelteBrukere().getDoc_count();

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/BrukerinnsynTilgangFilterType.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/BrukerinnsynTilgangFilterType.java
@@ -3,12 +3,7 @@ public enum BrukerinnsynTilgangFilterType {
     /**
      * Alle brukere som veileder har innsynsrett på
      */
-    ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ,
-
-    /**
-     * Alle brukere inkludert de som veileder eventuelt ikke har innsynsrett på
-     */
-    ALLE_BRUKERE,
+    BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ,
 
     /**
      * Kun brukere som veileder eventuelt ikke har innsynsrett på

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -54,7 +54,7 @@ public class OpensearchQueryBuilder {
 
     static BoolQueryBuilder leggTilBrukerinnsynTilgangFilter(BoolQueryBuilder boolQuery, BrukerinnsynTilganger brukerInnsynTilganger, BrukerinnsynTilgangFilterType filterType) {
         return switch (filterType) {
-            case ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ -> {
+            case BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ -> {
                 if (!brukerInnsynTilganger.tilgangTilAdressebeskyttelseStrengtFortrolig()) {
                     boolQuery.mustNot(matchQuery("diskresjonskode", Adressebeskyttelse.STRENGT_FORTROLIG.diskresjonskode));
                 }
@@ -89,8 +89,6 @@ public class OpensearchQueryBuilder {
 
                 yield boolQuery;
             }
-
-            case ALLE_BRUKERE -> boolQuery;
         };
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
-import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
+import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
 import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.*;
 import static org.opensearch.index.query.QueryBuilders.*;
 
@@ -82,7 +82,7 @@ public class OpensearchService {
         searchSourceBuilder.query(boolQuery);
 
         if (FeatureToggle.brukFilterForBrukerinnsynTilganger(unleashService)) {
-            leggTilBrukerinnsynTilgangFilter(boolQuery, authService.hentVeilederBrukerInnsynTilganger(), ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+            leggTilBrukerinnsynTilgangFilter(boolQuery, authService.hentVeilederBrukerInnsynTilganger(), BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         }
 
         sorterQueryParametere(sortOrder, sortField, searchSourceBuilder, filtervalg);
@@ -98,7 +98,7 @@ public class OpensearchService {
         return new BrukereMedAntall(totalHits, brukere);
     }
 
-    public VeilederPortefoljeStatusTall hentStatusTallForVeileder(String veilederId, String enhetId, BrukerinnsynTilgangFilterType brukerinnsynTilgangFilterType) {
+    public VeilederPortefoljeStatusTall hentStatusTallForVeileder(String veilederId, String enhetId) {
         boolean vedtakstottePilotErPa = this.erVedtakstottePilotPa(EnhetId.of(enhetId));
 
         BoolQueryBuilder veilederOgEnhetQuery = boolQuery()
@@ -107,7 +107,7 @@ public class OpensearchService {
                 .must(termQuery("veileder_id", veilederId));
 
         if (FeatureToggle.brukFilterForBrukerinnsynTilganger(unleashService)) {
-            leggTilBrukerinnsynTilgangFilter(veilederOgEnhetQuery, authService.hentVeilederBrukerInnsynTilganger(), brukerinnsynTilgangFilterType);
+            leggTilBrukerinnsynTilgangFilter(veilederOgEnhetQuery, authService.hentVeilederBrukerInnsynTilganger(), BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         }
 
         SearchSourceBuilder request =
@@ -118,13 +118,7 @@ public class OpensearchService {
         return new VeilederPortefoljeStatusTall(buckets, vedtakstottePilotErPa);
     }
 
-    public Statustall hentStatustallForVeilederPortefolje(String veilederId, String enhetId, BrukerinnsynTilgangFilterType brukerinnsynTilgangFilterType) {
-        BrukerinnsynTilganger brukerInnsynTilganger = authService.hentVeilederBrukerInnsynTilganger();
-
-        if (brukerInnsynTilganger.harAlle() && BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ == brukerinnsynTilgangFilterType) {
-            return new Statustall();
-        }
-
+    public Statustall hentStatustallForVeilederPortefolje(String veilederId, String enhetId) {
         boolean vedtakstottePilotErPa = this.erVedtakstottePilotPa(EnhetId.of(enhetId));
 
         BoolQueryBuilder veilederOgEnhetQuery = boolQuery()
@@ -133,7 +127,7 @@ public class OpensearchService {
                 .must(termQuery("veileder_id", veilederId));
 
         if (FeatureToggle.brukFilterForBrukerinnsynTilganger(unleashService)) {
-            leggTilBrukerinnsynTilgangFilter(veilederOgEnhetQuery, brukerInnsynTilganger, brukerinnsynTilgangFilterType);
+            leggTilBrukerinnsynTilgangFilter(veilederOgEnhetQuery, authService.hentVeilederBrukerInnsynTilganger(), BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         }
 
         SearchSourceBuilder request =
@@ -144,7 +138,7 @@ public class OpensearchService {
         return new Statustall(buckets, vedtakstottePilotErPa);
     }
 
-    public Statustall hentStatusTallForEnhet(String enhetId, BrukerinnsynTilgangFilterType brukerinnsynTilgangFilterType) {
+    public Statustall hentStatusTallForEnhet(String enhetId) {
         List<String> veilederPaaEnhet = veilarbVeilederClient.hentVeilederePaaEnhet(EnhetId.of(enhetId));
 
         boolean vedtakstottePilotErPa = this.erVedtakstottePilotPa(EnhetId.of(enhetId));
@@ -154,7 +148,7 @@ public class OpensearchService {
                 .must(termQuery("enhet_id", enhetId));
 
         if (FeatureToggle.brukFilterForBrukerinnsynTilganger(unleashService)) {
-            leggTilBrukerinnsynTilgangFilter(enhetQuery, authService.hentVeilederBrukerInnsynTilganger(), brukerinnsynTilgangFilterType);
+            leggTilBrukerinnsynTilgangFilter(enhetQuery, authService.hentVeilederBrukerInnsynTilganger(), BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         }
 
         SearchSourceBuilder request =

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
+import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
 import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.*;
 import static org.opensearch.index.query.QueryBuilders.*;
 
@@ -47,15 +48,8 @@ public class OpensearchService {
             String sortField,
             Filtervalg filtervalg,
             Integer fra,
-            Integer antall,
-            BrukerinnsynTilgangFilterType brukerinnsynTilgangFilterType
+            Integer antall
     ) {
-        BrukerinnsynTilganger brukerInnsynTilganger = authService.hentVeilederBrukerInnsynTilganger();
-
-        if (brukerInnsynTilganger.harAlle() && BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ == brukerinnsynTilgangFilterType) {
-            return new BrukereMedAntall(0, emptyList());
-        }
-
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
 
         int from = Optional.ofNullable(fra).orElse(0);
@@ -88,7 +82,7 @@ public class OpensearchService {
         searchSourceBuilder.query(boolQuery);
 
         if (FeatureToggle.brukFilterForBrukerinnsynTilganger(unleashService)) {
-            leggTilBrukerinnsynTilgangFilter(boolQuery, brukerInnsynTilganger, brukerinnsynTilgangFilterType);
+            leggTilBrukerinnsynTilgangFilter(boolQuery, authService.hentVeilederBrukerInnsynTilganger(), ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         }
 
         sorterQueryParametere(sortOrder, sortField, searchSourceBuilder, filtervalg);

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
@@ -5,6 +5,7 @@ import lombok.SneakyThrows;
 import no.nav.common.json.JsonUtils;
 import no.nav.common.types.identer.EnhetId;
 import no.nav.pto.veilarbportefolje.auth.AuthService;
+import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.client.VeilarbVeilederClient;
 import no.nav.pto.veilarbportefolje.config.FeatureToggle;
 import no.nav.pto.veilarbportefolje.domene.*;
@@ -49,6 +50,12 @@ public class OpensearchService {
             Integer antall,
             BrukerinnsynTilgangFilterType brukerinnsynTilgangFilterType
     ) {
+        BrukerinnsynTilganger brukerInnsynTilganger = authService.hentVeilederBrukerInnsynTilganger();
+
+        if (brukerInnsynTilganger.harAlle() && BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ == brukerinnsynTilgangFilterType) {
+            return new BrukereMedAntall(0, emptyList());
+        }
+
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
 
         int from = Optional.ofNullable(fra).orElse(0);
@@ -81,7 +88,7 @@ public class OpensearchService {
         searchSourceBuilder.query(boolQuery);
 
         if (FeatureToggle.brukFilterForBrukerinnsynTilganger(unleashService)) {
-            leggTilBrukerinnsynTilgangFilter(boolQuery, authService.hentVeilederBrukerInnsynTilganger(), brukerinnsynTilgangFilterType);
+            leggTilBrukerinnsynTilgangFilter(boolQuery, brukerInnsynTilganger, brukerinnsynTilgangFilterType);
         }
 
         sorterQueryParametere(sortOrder, sortField, searchSourceBuilder, filtervalg);
@@ -118,6 +125,12 @@ public class OpensearchService {
     }
 
     public Statustall hentStatustallForVeilederPortefolje(String veilederId, String enhetId, BrukerinnsynTilgangFilterType brukerinnsynTilgangFilterType) {
+        BrukerinnsynTilganger brukerInnsynTilganger = authService.hentVeilederBrukerInnsynTilganger();
+
+        if (brukerInnsynTilganger.harAlle() && BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ == brukerinnsynTilgangFilterType) {
+            return new Statustall();
+        }
+
         boolean vedtakstottePilotErPa = this.erVedtakstottePilotPa(EnhetId.of(enhetId));
 
         BoolQueryBuilder veilederOgEnhetQuery = boolQuery()
@@ -126,7 +139,7 @@ public class OpensearchService {
                 .must(termQuery("veileder_id", veilederId));
 
         if (FeatureToggle.brukFilterForBrukerinnsynTilganger(unleashService)) {
-            leggTilBrukerinnsynTilgangFilter(veilederOgEnhetQuery, authService.hentVeilederBrukerInnsynTilganger(), brukerinnsynTilgangFilterType);
+            leggTilBrukerinnsynTilgangFilter(veilederOgEnhetQuery, brukerInnsynTilganger, brukerinnsynTilgangFilterType);
         }
 
         SearchSourceBuilder request =
@@ -159,6 +172,12 @@ public class OpensearchService {
     }
 
     public Statustall hentStatusTallForEnhetPortefolje(String enhetId, BrukerinnsynTilgangFilterType brukerinnsynTilgangFilterType) {
+        BrukerinnsynTilganger brukerInnsynTilganger = authService.hentVeilederBrukerInnsynTilganger();
+
+        if (brukerInnsynTilganger.harAlle() && BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ == brukerinnsynTilgangFilterType) {
+            return new Statustall();
+        }
+
         List<String> veilederPaaEnhet = veilarbVeilederClient.hentVeilederePaaEnhet(EnhetId.of(enhetId));
 
         boolean vedtakstottePilotErPa = this.erVedtakstottePilotPa(EnhetId.of(enhetId));
@@ -168,7 +187,7 @@ public class OpensearchService {
                 .must(termQuery("enhet_id", enhetId));
 
         if (FeatureToggle.brukFilterForBrukerinnsynTilganger(unleashService)) {
-            leggTilBrukerinnsynTilgangFilter(enhetQuery, authService.hentVeilederBrukerInnsynTilganger(), brukerinnsynTilgangFilterType);
+            leggTilBrukerinnsynTilgangFilter(enhetQuery, brukerInnsynTilganger, brukerinnsynTilgangFilterType);
         }
 
         SearchSourceBuilder request =

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterOpensearchIntegrasjon.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterOpensearchIntegrasjon.java
@@ -11,7 +11,6 @@ import no.nav.pto.veilarbportefolje.domene.Moteplan;
 import no.nav.pto.veilarbportefolje.domene.StillingFraNAVFilter;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
-import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerEntity;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerRepositoryV3;
@@ -84,7 +83,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of(I_AKTIVITET)),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(1);
                 }
@@ -118,7 +117,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setNavnEllerFnrQuery(fodselsnummer.toString()).setFerdigfilterListe(new ArrayList<>()),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(1);
                     assertThat(responseBrukere.getBrukere().get(0).getNesteCvKanDelesStatus()).isEqualTo("JA");
@@ -169,7 +168,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg().setFerdigfilterListe(List.of(I_AKTIVITET)),
                     null,
-                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null);
 
             assertThat(responseBrukere.getAntall()).isEqualTo(2);
         });
@@ -183,7 +182,7 @@ public class AktiviteterOpensearchIntegrasjon extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg().setStillingFraNavFilter(List.of(StillingFraNAVFilter.CV_KAN_DELES_STATUS_JA)).setFerdigfilterListe(new ArrayList<>()),
                 null,
-                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null);
 
         System.out.println(JsonUtils.toJson( new Filtervalg().setStillingFraNavFilter(List.of(StillingFraNAVFilter.CV_KAN_DELES_STATUS_JA)).setFerdigfilterListe(new ArrayList<>())));
         assertThat(responseBrukere.getAntall()).isEqualTo(1);

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
@@ -15,7 +15,6 @@ import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
 import no.nav.pto.veilarbportefolje.domene.EnhetTiltak;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
-import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.postgres.AktivitetEntityDto;
 import no.nav.pto.veilarbportefolje.postgres.utils.TiltakaktivitetEntity;
@@ -201,7 +200,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(response1.getAntall()).isEqualTo(1);
 
@@ -212,7 +211,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(response2.getAntall()).isEqualTo(0);
                 }
@@ -309,7 +308,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(response1.getAntall()).isEqualTo(1);
 
@@ -320,7 +319,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(response2.getAntall()).isEqualTo(1);
                 }
@@ -362,7 +361,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(response1.getAntall()).isEqualTo(1);
                 }
@@ -459,7 +458,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(response1.getAntall()).isEqualTo(0);
 
@@ -470,7 +469,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(response2.getAntall()).isEqualTo(1);
                 }
@@ -816,7 +815,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     BrukereMedAntall responseBrukereLONNTILS = opensearchService.hentBrukere(
                             navKontor.getValue(),
@@ -825,7 +824,7 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                             "ikke_satt",
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(responseBrukereMIDLONTIL.getAntall()).isEqualTo(1);
                     assertThat(responseBrukereLONNTILS.getAntall()).isEqualTo(0);

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslistaSorteringOpensearch.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslistaSorteringOpensearch.java
@@ -7,7 +7,6 @@ import no.nav.pto.veilarbportefolje.domene.Brukerstatus;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
-import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.util.EndToEndTest;
@@ -80,7 +79,7 @@ public class ArbeidslistaSorteringOpensearch extends EndToEndTest {
                     "ikke_satt",
                     getArbeidslisteFilter(),
                     null,
-                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null);
 
             return brukereMedAntall.getAntall() == 3;
         });
@@ -92,7 +91,7 @@ public class ArbeidslistaSorteringOpensearch extends EndToEndTest {
                 "arbeidsliste_overskrift",
                 getArbeidslisteFilter(),
                 null,
-                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null);
 
         var sortertResponsDescending = opensearchService.hentBrukere(
                 enhetId.getValue(),
@@ -101,7 +100,7 @@ public class ArbeidslistaSorteringOpensearch extends EndToEndTest {
                 "arbeidsliste_overskrift",
                 getArbeidslisteFilter(),
                 null,
-                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null);
 
         assertThat(sortertResponsAscending.getBrukere().get(0).getArbeidsliste().getKategori())
                 .isEqualTo(arbeidsliste2_kategori);

--- a/src/test/java/no/nav/pto/veilarbportefolje/controller/EnhetControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/controller/EnhetControllerTest.java
@@ -59,40 +59,40 @@ public class EnhetControllerTest {
     public void skal_hent_portefolje_fra_indeks_dersom_tilgang() {
         when(poaoTilgangWrapper.harVeilederTilgangTilModia()).thenReturn(Decision.Permit.INSTANCE);
         when(pep.harVeilederTilgangTilEnhet(any(NavIdent.class), any(EnhetId.class))).thenReturn(true);
-        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
+        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
 
         authContextHolder.withContext(
                 new AuthContext(UserRole.INTERN, TestDataUtils.generateJWT("A111111")),
                 () -> enhetController.hentPortefoljeForEnhet("0001", 0, 0, "ikke_satt", "ikke_satt", new Filtervalg())
         );
-        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), any(), any(), any());
+        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
     public void skal_hente_hele_portefolje_fra_indeks_dersom_man_mangle_antall() {
         when(pep.harVeilederTilgangTilEnhet(any(), any())).thenReturn(true);
         when(poaoTilgangWrapper.harVeilederTilgangTilModia()).thenReturn(Decision.Permit.INSTANCE);
-        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
+        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
 
         authContextHolder.withContext(
                 new AuthContext(UserRole.INTERN, TestDataUtils.generateJWT("A111111")),
                 () -> enhetController.hentPortefoljeForEnhet("0001", 0, null, "ikke_satt", "ikke_satt", new Filtervalg())
         );
-        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), any(), any(), any());
+        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
     public void skal_hente_hele_portefolje_fra_indeks_dersom_man_mangle_fra() {
         when(pep.harVeilederTilgangTilEnhet(any(), any())).thenReturn(true);
         when(poaoTilgangWrapper.harVeilederTilgangTilModia()).thenReturn(Decision.Permit.INSTANCE);
-        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
+        when(opensearchService.hentBrukere(any(), any(), any(), any(), any(), any(), any())).thenReturn(new BrukereMedAntall(0, Collections.emptyList()));
         authContextHolder
                 .withContext(
                         new AuthContext(UserRole.INTERN, TestDataUtils.generateJWT("A111111")),
                         () -> enhetController.hentPortefoljeForEnhet("0001", null, 20, "ikke_satt", "ikke_satt", new Filtervalg())
                 );
 
-        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), isNull(), any(), any());
+        verify(opensearchService, times(1)).hentBrukere(any(), any(), any(), any(), any(), isNull(), any());
     }
 
     @Test(expected = ResponseStatusException.class)

--- a/src/test/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereServiceTest.java
@@ -11,7 +11,6 @@ import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.ensligforsorger.dto.input.*;
 import no.nav.pto.veilarbportefolje.ensligforsorger.dto.output.EnsligeForsorgerOvergangsstønadTiltakDto;
-import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OppfolgingsBruker;
 import no.nav.pto.veilarbportefolje.util.EndToEndTest;
@@ -81,7 +80,7 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                             "ikke_satt",
                             filtervalg,
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(1);
                     assertThat(responseBrukere.getBrukere().get(0).getEnsligeForsorgereOvergangsstonad().vedtaksPeriodetype()).isEqualTo("Ny periode for nytt barn");
@@ -121,7 +120,7 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                             "ikke_satt",
                             filtervalg,
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(responseBrukere.getAntall()).isEqualTo(0);
                 }
@@ -181,8 +180,8 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         Assertions.assertThat(response.getAntall()).isEqualTo(2);
         Assertions.assertThat(response.getBrukere().get(0).getFnr().equals(bruker2.getFnr()));

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -318,8 +318,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg(),
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(brukereMedAntall.getAntall()).isEqualTo(2);
     }
@@ -356,8 +356,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filtervalg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
 
         assertThat(response.getAntall()).isEqualTo(2);
@@ -408,7 +408,7 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
 
         pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == brukere.size());
 
-        var response = opensearchService.hentBrukere(TEST_ENHET, empty(), "asc", "ikke_satt", filtervalg, null, null, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        var response = opensearchService.hentBrukere(TEST_ENHET, empty(), "asc", "ikke_satt", filtervalg, null, null);
 
         assertThat(response.getAntall()).isEqualTo(2);
     }
@@ -447,7 +447,7 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
         pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == brukere.size());
 
         var filtervalg = new Filtervalg().setFerdigfilterListe(List.of(UFORDELTE_BRUKERE));
-        var response = opensearchService.hentBrukere(TEST_ENHET, empty(), "asc", "ikke_satt", filtervalg, null, null, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        var response = opensearchService.hentBrukere(TEST_ENHET, empty(), "asc", "ikke_satt", filtervalg, null, null);
         assertThat(response.getAntall()).isEqualTo(2);
     }
 
@@ -826,8 +826,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "arbeidslistekategori",
                 new Filtervalg(),
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         List<Bruker> brukere = brukereMedAntall.getBrukere();
 
@@ -886,8 +886,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "valgteaktiviteter",
                 filtervalg1,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
         BrukereMedAntall brukereMedAntall2 = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.empty(),
@@ -895,8 +895,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "valgteaktiviteter",
                 filtervalg2,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         List<Bruker> brukere1 = brukereMedAntall.getBrukere();
         List<Bruker> brukere2 = brukereMedAntall2.getBrukere();
@@ -943,8 +943,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg().setFerdigfilterListe(List.of(TRENGER_VURDERING)),
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ).getAntall() == liste.size());
+                null
+        ).getAntall() == liste.size());
 
         List<Brukerstatus> ferdigFiltere = List.of(
                 UFORDELTE_BRUKERE,
@@ -958,8 +958,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg().setFerdigfilterListe(ferdigFiltere),
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(userExistsInResponse(nyForEnhet, response)).isTrue();
@@ -992,8 +992,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg(),
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ).getAntall() == 1);
+                null
+        ).getAntall() == 1);
 
 
         var response = opensearchService.hentBrukere(
@@ -1003,8 +1003,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg(),
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(userExistsInResponse(brukerVeilederHarTilgangTil, response)).isTrue();
@@ -1042,8 +1042,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 new Filtervalg().setFerdigfilterListe(List.of(UFORDELTE_BRUKERE)),
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(veilederExistsInResponse(LITE_PRIVILEGERT_VEILEDER, response)).isTrue();
@@ -1087,9 +1087,9 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
+                null
 
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        );
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().anyMatch(it -> it.getFodselsdagIMnd() == 7)).isTrue();
@@ -1129,8 +1129,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().anyMatch(bruker -> "K".equals(bruker.getKjonn()))).isTrue();
@@ -1171,8 +1171,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(userExistsInResponse(brukerMedAAP, response)).isTrue();
@@ -1236,8 +1236,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(userExistsInResponse(brukerMedDagpengerMedPermittering, response)).isTrue();
@@ -1287,8 +1287,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(userExistsInResponse(brukerMedSokeAvtale, response)).isTrue();
@@ -1336,8 +1336,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(userExistsInResponse(brukerMedBehandling, response)).isTrue();
@@ -1387,8 +1387,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(userExistsInResponse(brukerMedTiltak, response)).isTrue();
@@ -1439,8 +1439,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(userExistsInResponse(brukerMedBehandling, response)).isTrue();
@@ -1514,8 +1514,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "utkast_14a_ansvarlig_veileder",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(4);
         assertThat(userExistsInResponse(brukerMedVedtak, response)).isTrue();
@@ -1589,8 +1589,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(response.getBrukere().stream().filter(x -> x.getTalespraaktolk().equals("JPN")).anyMatch(x -> x.getTolkBehovSistOppdatert().equals("2022-02-22")));
@@ -1608,8 +1608,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().filter(x -> x.getTalespraaktolk().equals("SWE")).anyMatch(x -> x.getTolkBehovSistOppdatert().equals("2021-03-23")));
 
@@ -1624,8 +1624,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(response.getBrukere().stream().filter(x -> x.getTalespraaktolk().equals("JPN")).anyMatch(x -> x.getTolkBehovSistOppdatert().equals("2022-02-22")));
@@ -1644,8 +1644,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().filter(x -> x.getTalespraaktolk().equals("JPN")).anyMatch(x -> x.getTolkBehovSistOppdatert().equals("2022-02-22")));
 
@@ -1661,8 +1661,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().filter(x -> x.getTalespraaktolk().equals("JPN")).anyMatch(x -> x.getTolkBehovSistOppdatert().equals("2022-02-22")));
     }
@@ -1745,8 +1745,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(response.getBrukere().stream().filter(x -> x.getFoedeland().equals("Aserbajdsjan")).findFirst().isPresent());
@@ -1764,8 +1764,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().filter(x -> x.getFoedeland().equals("Norge")).findFirst().isPresent());
 
@@ -1781,8 +1781,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().noneMatch(x -> x.getFoedeland() != null));
 
@@ -1797,8 +1797,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
         assertThat(response.getAntall()).isEqualTo(3);
         assertThat(response.getBrukere().stream().filter(x -> x.getFoedeland() != null).anyMatch(x -> x.getFoedeland().equals("SGP")));
         assertThat(response.getBrukere().stream().filter(x -> x.getFoedeland() != null).anyMatch(x -> x.getFoedeland().equals("AZE")));
@@ -1889,8 +1889,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "fodeland",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(6);
         assertThat(response.getBrukere().get(0).getFoedeland().equals("Aserbajdsjan"));
@@ -1907,8 +1907,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "fodeland",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(6);
         assertThat(response.getBrukere().get(0).getFoedeland().equals("Singapore"));
@@ -1925,8 +1925,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "statsborgerskap",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(6);
         assertThat(response.getBrukere().get(0).getHovedStatsborgerskap().getStatsborgerskap().equals("Estland"));
@@ -2000,8 +2000,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(2);
         assertThat(response.getBrukere().stream().allMatch(x -> x.getBostedKommune().equals("10")));
@@ -2018,8 +2018,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(response.getBrukere().stream().allMatch(x -> x.getBostedBydel().equals("1233")));
 
@@ -2035,8 +2035,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
         assertThat(response.getAntall()).isEqualTo(3);
         assertThat(response.getBrukere().stream().filter(x -> x.getBostedKommune().equalsIgnoreCase("10")).count()).isEqualTo(2);
         assertThat(response.getBrukere().stream().anyMatch(x -> x.getBostedBydel().equalsIgnoreCase("1233")));
@@ -2108,8 +2108,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "kommunenummer",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getBostedKommune().equals("10"));
@@ -2125,8 +2125,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "bydelsnummer",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getBostedBydel().equals("1010"));
@@ -2191,8 +2191,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getBrukere())
                 .hasSize(2)
@@ -2254,8 +2254,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getBrukere())
                 .hasSize(5)
@@ -2315,8 +2315,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getBrukere()).hasSize(5);
     }
@@ -2364,8 +2364,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "etternavn",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getBrukere()).hasSize(3);
         assertThat(response.getBrukere().get(0).getEtternavn()).isEqualTo("C");
@@ -2412,8 +2412,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "etternavn",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getBrukere()).hasSize(3);
         assertThat(response.getBrukere().get(0).getEtternavn()).isEqualTo("C");
@@ -2482,8 +2482,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "enslige_forsorgere_utlop_ytelse",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getFnr().equals(bruker3.getFnr()));
@@ -2498,8 +2498,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "enslige_forsorgere_om_barnet",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getFnr().equals(bruker3.getFnr()));
@@ -2514,8 +2514,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "enslige_forsorgere_aktivitetsplikt",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getFnr().equals(bruker1.getFnr()));
@@ -2530,8 +2530,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                 "enslige_forsorgere_vedtaksperiodetype",
                 filterValg,
                 null,
-                null,
-                ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null
+        );
 
         assertThat(response.getAntall()).isEqualTo(5);
         assertThat(response.getBrukere().get(0).getFnr().equals(bruker2.getFnr()));
@@ -2572,8 +2572,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                         "ikke_satt",
                         new Filtervalg(),
                         null,
-                        null,
-                        ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ)
+                        null
+                )
         );
     }
 
@@ -2587,8 +2587,8 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
                         "ikke_satt",
                         new Filtervalg(),
                         null,
-                        null,
-                        ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ)
+                        null
+                )
         );
     }
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -36,7 +36,7 @@ import static java.util.Optional.empty;
 import static java.util.stream.Collectors.toList;
 import static no.nav.pto.veilarbportefolje.domene.AktivitetFiltervalg.JA;
 import static no.nav.pto.veilarbportefolje.domene.Brukerstatus.*;
-import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
+import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ;
 import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ;
 import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.byggArbeidslisteQuery;
 import static no.nav.pto.veilarbportefolje.util.DateUtils.toIsoUTC;
@@ -567,7 +567,7 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
 
         pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == liste.size());
 
-        var statustall = opensearchService.hentStatusTallForVeileder(TEST_VEILEDER_0, TEST_ENHET, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        var statustall = opensearchService.hentStatusTallForVeileder(TEST_VEILEDER_0, TEST_ENHET);
         assertThat(statustall.erSykmeldtMedArbeidsgiver).isEqualTo(0);
         assertThat(statustall.iavtaltAktivitet).isEqualTo(1);
         assertThat(statustall.ikkeIavtaltAktivitet).isEqualTo(2);
@@ -690,7 +690,7 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
 
         pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == brukere.size());
 
-        Statustall respons = opensearchService.hentStatusTallForEnhetPortefolje(TEST_ENHET, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        Statustall respons = opensearchService.hentStatusTallForEnhetPortefolje(TEST_ENHET, BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
 
         assertThat(respons.getTotalt()).isEqualTo(3);
         assertThat(respons.getVenterPaSvarFraNAV()).isEqualTo(1);
@@ -756,7 +756,7 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
 
         Statustall responsMedBrukerinnsyn = authContextHolder.withContext(
                 new AuthContext(UserRole.INTERN, generateJWT(TEST_VEILEDER_0)),
-                () -> opensearchService.hentStatusTallForEnhetPortefolje(TEST_ENHET, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ)
+                () -> opensearchService.hentStatusTallForEnhetPortefolje(TEST_ENHET, BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ)
         );
 
         assertThat(responsMedBrukerinnsyn.getTotalt()).isEqualTo(15);
@@ -790,7 +790,7 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
 
         when(veilarbVeilederClientMock.hentVeilederePaaEnhet(any())).thenReturn(List.of(TEST_VEILEDER_0));
 
-        var statustall = opensearchService.hentStatusTallForEnhet(TEST_ENHET, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        var statustall = opensearchService.hentStatusTallForEnhet(TEST_ENHET);
         assertThat(statustall.getUfordelteBrukere()).isEqualTo(1);
     }
 
@@ -1048,7 +1048,7 @@ class OpensearchServiceIntegrationTest extends EndToEndTest {
         assertThat(response.getAntall()).isEqualTo(1);
         assertThat(veilederExistsInResponse(LITE_PRIVILEGERT_VEILEDER, response)).isTrue();
 
-        Statustall statustall = opensearchService.hentStatusTallForEnhet(TEST_ENHET, ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+        Statustall statustall = opensearchService.hentStatusTallForEnhet(TEST_ENHET);
         assertThat(statustall.getUfordelteBrukere()).isEqualTo(1);
     }
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/registrering/RegistreringServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/registrering/RegistreringServiceTest.java
@@ -9,7 +9,6 @@ import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
-import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OppfolgingsBruker;
@@ -84,7 +83,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgBestatt(),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(responseBrukere2.getAntall()).isEqualTo(1);
                 }
@@ -98,7 +97,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgGodkjent(),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(responseBrukere3.getAntall()).isEqualTo(2);
                 }
@@ -112,7 +111,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgUtdanning(),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(responseBrukere4.getAntall()).isEqualTo(2);
                 }
@@ -126,7 +125,7 @@ class RegistreringServiceTest extends EndToEndTest {
                             "ikke_satt",
                             getFiltervalgMix(),
                             null,
-                            null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                            null);
 
                     assertThat(responseBrukere5.getAntall()).isEqualTo(1);
                 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/sisteendring/SisteEndringIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/sisteendring/SisteEndringIntegrationTest.java
@@ -12,7 +12,6 @@ import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.mal.MalEndringKafkaDTO;
 import no.nav.pto.veilarbportefolje.mal.MalService;
-import no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerRepositoryV3;
@@ -166,7 +165,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
-                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null);
             return brukereMedAntall.getAntall() == 1;
         });
         verifiserAsynkront(2, TimeUnit.SECONDS, () -> {
@@ -178,7 +177,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
-                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null);
 
             assertThat(responseBrukere.getAntall()).isEqualTo(1);
             assertThat(responseBrukere.getBrukere().get(0).getSisteEndringTidspunkt()).isEqualTo(zonedDateTime.toLocalDateTime());
@@ -199,7 +198,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg(),
                     null,
-                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null);
 
             return brukereMedAntall.getAntall() == 1;
         });
@@ -211,7 +210,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 getFiltervalg(FULLFORT_IJOBB, true),
                 null,
-                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null);
 
         assertThat(responseBrukere.getAntall()).isEqualTo(0);
     }
@@ -234,7 +233,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg(),
                     null,
-                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null);
 
             return brukereMedAntall.getAntall() == 1;
         });
@@ -256,7 +255,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(NY_IJOBB),
                     null,
-                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null);
             return brukereMedAntall.getAntall() == 1;
         });
 
@@ -270,7 +269,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB, true),
                     null,
-                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null);
             return brukereMedAntall.getAntall() == 0;
         });
 
@@ -281,7 +280,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 getFiltervalg(NY_IJOBB, true),
                 null,
-                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null);
 
         assertThat(responseBrukere1.getAntall()).isEqualTo(1);
 
@@ -292,7 +291,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "ikke_satt",
                 getFiltervalg(FULLFORT_IJOBB, true),
                 null,
-                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null);
 
         assertThat(responseBrukere2.getAntall()).isEqualTo(0);
     }
@@ -322,7 +321,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     new Filtervalg(),
                     null,
-                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null);
 
             return brukereMedAntall.getAntall() == 3;
         });
@@ -355,7 +354,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
-                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null);
 
             return brukereMedAntall.getAntall() == 2;
         });
@@ -368,7 +367,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                     "ikke_satt",
                     getFiltervalg(FULLFORT_EGEN),
                     null,
-                    null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                    null);
 
             return brukereMedAntall.getAntall() == 3;
         });
@@ -380,7 +379,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "siste_endring_tidspunkt",
                 getFiltervalg(FULLFORT_IJOBB),
                 null,
-                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null);
 
         assertThat(responseSortertFULLFORT_IJOBB.getAntall()).isEqualTo(2);
         assertThat(responseSortertFULLFORT_IJOBB.getBrukere().get(0).getSisteEndringTidspunkt().getYear()).isEqualTo(endret_Tid_IJOBB_bruker_2_i_2025.getYear());
@@ -393,7 +392,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "siste_endring_tidspunkt",
                 getFiltervalg(FULLFORT_EGEN),
                 null,
-                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null);
 
         assertThat(responseSortertFULLFORT_EGEN.getAntall()).isEqualTo(3);
         assertThat(responseSortertFULLFORT_EGEN.getBrukere().get(0).getSisteEndringTidspunkt().getYear()).isEqualTo(endret_Tid_EGEN_bruker_3_i_2019.getYear());
@@ -407,7 +406,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 "siste_endring_tidspunkt",
                 getFiltervalg(NY_IJOBB),
                 null,
-                null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
+                null);
         assertThat(responseSortertTomRes1.getAntall()).isEqualTo(0);
     }
 
@@ -421,7 +420,7 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                         "siste_endring_tidspunkt",
                         getFiltervalg(FULLFORT_IJOBB, FULLFORT_EGEN),
                         null,
-                        null, BrukerinnsynTilgangFilterType.ALLE_BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ));
+                        null));
         assertThat(exception).isNotNull();
     }
 


### PR DESCRIPTION
## Describe your changes

Dersom vi bruker filtertypen `BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ` men veileder samtidig har _alle_ brukerinnsyntilganger, så returnerer vi heller default (dvs. en liste med 0 brukere  / respons der alle statustallene er 0).

## Trello ticket number and link

[TC-270](https://trello.com/c/eegtUQrl/270-fjerne-mulighet-for-%C3%A5-kunne-identifisere-navn-og-stedslokaliserende-informasjon-for-egen-ansatt-og-kode-6-og-7)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
