### PR TITLE
Bedre feilhandtering arbeidsliste

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/v1/ArbeidsListeController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/v1/ArbeidsListeController.java
@@ -105,7 +105,7 @@ public class ArbeidsListeController {
 
         arbeidslisteService.createArbeidsliste(data(body, Fnr.ofValidFnr(fnr)))
                 .onFailure(e -> secureLog.warn("Kunne ikke opprette arbeidsliste: {}", e.getMessage()))
-                .getOrElseThrow((Function<Throwable, RuntimeException>) RuntimeException::new);
+                .getOrElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR));
 
         return arbeidslisteService.getArbeidsliste(Fnr.ofValidFnr(fnr)).get()
                 .setHarVeilederTilgang(true)
@@ -122,13 +122,13 @@ public class ArbeidsListeController {
         arbeidslisteService
                 .updateArbeidsliste(data(body, fnr))
                 .onFailure(e -> secureLog.warn("Kunne ikke oppdatere arbeidsliste: {}", e.getMessage()))
-                .getOrElseThrow((Function<Throwable, RuntimeException>) RuntimeException::new);
+                .getOrElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR));
 
         if (arbeidslisteService.getArbeidsliste(fnr).get() == null) {
             VeilederId veilederId = AuthUtils.getInnloggetVeilederIdent();
             NavKontor enhet = brukerService.hentNavKontor(fnr).orElse(null);
             secureLog.warn("Arbeidsliste kunne ikke oppdateres, var null, fnr: {}, veileder: {}, på enhet: {}", fnrString, veilederId, enhet);
-            throw new IllegalStateException("Kunne ikke oppdatere. Fant ikke arbeidsliste for bruker");
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Kunne ikke oppdatere. Fant ikke arbeidsliste for bruker");
         }
 
         return arbeidslisteService.getArbeidsliste(fnr).get()
@@ -149,7 +149,7 @@ public class ArbeidsListeController {
             VeilederId veilederId = AuthUtils.getInnloggetVeilederIdent();
             NavKontor enhet = brukerService.hentNavKontor(Fnr.ofValidFnr(fnr)).orElse(null);
             secureLog.warn("Kunne ikke slette arbeidsliste for fnr: {}, av veileder: {}, på enhet: {}", fnr, veilederId.toString(), enhet);
-            throw new IllegalStateException("Kunne ikke slette. Fant ikke arbeidsliste for bruker");
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Kunne ikke slette. Fant ikke arbeidsliste for bruker");
         }
 
         return emptyArbeidsliste().setHarVeilederTilgang(true).setIsOppfolgendeVeileder(true);
@@ -170,7 +170,7 @@ public class ArbeidsListeController {
         Validation<List<Fnr>, List<Fnr>> validerFnrs = ValideringsRegler.validerFnrs(fnrs);
         Validation<String, List<Fnr>> veilederForBrukere = arbeidslisteService.erVeilederForBrukere(fnrs);
         if (validerFnrs.isInvalid() || veilederForBrukere.isInvalid()) {
-            throw new IllegalStateException(format("%s inneholder ett eller flere ugyldige fødselsnummer", validerFnrs.getError()));
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, format("%s inneholder ett eller flere ugyldige fødselsnummer", validerFnrs.getError()));
         }
 
         validerFnrs.get().forEach(fnr -> {
@@ -189,13 +189,13 @@ public class ArbeidsListeController {
         });
 
         if (feiledeFnrs.size() == fnrs.size()) {
-            throw new IllegalStateException();
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         }
         return RestResponse.of(okFnrs, feiledeFnrs);
     }
 
     private void sjekkTilgangTilEnhet(Fnr fnr) {
-        NavKontor enhet = brukerService.hentNavKontor(fnr).orElseThrow(() -> new IllegalArgumentException("Kunne ikke hente enhet for denne brukeren"));
+        NavKontor enhet = brukerService.hentNavKontor(fnr).orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Kunne ikke hente enhet for denne brukeren"));
         authService.tilgangTilEnhet(enhet.getValue());
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/v2/ArbeidsListeV2Controller.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/v2/ArbeidsListeV2Controller.java
@@ -75,8 +75,8 @@ public class ArbeidsListeV2Controller {
         sjekkTilgangTilEnhet(gyldigFnr);
 
         arbeidslisteService.createArbeidsliste(data(body, gyldigFnr))
-                .onFailure(e -> secureLog.warn("Kunne ikke opprette arbeidsliste: {}", e.getMessage()))
-                .getOrElseThrow((Function<Throwable, RuntimeException>) RuntimeException::new);
+                .onFailure(e -> secureLog.warn("Kunne ikke opprette arberidsliste: {}", e.getMessage()))
+                .getOrElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR));
 
         return arbeidslisteService.getArbeidsliste(gyldigFnr).get()
                 .setHarVeilederTilgang(true)
