### PR TITLE
TC-358 Legg til metrikker for statistikk vedr. avvik § 14 a

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/config/SchedulConfig.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/config/SchedulConfig.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.pto.veilarbportefolje.aktiviteter.AktivitetService;
 import no.nav.pto.veilarbportefolje.arenapakafka.ytelser.YtelsesService;
 import no.nav.pto.veilarbportefolje.opensearch.HovedIndekserer;
+import no.nav.pto.veilarbportefolje.siste14aVedtak.Avvik14aStatistikkMetrikk;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,8 +18,10 @@ import javax.sql.DataSource;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 
+import static com.github.kagkarlsson.scheduler.task.schedule.Schedules.fixedDelay;
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 
@@ -31,15 +34,20 @@ public class SchedulConfig {
     private final Scheduler scheduler;
 
     @Autowired
-    public SchedulConfig(DataSource dataSource,
-                         HovedIndekserer hovedIndekserer,
-                         AktivitetService aktivitetService,
-                         YtelsesService ytelsesService) {
+    public SchedulConfig(
+            DataSource dataSource,
+            HovedIndekserer hovedIndekserer,
+            AktivitetService aktivitetService,
+            YtelsesService ytelsesService,
+            Avvik14aStatistikkMetrikk avvik14aStatistikkMetrikk
+    ) {
         this.hovedIndekserer = hovedIndekserer;
         this.aktivitetService = aktivitetService;
         this.ytelsesService = ytelsesService;
 
-        List<RecurringTask<?>> jobber = nattligeJobber();
+        List<RecurringTask<?>> jobber = new ArrayList<>();
+        jobber.addAll(nattligeJobber());
+        jobber.add(oppdaterAvvik14aStatistikkMetrikkerJobb(avvik14aStatistikkMetrikk));
         scheduler = Scheduler
                 .create(dataSource)
                 .deleteUnresolvedAfter(Duration.of(1, HOURS))
@@ -63,6 +71,15 @@ public class SchedulConfig {
                         }))
                         .execute((instance, ctx) -> hovedIndekserer.hovedIndeksering())
         );
