### PR TITLE
Prodsette #1440

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/navikt/pus-nais-java-app/pus-nais-java-app:java17
+FROM ghcr.io/navikt/poao-baseimages/java:17
 COPY /target/veilarbportefolje.jar app.jar

--- a/src/main/java/no/nav/pto/veilarbportefolje/admin/v1/AdminController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/admin/v1/AdminController.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static no.nav.pto.veilarbportefolje.auth.AuthUtils.erSystemkallFraAzureAd;
 import static no.nav.pto.veilarbportefolje.auth.AuthUtils.hentApplikasjonFraContex;
+import static no.nav.pto.veilarbportefolje.opensearch.OpensearchConfig.BRUKERINDEKS_ALIAS;
 import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 
 @Slf4j
@@ -50,7 +51,7 @@ public class AdminController {
     public String slettOppfolgingsbruker(@RequestBody String aktoerId) {
         sjekkTilgangTilAdmin();
         oppfolgingAvsluttetService.avsluttOppfolging(AktorId.of(aktoerId));
-        return "Slettet oppfølgingsbruker " + aktoerId;
+        return "Oppfølgingsbruker ble slettet";
     }
 
     @PostMapping("/lastInnOppfolging")
@@ -151,6 +152,7 @@ public class AdminController {
     @PostMapping("/opensearch/getSettings")
     public String getSettings(@RequestParam String indexName) {
         sjekkTilgangTilAdmin();
+        validerIndexName(indexName);
         return opensearchAdminService.getSettingsOnIndex(indexName);
     }
 
@@ -216,5 +218,11 @@ public class AdminController {
             return;
         }
         throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+    }
+
+    private void validerIndexName(String indexName) {
+        if (!BRUKERINDEKS_ALIAS.equals(indexName)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
     }
 }


### PR DESCRIPTION
## Describe your changes

`pus-nais-java-app`-imagene har ikke vært vedlikeholdt på en stund, så derfor bumper vi til `poao-baseimages`-image.

Dette skal ikke medføre noen endringer for applikasjonen, med unntak av det faktum at `poao-baseimages`ikke har enablet AppDynamics. Applikasjonen vil derfor slutte å rapportere metrikker dit. AppDynamics er derimot ikke støttet i GCP og har EOL ved utgangen av 2024, så dette er noe vi uansett må kvitte oss med.

## Trello ticket number and link

## Type of change

Please delete options that are not relevant.

- [X] Maintenance (non-breaking maintenance change)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