@@ -93,13 +93,13 @@ public class ArbeidsListeV2Controller {
         arbeidslisteService
                 .updateArbeidsliste(data(body, fnr))
                 .onFailure(e -> secureLog.warn("Kunne ikke oppdatere arbeidsliste: {}", e.getMessage()))
-                .getOrElseThrow((Function<Throwable, RuntimeException>) RuntimeException::new);
+                .getOrElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR));
 
         if (arbeidslisteService.getArbeidsliste(fnr).get() == null) {
             VeilederId veilederId = AuthUtils.getInnloggetVeilederIdent();
             NavKontor enhet = brukerService.hentNavKontor(fnr).orElse(null);
             secureLog.warn("Arbeidsliste kunne ikke oppdateres, var null, fnr: {}, veileder: {}, på enhet: {}", body.fnr().get(), veilederId, enhet);
-            throw new IllegalStateException("Kunne ikke oppdatere. Fant ikke arbeidsliste for bruker");
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Kunne ikke oppdatere. Fant ikke arbeidsliste for bruker");
         }
 
         return arbeidslisteService.getArbeidsliste(fnr).get()
@@ -121,14 +121,14 @@ public class ArbeidsListeV2Controller {
             VeilederId veilederId = AuthUtils.getInnloggetVeilederIdent();
             NavKontor enhet = brukerService.hentNavKontor(gyldigFnr).orElse(null);
             secureLog.warn("Kunne ikke slette arbeidsliste for fnr: {}, av veileder: {}, på enhet: {}", gyldigFnr.get(), veilederId.toString(), enhet);
-            throw new IllegalStateException("Kunne ikke slette. Fant ikke arbeidsliste for bruker");
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Kunne ikke slette. Fant ikke arbeidsliste for bruker");
         }
 
         return emptyArbeidsliste().setHarVeilederTilgang(true).setIsOppfolgendeVeileder(true);
     }
 
     private void sjekkTilgangTilEnhet(Fnr fnr) {
-        NavKontor enhet = brukerService.hentNavKontor(fnr).orElseThrow(() -> new IllegalArgumentException("Kunne ikke hente enhet for denne brukeren"));
+        NavKontor enhet = brukerService.hentNavKontor(fnr).orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Kunne ikke hente enhet for denne brukeren"));
         authService.tilgangTilEnhet(enhet.getValue());
     }
 


### PR DESCRIPTION
## Describe your changes

Per dags dato så har vi flere Arbeidsliste-relaterte endepunkter hvor vi kaster exceptions som Spring ikke mapper om til et responsobjekt. Dette resulterer i at vi lekker stacktraces til klienten/nettleseren. Endrer til å kaste Spring sin innebygde `ResponseStatusException` som [automatisk håndteres og mappes av Spring](https://www.baeldung.com/spring-response-status-exception).

Dette er en ikke-breaking change siden statuskoden som klienten mottar fortsatt vil være `HTTP 500`.

## Trello ticket number and link

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
