### PR TITLE
Change some of PDL workflow functions to be async

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/config/ApplicationConfig.java
@@ -16,16 +16,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
 
 import java.util.List;
 
-import static no.nav.common.utils.UrlUtils.createServiceUrl;
-
 @EnableScheduling
 @Configuration
 @EnableConfigurationProperties({EnvironmentProperties.class})
+@EnableAsync
 public class ApplicationConfig {
 
     public static final String APPLICATION_NAME = "veilarbportefolje";

--- a/src/main/java/no/nav/pto/veilarbportefolje/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/config/ApplicationConfig.java
@@ -19,8 +19,10 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 
 @EnableScheduling
 @Configuration
@@ -69,4 +71,13 @@ public class ApplicationConfig {
         return new KodeverkClientImpl(environmentProperties.getKodeverkUrl());
     }
 
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlService.java
@@ -9,6 +9,7 @@ import no.nav.pto.veilarbportefolje.persononinfo.barnUnder18Aar.BarnUnder18AarSe
 import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLIdent;
 import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLPerson;
 import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLPersonBarn;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,7 @@ public class PdlService {
     private final BarnUnder18AarService barnUnder18AarService;
     private final PdlPortefoljeClient pdlClient;
 
+    @Async
     public void hentOgLagrePdlData(AktorId aktorId) {
         List<PDLIdent> identer = hentOgLagreIdenter(aktorId);
         Fnr fnr = hentAktivFnr(identer);
@@ -34,6 +36,7 @@ public class PdlService {
         hentOgLagreBrukerData(fnr);
     }
 
+    @Async
     public void hentOgLagreBrukerData(Fnr fnrPerson) {
         try {
             PDLPerson personData = pdlClient.hentBrukerDataFraPdl(fnrPerson);
@@ -43,17 +46,20 @@ public class PdlService {
         }
     }
 
+    @Async
     public void hentOgLagreBrukerDataPaBarn(Fnr fnrBarn) {
         PDLPersonBarn barnData = pdlClient.hentBrukerBarnDataFraPdl(fnrBarn);
         barnUnder18AarService.oppdaterEndringPaBarn(fnrBarn, barnData);
     }
 
+    @Async
     public void lagreBrukerData(Fnr fnrPerson, PDLPerson personData) {
         pdlPersonRepository.upsertPerson(fnrPerson, personData);
 
         barnUnder18AarService.lagreBarnOgForeldreansvar(fnrPerson, personData.getForeldreansvar());
     }
 
+    @Async
     public void lagreBrukerDataPaBarn(Fnr fnrBarn, PDLPersonBarn pdlPersonBarn) {
         barnUnder18AarService.oppdaterEndringPaBarn(fnrBarn, pdlPersonBarn);
     }
@@ -92,6 +98,7 @@ public class PdlService {
         pdlIdentRepository.slettLagretePerson(lokalIdent);
     }
 
+    @Async
     public void slettPDLBrukerData(List<Fnr> fnrs) {
         List<Fnr> barnFnrsForForeldre = barnUnder18AarService.hentBarnFnrsForForeldre(fnrs);
         pdlPersonRepository.slettLagretBrukerData(fnrs);

--- a/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlBrukerdataKafkaServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlBrukerdataKafkaServiceTest.java
@@ -1,0 +1,110 @@
+package no.nav.pto.veilarbportefolje.persononinfo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import no.nav.common.client.pdl.PdlClientImpl;
+import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest;
+import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
+import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
+import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingRepositoryV2;
+import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerRepositoryV3;
+import no.nav.pto.veilarbportefolje.persononinfo.PdlResponses.PdlDokument;
+import no.nav.pto.veilarbportefolje.persononinfo.barnUnder18Aar.BarnUnder18AarRepository;
+import no.nav.pto.veilarbportefolje.persononinfo.barnUnder18Aar.BarnUnder18AarService;
+import no.nav.pto.veilarbportefolje.service.BrukerServiceV2;
+import no.nav.pto.veilarbportefolje.service.UnleashService;
+import no.nav.pto.veilarbportefolje.util.SingletonPostgresContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static no.nav.pto.veilarbportefolje.util.TestUtil.readFileAsJsonString;
+
+@SpringBootTest(classes = ApplicationConfigTest.class)
+public class PdlBrukerdataKafkaServiceTest {
+
+    private final PdlDokument randomPdlDokument;
+
+    private static BarnUnder18AarRepository barnUnder18AarRepository;
+    private static PdlBrukerdataKafkaService pdlBrukerdataKafkaService;
+
+    private static PdlIdentRepository pdlIdentRepository;
+
+    private static PdlPersonRepository pdlPersonRepository;
+
+    private static OppfolgingsbrukerRepositoryV3 oppfolgingsbrukerRepositoryV3;
+
+    private static OppfolgingRepositoryV2 oppfolgingRepositoryV2;
+
+    @MockBean
+    private static OpensearchIndexer opensearchIndexer;
+    @MockBean
+    private static OpensearchIndexerV2 opensearchIndexerV2;
+
+    @MockBean
+    private static UnleashService unleashService;
+
+    private static final WireMockServer server = new WireMockServer();
+
+    private static JdbcTemplate db;
+
+    public PdlBrukerdataKafkaServiceTest() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        String pdlDokumentAsString = readFileAsJsonString("/PDL_Files/pdl_dokument.json", getClass());
+        randomPdlDokument = mapper.readValue(pdlDokumentAsString, PdlDokument.class);
+    }
+
+    @BeforeAll
+    public static void setup() {
+        db = SingletonPostgresContainer.init().createJdbcTemplate();
+        barnUnder18AarRepository = new BarnUnder18AarRepository(db, db);
+        pdlIdentRepository = new PdlIdentRepository(db);
+        pdlPersonRepository = new PdlPersonRepository(db, db);
+        oppfolgingsbrukerRepositoryV3 = new OppfolgingsbrukerRepositoryV3(db, null);
+        oppfolgingRepositoryV2 = new OppfolgingRepositoryV2(db);
+
+        db.update("truncate bruker_data CASCADE");
+        db.update("truncate bruker_data_barn CASCADE");
+        db.update("truncate foreldreansvar");
+        server.start();
+
+        PdlPortefoljeClient pdlPortefoljeClient = new PdlPortefoljeClient(new PdlClientImpl("http://localhost:" + server.port(), () -> "SYSTEM_TOKEN"));
+        BarnUnder18AarService barnUnder18AarService = new BarnUnder18AarService(barnUnder18AarRepository, pdlPortefoljeClient);
+
+        pdlBrukerdataKafkaService = new PdlBrukerdataKafkaService(new PdlService(
+                pdlIdentRepository,
+                pdlPersonRepository,
+                barnUnder18AarService,
+                pdlPortefoljeClient
+        )
+                , pdlIdentRepository,
+                new BrukerServiceV2(pdlIdentRepository, oppfolgingsbrukerRepositoryV3, oppfolgingRepositoryV2),
+                barnUnder18AarService,
+                opensearchIndexer,
+                opensearchIndexerV2,
+                unleashService
+        );
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        db.update("truncate bruker_data CASCADE");
+        db.update("truncate bruker_data_barn CASCADE");
+        db.update("truncate foreldreansvar");
+    }
+
+    @Test
+    @Timeout(25)
+    public void testRepublishing() {
+        int i = 0;
+        while (i < 6000) {
+            pdlBrukerdataKafkaService.behandleKafkaMeldingLogikk(randomPdlDokument);
+            i++;
+        }
+    }
+}

--- a/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlBrukerdataKafkaServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlBrukerdataKafkaServiceTest.java
@@ -15,10 +15,7 @@ import no.nav.pto.veilarbportefolje.persononinfo.barnUnder18Aar.BarnUnder18AarSe
 import no.nav.pto.veilarbportefolje.service.BrukerServiceV2;
 import no.nav.pto.veilarbportefolje.service.UnleashService;
 import no.nav.pto.veilarbportefolje.util.SingletonPostgresContainer;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -100,6 +97,11 @@ public class PdlBrukerdataKafkaServiceTest {
         db.update("truncate bruker_data CASCADE");
         db.update("truncate bruker_data_barn CASCADE");
         db.update("truncate foreldreansvar");
+    }
+
+    @AfterEach
+    public void stopServer() {
+        server.stop();
     }
 
     @Test


### PR DESCRIPTION
## Describe your changes

When we have a huge number of PDL messages (e.g. during republishing) we process those messages very slowely (rate around 20 messages per second) and this PR is one way to try to decrease processing time.

## Trello ticket number and link

n/a

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
