### PR TITLE
Change some of PDL workflow functions to be async

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepository.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepository.java
@@ -9,7 +9,6 @@ import no.nav.pto.veilarbportefolje.persononinfo.domene.IdenterForBruker;
 import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLIdent;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -25,7 +24,6 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 public class PdlIdentRepository {
     private final JdbcTemplate db;
 
-    @Transactional
     public void upsertIdenter(List<PDLIdent> identer) {
         List<String> personer = hentPersoner(identer);
         personer.forEach(this::slettLagretePerson);

--- a/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/barnUnder18Aar/BarnUnder18AarRepository.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/barnUnder18Aar/BarnUnder18AarRepository.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.Fnr;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -55,21 +56,30 @@ public class BarnUnder18AarRepository {
     }
 
     public Boolean finnesBarnIForeldreansvar(Fnr fnrBarn) {
-        String foresattIdent = dbReadOnly.queryForObject("""
-                    SELECT foresatt_ident FROM foreldreansvar WHERE barn_ident = ? limit 1
+        try {
+            String foresattIdent = dbReadOnly.queryForObject("""
+                        SELECT foresatt_ident FROM foreldreansvar WHERE barn_ident = ? LIMIT 1
                 """, String.class, fnrBarn.get());
 
-        return foresattIdent != null && !foresattIdent.isEmpty();
+            return foresattIdent != null && !foresattIdent.isEmpty();
+        } catch (EmptyResultDataAccessException e) {
+            return false;
+        }
+
     }
 
     public Boolean finnesBarnIForeldreansvar(List<Fnr> fnrBarn) {
-        String fnrsparam = fnrBarn.stream().map(Fnr::get).collect(Collectors.joining(",", "{", "}"));
-        String foresattIdent = dbReadOnly.queryForObject("""
+        try {
+            String fnrsparam = fnrBarn.stream().map(Fnr::get).collect(Collectors.joining(",", "{", "}"));
+            String foresattIdent = dbReadOnly.queryForObject("""
                     SELECT foresatt_ident FROM foreldreansvar WHERE barn_ident = any (?::varchar[]) LIMIT 1
                 """, String.class, fnrsparam);
 
 
-        return foresattIdent != null && !foresattIdent.isEmpty();
+            return foresattIdent != null && !foresattIdent.isEmpty();
+        } catch (EmptyResultDataAccessException e) {
+            return false;
+        }
     }
 
     public void lagreBarnData(Fnr barnIdent, LocalDate barnFoedselsdato, String diskresjonskode) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/barnUnder18Aar/BarnUnder18AarService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/barnUnder18Aar/BarnUnder18AarService.java
@@ -6,7 +6,6 @@ import no.nav.common.types.identer.Fnr;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlPortefoljeClient;
 import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLPersonBarn;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,7 +18,6 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
 public class BarnUnder18AarService {
 
     private final BarnUnder18AarRepository barnUnder18AarRepository;


### PR DESCRIPTION
## Describe your changes

When we have a huge number of PDL messages (e.g. during republishing) we process those messages very slowely (rate around 20 messages per second) and this PR is one way to try to decrease processing time.

## Trello ticket number and link

n/a

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
