### PR TITLE
Tilpasse feilhåndtering ved sletting av arbeidsliste

### DIFF
--- a/.intelliJ_ddl/DDL.sql
+++ b/.intelliJ_ddl/DDL.sql
@@ -437,7 +437,6 @@ CREATE TABLE public.gruppe_aktiviter (
 --
 
 CREATE TABLE public.huskelapp (
-    endrings_id uuid NOT NULL,
     huskelapp_id uuid,
     fnr character varying(11) NOT NULL,
     enhet_id character varying(4) NOT NULL,
@@ -445,8 +444,29 @@ CREATE TABLE public.huskelapp (
     endret_dato timestamp without time zone DEFAULT now(),
     frist timestamp without time zone,
     kommentar character varying(200),
-    status character varying(10)
+    status character varying(10),
+    endrings_id integer NOT NULL
 );
+
+
+--
+-- Name: huskelapp_endrings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.huskelapp_endrings_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: huskelapp_endrings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.huskelapp_endrings_id_seq OWNED BY public.huskelapp.endrings_id;
 
 
 --
@@ -702,6 +722,13 @@ ALTER TABLE ONLY public.enslige_forsorgere_vedtaksperiode_type ALTER COLUMN id S
 --
 
 ALTER TABLE ONLY public.enslige_forsorgere_vedtaksresultat_type ALTER COLUMN id SET DEFAULT nextval('public.enslige_forsorgere_vedtaksresultat_type_id_seq'::regclass);
+
+
+--
+-- Name: huskelapp endrings_id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.huskelapp ALTER COLUMN endrings_id SET DEFAULT nextval('public.huskelapp_endrings_id_seq'::regclass);
 
 
 --
@@ -1035,10 +1062,10 @@ CREATE INDEX enslige_forsorgere_aktivitet_type_indx ON public.enslige_forsorgere
 
 
 --
--- Name: fargekategori_fnr_index; Type: INDEX; Schema: public; Owner: -
+-- Name: fargekategori_fnr_unique_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fargekategori_fnr_index ON public.fargekategori USING btree (fnr);
+CREATE UNIQUE INDEX fargekategori_fnr_unique_index ON public.fargekategori USING btree (fnr);
 
 
 --

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
@@ -81,15 +81,19 @@ public class ArbeidslisteService {
         return rowsUpdated;
     }
 
-    public int slettArbeidsliste(Fnr fnr) {
+    public void slettArbeidsliste(Fnr fnr) {
         Optional<AktorId> aktoerId = brukerServiceV2.hentAktorId(fnr);
 
         if (aktoerId.isEmpty()) {
-            secureLog.error("Kunne ikke slette arbeidsliste. Årsak: fant ikke aktørId på fnr: {}", fnr.get());
-            return -1;
+            throw new SlettArbeidslisteException(String.format("Kunne ikke slette arbeidsliste. Årsak: fant ikke aktørId på fnr: %s", fnr.get()));
         }
 
-        return slettArbeidsliste(aktoerId.get());
+        int antallArbeidslisterSlettet = slettArbeidsliste(aktoerId.get());
+
+        if (antallArbeidslisterSlettet != 1) {
+            throw new SlettArbeidslisteException("Kunne ikke slette arbeidsliste. Årsak: antall arbeidslister for bruker er ulik 1.");
+        }
+
     }
 
     private Try<AktorId> hentAktorId(Fnr fnr) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
@@ -83,11 +83,13 @@ public class ArbeidslisteService {
 
     public int slettArbeidsliste(Fnr fnr) {
         Optional<AktorId> aktoerId = brukerServiceV2.hentAktorId(fnr);
-        if (aktoerId.isPresent()) {
-            return slettArbeidsliste(aktoerId.get());
+
+        if (aktoerId.isEmpty()) {
+            secureLog.error("Kunne ikke slette arbeidsliste. Årsak: fant ikke aktørId på fnr: {}", fnr.get());
+            return -1;
         }
-        log.error("fant ikke aktørId på fnr");
-        return -1;
+
+        return slettArbeidsliste(aktoerId.get());
     }
 
     private Try<AktorId> hentAktorId(Fnr fnr) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
@@ -86,13 +86,15 @@ public class ArbeidslisteService {
     public void slettArbeidsliste(AktorId aktoerId) {
         final int antallSlettedeArbeidslister = arbeidslisteRepositoryV2.slettArbeidsliste(aktoerId);
 
+        if (antallSlettedeArbeidslister <= 0) {
+            return;
+        }
+
         if (antallSlettedeArbeidslister > 1) {
             secureLog.warn("Uventet tilstand: fant flere arbeidslister ved sletting for aktørId {}. Forventet å finne kun en arbeidsliste. Antall arbeidslister/rader slettet {}.", aktoerId.get(), antallSlettedeArbeidslister);
         }
 
-        if (antallSlettedeArbeidslister == 1) {
-            opensearchIndexerV2.slettArbeidsliste(aktoerId);
-        }
+        opensearchIndexerV2.slettArbeidsliste(aktoerId);
     }
 
     private Try<AktorId> hentAktorId(Fnr fnr) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/SlettArbeidslisteException.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/SlettArbeidslisteException.java
@@ -1,0 +1,8 @@
+package no.nav.pto.veilarbportefolje.arbeidsliste;
+
+
+public class SlettArbeidslisteException extends RuntimeException {
+    public SlettArbeidslisteException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Describe your changes

Bruker en custom exception for å representere feil ved sletting og håndterer feil-logikken i service-klassen, i stedet for at vi har spredt logikk for å sjekke antall rader slettet rundt omkring i koden. 

I tillegg fjerner jeg et "feil-scenario" som ikke er mulig for konsumenten (aka. frontenden) å håndtere. Før så ble det sendt feil til konsumenten dersom antall rader slettet var ulik 1. Problemet med dette er at selve slettingen likevel ble utført (dvs. radene ble `DELETE`-et fra databasen), altså er det ingenting konsumenten kan gjøre for å recovere siden dataen allerede er slettet. Dersom man ønsker å tilby konsumenten mulighet for håndtering så må man avbryte selve `DELETE`-en, men dette blir utenfor scope her. Dessuten skal koden for arbeidsliste uansett fjernes snart, så denne PR-en er mest for å gjøre migreringen av FARGEKATEGORI enklere.

## Trello ticket number and link

- [TC-456](https://trello.com/c/p7Nsm0HR/456-separere-fargekategoriene-fra-arbeidslista)

## Type of change

Please delete options that are not relevant.

- [X] Modification (non-breaking change which modifies code)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
