### PR TITLE
Revert Hikari pool size

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlBrukerdataKafkaService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlBrukerdataKafkaService.java
@@ -19,6 +19,7 @@ import no.nav.pto.veilarbportefolje.persononinfo.domene.PdlPersonValideringExcep
 import no.nav.pto.veilarbportefolje.service.BrukerServiceV2;
 import no.nav.pto.veilarbportefolje.service.UnleashService;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StopWatch;
 
 import java.util.List;
 import java.util.Optional;
@@ -52,25 +53,43 @@ public class PdlBrukerdataKafkaService extends KafkaCommonConsumerService<PdlDok
             return;
         }
 
+        StopWatch watch1 = new StopWatch();
+        StopWatch watch2 = new StopWatch();
+
+        watch1.start();
+
+
         List<PDLIdent> pdlIdenter = pdlDokument.getHentIdenter().getIdenter();
         List<AktorId> aktorIder = hentAktorider(pdlIdenter);
         List<Fnr> fnrs = hentFnrs(pdlIdenter);
         List<Fnr> inaktiveFnr = hentInaktiveFnr(pdlIdenter);
 
+
         if (pdlIdentRepository.harAktorIdUnderOppfolging(aktorIder)) {
+            watch2.start();
             AktorId aktivAktorId = hentAktivAktor(pdlIdenter);
             secureLog.info("Det oppsto en PDL endring aktoer: {}", aktivAktorId);
 
             handterIdentEndring(pdlIdenter);
 
+            watch2.stop();
+
+            log.info("Elapsed step 1: " + watch2.getLastTaskTimeMillis());
+            watch2.start();
+
             handterBrukerDataEndring(pdlDokument.getHentPerson(), pdlIdenter);
+
+            watch2.stop();
+            log.info("Elapsed step 2: " + watch2.getLastTaskTimeMillis());
 
             if (!FeatureToggle.stoppOpensearchIndeksering(unleashService)) {
                 oppdaterOpensearch(aktivAktorId, pdlIdenter);
             }
         }
 
+
         if (barnUnder18AarService.erFnrBarnAvForelderUnderOppfolging(fnrs)) {
+            watch2.start();
             log.info("Det oppsto en PDL endring for barn");
             Fnr aktivtFnr = hentAktivFnr(pdlIdenter);
             barnUnder18AarService.handterBarnIdentEndring(aktivtFnr, inaktiveFnr);
@@ -90,7 +109,14 @@ public class PdlBrukerdataKafkaService extends KafkaCommonConsumerService<PdlDok
                         }
                 );
             }
+
+            watch2.stop();
+            log.info("Elapsed step 3: " + watch2.getLastTaskTimeMillis());
         }
+
+        watch1.stop();
+        log.info("Elapsed total: " + watch1.getLastTaskTimeMillis());
+
     }
 
     private void handterBrukerDataEndring(PdlPersonResponse.PdlPersonResponseData.HentPersonResponsData personFraKafka,


### PR DESCRIPTION
## Describe your changes

I was experimenting with different pool sizes for Hikari yesterday after work hours, in order to speed up PDL processing, but didn't help significantly. So I am reverting those changes.

## Trello ticket number and link

n/a

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
