### PR TITLE
Legg til mulighet for å hente statistikk vedr. avvik § 14 a-vedtak

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/admin/AdminController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/admin/AdminController.java
@@ -10,9 +10,11 @@ import no.nav.common.utils.EnvironmentUtils;
 import no.nav.pto.veilarbportefolje.arenapakafka.ytelser.YtelsesService;
 import no.nav.pto.veilarbportefolje.auth.DownstreamApi;
 import no.nav.pto.veilarbportefolje.domene.AktorClient;
+import no.nav.pto.veilarbportefolje.domene.Avvik14aStatistikk;
 import no.nav.pto.veilarbportefolje.opensearch.HovedIndekserer;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchAdminService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
+import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
 import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingAvsluttetService;
 import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingRepositoryV2;
 import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingService;
@@ -45,6 +47,7 @@ public class AdminController {
     private final OppfolgingRepositoryV2 oppfolgingRepositoryV2;
     private final OpensearchAdminService opensearchAdminService;
     private final PdlService pdlService;
+    private final OpensearchService opensearchService;
 
     @DeleteMapping("/oppfolgingsbruker")
     public String slettOppfolgingsbruker(@RequestBody String aktoerId) {
@@ -189,6 +192,12 @@ public class AdminController {
         List<AktorId> brukereUnderOppfolging = oppfolgingRepositoryV2.hentAlleGyldigeBrukereUnderOppfolging();
         opensearchIndexer.dryrunAvPostgresTilOpensearchMapping(brukereUnderOppfolging);
         log.info("ferdig med dryrun");
+    }
+
+    @GetMapping("/opensearch/hentAvvik14aStatistikk")
+    public Avvik14aStatistikk hentAvvik14aStatistikk() {
+        sjekkTilgangTilAdmin();
+        return opensearchService.hentAvvik14aStatistikk();
     }
 
     private void sjekkTilgangTilAdmin() {

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Avvik14aStatistikk.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Avvik14aStatistikk.java
@@ -1,0 +1,20 @@
+package no.nav.pto.veilarbportefolje.domene;
+
+import no.nav.pto.veilarbportefolje.opensearch.domene.Avvik14aStatistikkResponse.Avvik14aStatistikkAggregation.Avvik14aStatistikkFilter.Avvik14aStatistikkBuckets;
+
+public record Avvik14aStatistikk(
+        Long antallMedInnsatsgruppeUlik,
+        Long antallMedHovedmaalUlik,
+        Long antallMedInnsatsgruppeOgHovedmaalUlik,
+        Long antallMedInnsatsgruppeManglerINyKilde
+) {
+
+    public static Avvik14aStatistikk of(Avvik14aStatistikkBuckets avvik14aStatistikkBuckets) {
+        return new Avvik14aStatistikk(
+                avvik14aStatistikkBuckets.getInnsatsgruppeUlik().getDoc_count(),
+                avvik14aStatistikkBuckets.getHovedmaalUlik().getDoc_count(),
+                avvik14aStatistikkBuckets.getInnsatsgruppeOgHovedmaalUlik().getDoc_count(),
+                avvik14aStatistikkBuckets.getInnsatsgruppeManglerINyKilde().getDoc_count()
+        );
+    }
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import no.nav.common.json.JsonUtils;
 import no.nav.common.types.identer.EnhetId;
+import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
 import no.nav.pto.veilarbportefolje.auth.AuthService;
 import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.client.VeilarbVeilederClient;
@@ -12,6 +13,8 @@ import no.nav.pto.veilarbportefolje.domene.*;
 import no.nav.pto.veilarbportefolje.opensearch.domene.*;
 import no.nav.pto.veilarbportefolje.opensearch.domene.StatustallResponse.StatustallAggregation.StatustallFilter.StatustallBuckets;
 import no.nav.pto.veilarbportefolje.service.UnleashService;
+import no.nav.pto.veilarbportefolje.opensearch.domene.Avvik14aStatistikkResponse.Avvik14aStatistikkAggregation.Avvik14aStatistikkFilter.Avvik14aStatistikkBuckets;
+import no.nav.pto.veilarbportefolje.siste14aVedtak.Avvik14aVedtak;
 import no.nav.pto.veilarbportefolje.vedtakstotte.VedtaksstotteClient;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.action.search.SearchRequest;
@@ -19,10 +22,12 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.search.aggregations.bucket.filter.FiltersAggregator;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.emptyList;
@@ -31,6 +36,7 @@ import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterT
 import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ;
 import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.*;
 import static org.opensearch.index.query.QueryBuilders.*;
+import static org.opensearch.search.aggregations.AggregationBuilders.filters;
 
 @Service
 @RequiredArgsConstructor
@@ -152,6 +158,39 @@ public class OpensearchService {
         PortefoljestorrelserResponse response = search(request, indexName.getValue(), PortefoljestorrelserResponse.class);
         List<Bucket> buckets = response.getAggregations().getFilter().getSterms().getBuckets();
         return new FacetResults(buckets);
+    }
+
+    public Avvik14aStatistikk hentAvvik14aStatistikk() {
+        FiltersAggregator.KeyedFilter[] filtre = new FiltersAggregator.KeyedFilter[]{
+                new FiltersAggregator.KeyedFilter(
+                        "innsatsgruppeUlik",
+                        boolQuery()
+                                .must(matchQuery("avvik14aVedtak", Avvik14aVedtak.INNSATSGRUPPE_ULIK))
+                ),
+                new FiltersAggregator.KeyedFilter(
+                        "hovedmaalUlik",
+                        boolQuery()
+                                .must(matchQuery("avvik14aVedtak", Avvik14aVedtak.HOVEDMAAL_ULIK))
+                ),
+                new FiltersAggregator.KeyedFilter(
+                        "innsatsgruppeOgHovedmaalUlik",
+                        boolQuery()
+                                .must(matchQuery("avvik14aVedtak", Avvik14aVedtak.INNSATSGRUPPE_OG_HOVEDMAAL_ULIK))
+                ),
+                new FiltersAggregator.KeyedFilter(
+                        "innsatsgruppeManglerINyKilde",
+                        boolQuery()
+                                .must(matchQuery("avvik14aVedtak", Avvik14aVedtak.INNSATSGRUPPE_MANGLER_I_NY_KILDE))
+                )
+        };
+
+        SearchSourceBuilder request = new SearchSourceBuilder()
+                .size(0)
+                .aggregation(filters("avvik14astatistikk", filtre));
+
+        Avvik14aStatistikkResponse response = search(request, indexName.getValue(), Avvik14aStatistikkResponse.class);
+        Avvik14aStatistikkBuckets buckets = response.getAggregations().getFilters().getBuckets();
+        return Avvik14aStatistikk.of(buckets);
     }
 
     @SneakyThrows

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/Avvik14aStatistikkResponse.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/Avvik14aStatistikkResponse.java
@@ -1,0 +1,29 @@
+package no.nav.pto.veilarbportefolje.opensearch.domene;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class Avvik14aStatistikkResponse {
+    Hits hits;
+    Avvik14aStatistikkAggregation aggregations;
+
+    @Data
+    public static class Avvik14aStatistikkAggregation {
+        @JsonProperty("filters#avvik14astatistikk")
+        Avvik14aStatistikkFilter filters;
+
+        @Data
+        public static class Avvik14aStatistikkFilter {
+            Avvik14aStatistikkBuckets buckets;
+
+            @Data
+            public static class Avvik14aStatistikkBuckets {
+                Bucket innsatsgruppeUlik;
+                Bucket hovedmaalUlik;
+                Bucket innsatsgruppeOgHovedmaalUlik;
+                Bucket innsatsgruppeManglerINyKilde;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Describe your changes

Legger til et admin-endepunkt som vi kan bruke for å hente ut statistikk for avvik på § 14 a-vedtak, i stedet for å måtte gjøre manuelt uttrekk fra DB hver gang.

Planen er å bruke dette nye endepunktet i pto-admin; har en PR på pto-admin [her](https://github.com/navikt/pto-admin/pull/53).

## Trello ticket number and link

TC-358

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