+    }
+
+    private RecurringTask<Void> oppdaterAvvik14aStatistikkMetrikkerJobb(Avvik14aStatistikkMetrikk avvik14aStatistikkMetrikk) {
+        return Tasks
+                .recurring("oppdater_avvik14astatistikk_metrikker", fixedDelay(Duration.ofHours(1)))
+                .execute((instance, ctx) -> {
+                    log.info("Utfører schedulert jobb oppdater_avvik14astatistikk_metrikker");
+                    avvik14aStatistikkMetrikk.oppdaterMetrikk();
+                });
     }
 
     @PostConstruct

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Avvik14aStatistikk.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Avvik14aStatistikk.java
@@ -1,0 +1,20 @@
+package no.nav.pto.veilarbportefolje.domene;
+
+import no.nav.pto.veilarbportefolje.opensearch.domene.Avvik14aStatistikkResponse.Avvik14aStatistikkAggregation.Avvik14aStatistikkFilter.Avvik14aStatistikkBuckets;
+
+public record Avvik14aStatistikk(
+        Long antallMedInnsatsgruppeUlik,
+        Long antallMedHovedmaalUlik,
+        Long antallMedInnsatsgruppeOgHovedmaalUlik,
+        Long antallMedInnsatsgruppeManglerINyKilde
+) {
+
+    public static Avvik14aStatistikk of(Avvik14aStatistikkBuckets avvik14aStatistikkBuckets) {
+        return new Avvik14aStatistikk(
+                avvik14aStatistikkBuckets.getInnsatsgruppeUlik().getDoc_count(),
+                avvik14aStatistikkBuckets.getHovedmaalUlik().getDoc_count(),
+                avvik14aStatistikkBuckets.getInnsatsgruppeOgHovedmaalUlik().getDoc_count(),
+                avvik14aStatistikkBuckets.getInnsatsgruppeManglerINyKilde().getDoc_count()
+        );
+    }
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import no.nav.common.json.JsonUtils;
 import no.nav.common.types.identer.EnhetId;
+import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
 import no.nav.pto.veilarbportefolje.auth.AuthService;
 import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.client.VeilarbVeilederClient;
@@ -12,6 +13,8 @@ import no.nav.pto.veilarbportefolje.domene.*;
 import no.nav.pto.veilarbportefolje.opensearch.domene.*;
 import no.nav.pto.veilarbportefolje.opensearch.domene.StatustallResponse.StatustallAggregation.StatustallFilter.StatustallBuckets;
 import no.nav.pto.veilarbportefolje.service.UnleashService;
+import no.nav.pto.veilarbportefolje.opensearch.domene.Avvik14aStatistikkResponse.Avvik14aStatistikkAggregation.Avvik14aStatistikkFilter.Avvik14aStatistikkBuckets;
+import no.nav.pto.veilarbportefolje.siste14aVedtak.Avvik14aVedtak;
 import no.nav.pto.veilarbportefolje.vedtakstotte.VedtaksstotteClient;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.action.search.SearchRequest;
@@ -19,10 +22,12 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.search.aggregations.bucket.filter.FiltersAggregator;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.emptyList;
@@ -31,6 +36,7 @@ import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterT
 import static no.nav.pto.veilarbportefolje.opensearch.BrukerinnsynTilgangFilterType.BRUKERE_SOM_VEILEDER_IKKE_HAR_INNSYNSRETT_PÅ;
 import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.*;
 import static org.opensearch.index.query.QueryBuilders.*;
+import static org.opensearch.search.aggregations.AggregationBuilders.filters;
 
 @Service
 @RequiredArgsConstructor
@@ -152,6 +158,39 @@ public class OpensearchService {
         PortefoljestorrelserResponse response = search(request, indexName.getValue(), PortefoljestorrelserResponse.class);
         List<Bucket> buckets = response.getAggregations().getFilter().getSterms().getBuckets();
         return new FacetResults(buckets);
+    }
+
+    public Avvik14aStatistikk hentAvvik14aStatistikk() {
+        FiltersAggregator.KeyedFilter[] filtre = new FiltersAggregator.KeyedFilter[]{
+                new FiltersAggregator.KeyedFilter(
+                        "innsatsgruppeUlik",
+                        boolQuery()
+                                .must(matchQuery("avvik14aVedtak", Avvik14aVedtak.INNSATSGRUPPE_ULIK))
+                ),
+                new FiltersAggregator.KeyedFilter(
+                        "hovedmaalUlik",
+                        boolQuery()
+                                .must(matchQuery("avvik14aVedtak", Avvik14aVedtak.HOVEDMAAL_ULIK))
+                ),
+                new FiltersAggregator.KeyedFilter(
+                        "innsatsgruppeOgHovedmaalUlik",
+                        boolQuery()
+                                .must(matchQuery("avvik14aVedtak", Avvik14aVedtak.INNSATSGRUPPE_OG_HOVEDMAAL_ULIK))
+                ),
+                new FiltersAggregator.KeyedFilter(
+                        "innsatsgruppeManglerINyKilde",
+                        boolQuery()
+                                .must(matchQuery("avvik14aVedtak", Avvik14aVedtak.INNSATSGRUPPE_MANGLER_I_NY_KILDE))
+                )
+        };
+
+        SearchSourceBuilder request = new SearchSourceBuilder()
+                .size(0)
+                .aggregation(filters("avvik14astatistikk", filtre));
+
+        Avvik14aStatistikkResponse response = search(request, indexName.getValue(), Avvik14aStatistikkResponse.class);
+        Avvik14aStatistikkBuckets buckets = response.getAggregations().getFilters().getBuckets();
+        return Avvik14aStatistikk.of(buckets);
     }
 
     @SneakyThrows

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
@@ -4,16 +4,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import no.nav.common.json.JsonUtils;
 import no.nav.common.types.identer.EnhetId;
-import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
 import no.nav.pto.veilarbportefolje.auth.AuthService;
 import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.client.VeilarbVeilederClient;
 import no.nav.pto.veilarbportefolje.config.FeatureToggle;
 import no.nav.pto.veilarbportefolje.domene.*;
 import no.nav.pto.veilarbportefolje.opensearch.domene.*;
+import no.nav.pto.veilarbportefolje.opensearch.domene.Avvik14aStatistikkResponse.Avvik14aStatistikkAggregation.Avvik14aStatistikkFilter.Avvik14aStatistikkBuckets;
 import no.nav.pto.veilarbportefolje.opensearch.domene.StatustallResponse.StatustallAggregation.StatustallFilter.StatustallBuckets;
 import no.nav.pto.veilarbportefolje.service.UnleashService;
-import no.nav.pto.veilarbportefolje.opensearch.domene.Avvik14aStatistikkResponse.Avvik14aStatistikkAggregation.Avvik14aStatistikkFilter.Avvik14aStatistikkBuckets;
 import no.nav.pto.veilarbportefolje.siste14aVedtak.Avvik14aVedtak;
 import no.nav.pto.veilarbportefolje.vedtakstotte.VedtaksstotteClient;
 import org.apache.commons.lang3.StringUtils;
@@ -27,7 +26,6 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.emptyList;

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/Avvik14aStatistikkResponse.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/Avvik14aStatistikkResponse.java
@@ -1,0 +1,29 @@
+package no.nav.pto.veilarbportefolje.opensearch.domene;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class Avvik14aStatistikkResponse {
+    Hits hits;
+    Avvik14aStatistikkAggregation aggregations;
+
+    @Data
+    public static class Avvik14aStatistikkAggregation {
+        @JsonProperty("filters#avvik14astatistikk")
+        Avvik14aStatistikkFilter filters;
+
+        @Data
+        public static class Avvik14aStatistikkFilter {
+            Avvik14aStatistikkBuckets buckets;
+
+            @Data
+            public static class Avvik14aStatistikkBuckets {
+                Bucket innsatsgruppeUlik;
+                Bucket hovedmaalUlik;
+                Bucket innsatsgruppeOgHovedmaalUlik;
+                Bucket innsatsgruppeManglerINyKilde;
+            }
+        }
+    }
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/siste14aVedtak/Avvik14aStatistikkMetrikk.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/siste14aVedtak/Avvik14aStatistikkMetrikk.java
@@ -1,0 +1,49 @@
+package no.nav.pto.veilarbportefolje.siste14aVedtak;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.pto.veilarbportefolje.domene.Avvik14aStatistikk;
+import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+@Slf4j
+public class Avvik14aStatistikkMetrikk implements MeterBinder {
+
+    private final OpensearchService opensearchService;
+
+    private AtomicLong antallMedInnsatsgruppeUlik;
+    private AtomicLong antallMedHovedmaalUlik;
+    private AtomicLong antallMedInnsatsgruppeOgHovedmaalUlik;
+    private AtomicLong antallMedInnsatsgruppeManglerINyKilde;
+
+    @Autowired
+    public Avvik14aStatistikkMetrikk(OpensearchService opensearchService) {
+        this.opensearchService = opensearchService;
+    }
+
+    @Override
+    public void bindTo(@NotNull MeterRegistry meterRegistry) {
+        Avvik14aStatistikk avvik14aStatistikk = opensearchService.hentAvvik14aStatistikk();
+
+        this.antallMedInnsatsgruppeUlik = meterRegistry.gauge("veilarbportefolje_avvik14astatistikk_innsatsgruppe_ulik", new AtomicLong(avvik14aStatistikk.antallMedInnsatsgruppeUlik()));
+        this.antallMedHovedmaalUlik = meterRegistry.gauge("veilarbportefolje_avvik14astatistikk_hovedmaal_ulik", new AtomicLong(avvik14aStatistikk.antallMedHovedmaalUlik()));
+        this.antallMedInnsatsgruppeOgHovedmaalUlik = meterRegistry.gauge("veilarbportefolje_avvik14astatistikk_innsatsgruppe_og_hovedmaal_ulik", new AtomicLong(avvik14aStatistikk.antallMedInnsatsgruppeOgHovedmaalUlik()));
+        this.antallMedInnsatsgruppeManglerINyKilde = meterRegistry.gauge("veilarbportefolje_avvik14astatistikk_innsatsgruppe_mangler", new AtomicLong(avvik14aStatistikk.antallMedInnsatsgruppeManglerINyKilde()));
+    }
+
+    public void oppdaterMetrikk() {
+        log.info("Oppdaterer metrikker for avvik 14 a statistikk");
+        Avvik14aStatistikk avvik14aStatistikk = opensearchService.hentAvvik14aStatistikk();
+
+        this.antallMedInnsatsgruppeUlik.set(avvik14aStatistikk.antallMedInnsatsgruppeUlik());
+        this.antallMedHovedmaalUlik.set(avvik14aStatistikk.antallMedHovedmaalUlik());
+        this.antallMedInnsatsgruppeOgHovedmaalUlik.set(avvik14aStatistikk.antallMedInnsatsgruppeOgHovedmaalUlik());
+        this.antallMedInnsatsgruppeManglerINyKilde.set(avvik14aStatistikk.antallMedInnsatsgruppeManglerINyKilde());
+    }
+}


### PR DESCRIPTION
## Describe your changes

Legger til 4 nye metrikker for statistikk på antall avvik på § 14 a-vedtak, i stedet for å måtte gjøre manuelt uttrekk fra DB hver gang. Metrikkene får følgende navn:

* `veilarbportefolje_avvik14astatistikk_innsatsgruppe_ulik`
* `veilarbportefolje_avvik14astatistikk_hovedmaal_ulik`
* `veilarbportefolje_avvik14astatistikk_innsatsgruppe_og_hovedmaal_ulik`
* `veilarbportefolje_avvik14astatistikk_innsatsgruppe_mangler`

Kan deretter brukes i Grafana slik: https://grafana.nais.io/goto/nBKAPJEVk?orgId=1

## Trello ticket number and link

TC-358

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
