### PR TITLE
Slutt å kaste exception dersom tiltakskoden ikke støttes - logg i stedet

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetService.java
@@ -67,7 +67,9 @@ public class AktivitetService extends KafkaCommonConsumerService<KafkaAktivitetM
                 opensearchIndexer.indekser(aktorId);
             }
         } else {
-            throw new RuntimeException("Mottok aktivitet med aktivitetId: " + aktivitetData.aktivitetId + " med uventet tiltakskode: " + aktivitetData.tiltakskode + " fra ny kilde. Tiltak ble ikke lagret.");
+            // TODO 05.07.23: Finne en bedre måte å håndtere dette på - nå bare ignorerer vi alt som ikke er MIDLONTIL eller VARLONTIL.
+            // Dette er greit per nå da vi uansett får dataen vi trenger fra Arena.
+            secureLog.debug("Mottok aktivitet med aktivitetId: " + aktivitetData.aktivitetId + " med uventet tiltakskode: " + aktivitetData.tiltakskode + " fra ny kilde. Tiltak ble ikke lagret.");
         }
     }
 


### PR DESCRIPTION
Oppretter PR direkte mot master da vi har kode i dev som ikke er syncet til master ennå.

---

Vi har begynt å få tiltakskoder på pto.aktivitet-portefolje-v1-topicen som vi ikke støtter. Opprinnelig kastet vi exception da vi ønsket å kunne fange opp dette, men denne håndteringen er ikke helt heldig nå når vi får mange aktiviteter med andre tiltakstyper. Endere derfor implementasjonen til at vi ignorerer tiltakskoder som ikke er en av MIDLONTIL eller VARLONTIL og logger heller en warning med samme melding som vi før la i exceptionet.

Dette er en enkel løsning vi gjør nå slik at vi ikke blokkerer oppdateringer og kan fortsette å prosessere Kafka-meldingene. Per nå vil det ikke ha noen konsekvens å bare ignorere meldingene siden vi fortsatt får tilsvarende data fra Arena. Vi bør derimot se litt på hvordan vi ønsker å gjøre dette fremover - skal vi konsumere alt av tiltaksaktiviteter vi får fra denne topic-en, eller skal vi gå rett mot kilden?
