### PR TITLE
Fjern unødvendig logglinje som mangler et use-case

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
@@ -92,10 +92,6 @@ public class ArbeidslisteService {
             return;
         }
 
-        if (antallSlettedeArbeidslister > 1) {
-            secureLog.warn("Uventet tilstand: fant flere arbeidslister ved sletting for aktørId {}. Forventet å finne kun en arbeidsliste. Antall arbeidslister/rader slettet {}.", aktoerId.get(), antallSlettedeArbeidslister);
-        }
-
         opensearchIndexerV2.slettArbeidsliste(aktoerId);
     }
 


### PR DESCRIPTION
## Describe your changes

For det første er sjekken vi gjør feil, siden både `1` og `2` er lovlige antall rader returnert fra `ArbeidslisteRepositoryV2.slettArbeidsliste(...)`. For det andre er loggingen unødvendig siden dersom antall rader slettet per tabell ikke er som forventet blir det uansett kastet exception i `ArbeidslisteRepositoryV2`.

Testene derimot er korrekte.

## Trello ticket number and link

- [TC-456](https://trello.com/c/p7Nsm0HR/456-separere-fargekategoriene-fra-arbeidslista)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
