### PR TITLE
Legg til workflow for scanning av Docker image

### DIFF
--- a/.github/workflows/docker-image-vulnerability-scan.yaml
+++ b/.github/workflows/docker-image-vulnerability-scan.yaml
@@ -1,0 +1,53 @@
+name: Scan and report Docker image vulnerabilities
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}/veilarbportefolje
+  IMAGE_TAG: ${{ github.sha }}
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+
+jobs:
+  build-and-scan-docker-image:
+    name: Build and scan Docker image
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build maven artifacts
+        run: mvn -Dgithub.token=${{ secrets.GITHUB_TOKEN }} -B package -D skipTests
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: ${{ env.IMAGE }}:${{ env.IMAGE_TAG }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ env.IMAGE }}:${{ env.IMAGE_TAG }}'
+          format: 'sarif'
+          output: 'trivy.sarif'
+          severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+
+      - name: Upload results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy.sarif'


### PR DESCRIPTION
## Describe your changes

Legge til workflow som bygger og scanner Docker-image nattlig vha. aquasecurity/trivy.
Resultatet vil lastes opp til GitHub Advanced Security og kan sees under ["Security/Code scanning"](https://github.com/navikt/veilarbportefolje/security/code-scanning).

Inspirasjon er hentet fra [NAV Security Playbook](https://sikkerhet.nav.no/docs/verktoy/trivy).

## Trello ticket number and link

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
