### PR TITLE
Move back henting of PDL identer not to be async

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlService.java
@@ -27,8 +27,7 @@ public class PdlService {
 
     private final BarnUnder18AarService barnUnder18AarService;
     private final PdlPortefoljeClient pdlClient;
-
-    @Async
+    
     public void hentOgLagrePdlData(AktorId aktorId) {
         List<PDLIdent> identer = hentOgLagreIdenter(aktorId);
         Fnr fnr = hentAktivFnr(identer);


### PR DESCRIPTION
## Describe your changes

Async henting av pdl data er problem når vi begynne med oppfolging. Så vi sletter async annotation.

## Trello ticket number and link

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
