### PR TITLE
Only consider aapordinerutlopsdato for specific innsatsgrouppe

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/PortefoljeMapper.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/PortefoljeMapper.java
@@ -4,8 +4,6 @@ import no.nav.pto.veilarbportefolje.domene.ArenaHovedmal;
 import no.nav.pto.veilarbportefolje.domene.ArenaInnsatsgruppe;
 import no.nav.pto.veilarbportefolje.vedtakstotte.Hovedmal;
 import no.nav.pto.veilarbportefolje.vedtakstotte.Innsatsgruppe;
-import no.nav.pto_schema.enums.arena.Hovedmaal;
-import no.nav.pto_schema.enums.arena.Kvalifiseringsgruppe;
 
 public class PortefoljeMapper {
     public static ArenaInnsatsgruppe mapTilArenaInnsatsgruppe(Innsatsgruppe innsatsgruppe) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
@@ -125,7 +125,11 @@ public class BrukerRepositoryV2 {
         String fnr = rs.getString(FODSELSNR);
         String utkast14aStatus = rs.getString(UTKAST_14A_STATUS);
 
-        LocalDate aapordinerutlopsdato = DateUtils.addWeeksToTodayAndGetNthDay(rs.getTimestamp("YTELSE_ENDRET_DATO"), rs.getInt(AAPMAXTIDUKE), rs.getInt(ANTALLDAGERIGJEN));
+        LocalDate aapordinerutlopsdato = null;
+        boolean erSpesieltTilpassetInnsats = (rs.getString(KVALIFISERINGSGRUPPEKODE) != null && rs.getString(KVALIFISERINGSGRUPPEKODE).equals("BATT"));
+        if (erSpesieltTilpassetInnsats) {
+            aapordinerutlopsdato = DateUtils.addWeeksToTodayAndGetNthDay(rs.getTimestamp("YTELSE_ENDRET_DATO"), rs.getInt(AAPMAXTIDUKE), rs.getInt(ANTALLDAGERIGJEN));
+        }
 
         OppfolgingsBruker bruker = new OppfolgingsBruker()
                 .setFnr(fnr)

--- a/src/main/java/no/nav/pto/veilarbportefolje/util/DateUtils.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/util/DateUtils.java
@@ -201,7 +201,7 @@ public class DateUtils {
 
         WeekFields weekFields = WeekFields.ISO;
         TemporalField dayOfWeek = weekFields.dayOfWeek();
-        return (DateUtils.toLocalDate(initialDay).plusWeeks(weeksNumber)).with(dayOfWeek, 1).plusDays(dayNumber - 1L);
+        return (DateUtils.toLocalDate(initialDay).plusWeeks(weeksNumber)).with(dayOfWeek, 1).plusDays(dayNumber);
     }
 
     public static Comparator<LocalDate> closestToTodayComparator() {

--- a/src/test/java/no/nav/pto/veilarbportefolje/util/DateUtilsTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/util/DateUtilsTest.java
@@ -131,16 +131,16 @@ public class DateUtilsTest {
     public void testAddWeeksToTodayAndGetNthDay() {
         WeekFields weekFields = WeekFields.ISO;
         LocalDate dateInFuture = addWeeksToTodayAndGetNthDay(Timestamp.from(Instant.now()), 5, 3);
-        assertThat(dateInFuture.getDayOfWeek().getValue()).isEqualTo(3);
+        assertThat(dateInFuture.getDayOfWeek().getValue()).isEqualTo(4);
         assertThat(dateInFuture.minusWeeks(5).get(weekFields.weekOfYear())).isEqualTo(LocalDate.now().get(weekFields.weekOfYear()));
 
 
         dateInFuture = addWeeksToTodayAndGetNthDay(Timestamp.from(Instant.now()), 45, 1);
-        assertThat(dateInFuture.getDayOfWeek().getValue()).isEqualTo(1);
+        assertThat(dateInFuture.getDayOfWeek().getValue()).isEqualTo(2);
         assertThat(dateInFuture.minusWeeks(45).get(weekFields.weekOfYear())).isEqualTo(LocalDate.now().get(weekFields.weekOfYear()));
 
 
-        dateInFuture = addWeeksToTodayAndGetNthDay(Timestamp.from(Instant.now()), 123, 7);
+        dateInFuture = addWeeksToTodayAndGetNthDay(Timestamp.from(Instant.now()), 123, 6);
         assertThat(dateInFuture.getDayOfWeek().getValue()).isEqualTo(7);
         assertThat(dateInFuture.minusWeeks(123).get(weekFields.weekOfYear())).isEqualTo(LocalDate.now().get(weekFields.weekOfYear()));
     }


### PR DESCRIPTION
## Describe your changes

Its decided to calculate AAP uptlopsdato only for SPESIELT TILPASSET INNSATS so those changes are based on that.

## Type of change

Please delete options that are not relevant.

- [✔️] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [✔️] I have performed a self-review of my code
- [❌] If it is a core feature, I have added thorough tests.
- [❌] We need to implement grafana analytics
