### PR TITLE
Fiks autentiseringsfeil i nais deploy action v2

### DIFF
--- a/.github/workflows/deploy-alerts-to-prod.yaml
+++ b/.github/workflows/deploy-alerts-to-prod.yaml
@@ -20,6 +20,6 @@ jobs:
       - name: Deploy to prod-fss
         uses: nais/deploy/actions/deploy@v1
         env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY_OBO }}
           CLUSTER: prod-fss
           RESOURCE: .nais/alerts/alerts-config-prod.yaml


### PR DESCRIPTION
For deployment til obo-namespace kreves egen deploy api-key. Den uten "OBO"-postfix er for pto-namespacet.