### PR TITLE
Endepunkt for lesing av fargekategori

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriController.java
@@ -36,7 +36,7 @@ public class FargekategoriController {
         // TODO autentisering
 
         try {
-            Optional<FargekategoriEntity> kanskjeFargekategori = fargekategoriService.hentFargekategoriForBruker(request, innloggetVeileder);
+            Optional<FargekategoriEntity> kanskjeFargekategori = fargekategoriService.hentFargekategoriForBruker(request);
 
             return kanskjeFargekategori.map(ResponseEntity::ok).orElseThrow();
         } catch (Exception e) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriController.java
@@ -32,6 +32,7 @@ public class FargekategoriController {
         VeilederId innloggetVeileder = AuthUtils.getInnloggetVeilederIdent();
 
         // TODO validering
+        validerRequest(request.fnr);
 
         // TODO autentisering
 
@@ -51,7 +52,7 @@ public class FargekategoriController {
     @PutMapping("/fargekategori")
     public ResponseEntity<FargekategoriResponse> oppdaterFargekategoriForBruker(@RequestBody OppdaterFargekategoriRequest request) {
         VeilederId innloggetVeileder = AuthUtils.getInnloggetVeilederIdent();
-        validerRequest(request);
+        validerRequest(request.fnr);
 
         Optional<NavKontor> brukerEnhet = brukerServiceV2.hentNavKontor(request.fnr);
 
@@ -77,8 +78,8 @@ public class FargekategoriController {
         }
     }
 
-    private static void validerRequest(OppdaterFargekategoriRequest request) {
-        if (!Fnr.isValid(request.fnr().get())) {
+    private static void validerRequest(Fnr fnr) {
+        if (!Fnr.isValid(fnr.get())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Ugyldig fnr");
         }
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriController.java
@@ -10,10 +10,7 @@ import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.service.BrukerServiceV2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
@@ -29,6 +26,27 @@ public class FargekategoriController {
     private final FargekategoriService fargekategoriService;
     private final AuthService authService;
     private final BrukerServiceV2 brukerServiceV2;
+
+    @PostMapping("/hent-fargekategori")
+    public ResponseEntity<FargekategoriEntity> hentFargekategoriForBruker(@RequestBody HentFargekategoriRequest request) {
+        VeilederId innloggetVeileder = AuthUtils.getInnloggetVeilederIdent();
+
+        // TODO validering
+
+        // TODO autentisering
+
+        try {
+            Optional<FargekategoriEntity> kanskjeFargekategori = fargekategoriService.hentFargekategoriForBruker(request, innloggetVeileder);
+
+            return kanskjeFargekategori.map(ResponseEntity::ok).orElseThrow();
+        } catch (Exception e) {
+            String melding = String.format("Klarte ikke å hente fargekategori for fnr %s", request.fnr.get());
+            secureLog.error(melding, e);
+
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+    }
 
     @PutMapping("/fargekategori")
     public ResponseEntity<FargekategoriResponse> oppdaterFargekategoriForBruker(@RequestBody OppdaterFargekategoriRequest request) {
@@ -63,6 +81,9 @@ public class FargekategoriController {
         if (!Fnr.isValid(request.fnr().get())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Ugyldig fnr");
         }
+    }
+
+    public record HentFargekategoriRequest(Fnr fnr) {
     }
 
     public record FargekategoriResponse(UUID id) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriController.java
@@ -1,6 +1,7 @@
 package no.nav.pto.veilarbportefolje.fargekategori;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.vavr.control.Validation;
 import lombok.RequiredArgsConstructor;
 import no.nav.common.types.identer.Fnr;
 import no.nav.pto.veilarbportefolje.auth.AuthService;
@@ -40,7 +41,6 @@ public class FargekategoriController {
         authService.tilgangTilBruker(request.fnr.get());
         authService.tilgangTilEnhet(brukerEnhet.get().toString());
 
-
         try {
             Optional<FargekategoriEntity> kanskjeFargekategori = fargekategoriService.hentFargekategoriForBruker(request);
 
@@ -67,7 +67,11 @@ public class FargekategoriController {
         authService.tilgangTilOppfolging();
         authService.tilgangTilBruker(request.fnr.get());
         authService.tilgangTilEnhet(brukerEnhet.get().toString());
-        // TODO berre "tildelt veileder" skal kunne redigere
+        Validation<String, Fnr> erVeilederForBrukerValidation = fargekategoriService.erVeilederForBruker(request.fnr.get());
+
+        if (erVeilederForBrukerValidation.isInvalid()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Bruker er ikke tilordnet veileder");
+        }
 
         try {
             Optional<UUID> fargekategoriId = fargekategoriService.oppdaterFargekategoriForBruker(request, innloggetVeileder);

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriEntity.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriEntity.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 public record FargekategoriEntity(
         UUID id,
         Fnr fnr,
-        FargekategoriVerdi verdi,
+        FargekategoriVerdi fargekategoriVerdi,
         ZonedDateTime sistEndret,
         NavIdent sistEndretAvVeilederIdent
 ) {}

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriEntity.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriEntity.java
@@ -3,13 +3,13 @@ package no.nav.pto.veilarbportefolje.fargekategori;
 import no.nav.common.types.identer.Fnr;
 import no.nav.common.types.identer.NavIdent;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import java.util.UUID;
 
 public record FargekategoriEntity(
         UUID id,
         Fnr fnr,
         FargekategoriVerdi fargekategoriVerdi,
-        ZonedDateTime sistEndret,
+        LocalDate sistEndret,
         NavIdent endretAv
 ) {}

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriEntity.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriEntity.java
@@ -11,5 +11,5 @@ public record FargekategoriEntity(
         Fnr fnr,
         FargekategoriVerdi fargekategoriVerdi,
         ZonedDateTime sistEndret,
-        NavIdent sistEndretAvVeilederIdent
+        NavIdent endretAv
 ) {}

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriMapper.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriMapper.java
@@ -1,0 +1,26 @@
+package no.nav.pto.veilarbportefolje.fargekategori;
+
+import lombok.SneakyThrows;
+import no.nav.common.types.identer.Fnr;
+import no.nav.common.types.identer.NavIdent;
+
+import java.sql.ResultSet;
+import java.util.UUID;
+
+import static no.nav.pto.veilarbportefolje.database.PostgresTable.FARGEKATEGORI.*;
+import static no.nav.pto.veilarbportefolje.util.DateUtils.toZonedDateTime;
+
+public class FargekategoriMapper {
+    private FargekategoriMapper() {}
+
+    @SneakyThrows
+    public static FargekategoriEntity fargekategoriMapper(ResultSet rs) {
+        return new FargekategoriEntity(
+                UUID.fromString(rs.getString(ID)),
+                Fnr.of(rs.getString(FNR)),
+                FargekategoriVerdi.valueOf(rs.getString(VERDI)),
+                toZonedDateTime(rs.getTimestamp(SIST_ENDRET)),
+                NavIdent.of(rs.getString(SIST_ENDRET_AV_VEILEDERIDENT))
+        );
+    }
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriMapper.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriMapper.java
@@ -8,6 +8,7 @@ import java.sql.ResultSet;
 import java.util.UUID;
 
 import static no.nav.pto.veilarbportefolje.database.PostgresTable.FARGEKATEGORI.*;
+import static no.nav.pto.veilarbportefolje.util.DateUtils.toLocalDate;
 import static no.nav.pto.veilarbportefolje.util.DateUtils.toZonedDateTime;
 
 public class FargekategoriMapper {
@@ -19,7 +20,7 @@ public class FargekategoriMapper {
                 UUID.fromString(rs.getString(ID)),
                 Fnr.of(rs.getString(FNR)),
                 FargekategoriVerdi.valueOf(rs.getString(VERDI)),
-                toZonedDateTime(rs.getTimestamp(SIST_ENDRET)),
+                toLocalDate(rs.getTimestamp(SIST_ENDRET)),
                 NavIdent.of(rs.getString(SIST_ENDRET_AV_VEILEDERIDENT))
         );
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriRepository.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriRepository.java
@@ -31,7 +31,15 @@ public class FargekategoriRepository {
                     SET verdi=?, sist_endret=?, sist_endret_av_veilederident=?
                 """;
 
-        jdbcTemplate.update(upsertSql, UUID.randomUUID(), request.fnr().get(), request.fargekategoriVerdi().name(), sistEndret, sistEndretAv.getValue(), request.fargekategoriVerdi().name(), sistEndret, sistEndretAv.getValue());
+        jdbcTemplate.update(upsertSql,
+                UUID.randomUUID(),
+                request.fnr().get(),
+                request.fargekategoriVerdi().name(),
+                sistEndret,
+                sistEndretAv.getValue(),
+                request.fargekategoriVerdi().name(),
+                sistEndret,
+                sistEndretAv.getValue());
 
         return jdbcTemplate.queryForObject(
                 "SELECT id FROM fargekategori WHERE fnr=?",

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriRepository.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriRepository.java
@@ -10,8 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
+import static no.nav.pto.veilarbportefolje.postgres.PostgresUtils.queryForObjectOrNull;
 import static no.nav.pto.veilarbportefolje.util.DateUtils.toTimestamp;
 
 @Repository
@@ -19,6 +21,17 @@ import static no.nav.pto.veilarbportefolje.util.DateUtils.toTimestamp;
 public class FargekategoriRepository {
 
     private final JdbcTemplate jdbcTemplate;
+
+    public Optional<FargekategoriEntity> hentFargekategoriForBruker(Fnr fnr) {
+        String hentSql = "SELECT * FROM fargekategori WHERE fnr=?";
+
+        return Optional.ofNullable(queryForObjectOrNull(() ->
+                jdbcTemplate.queryForObject(
+                        hentSql,
+                        (resultSet, rowNumber) -> FargekategoriMapper.fargekategoriMapper(resultSet),
+                        fnr.get())
+        ));
+    }
 
     @Transactional
     public UUID upsertFargekateori(OppdaterFargekategoriRequest request, VeilederId sistEndretAv) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
@@ -1,15 +1,26 @@
 package no.nav.pto.veilarbportefolje.fargekategori;
 
+import io.vavr.control.Try;
+import io.vavr.control.Validation;
 import lombok.RequiredArgsConstructor;
 import no.nav.common.types.identer.AktorId;
+import no.nav.common.types.identer.Fnr;
+import no.nav.pto.veilarbportefolje.auth.AuthUtils;
+import no.nav.pto.veilarbportefolje.domene.AktorClient;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.fargekategori.FargekategoriController.OppdaterFargekategoriRequest;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository;
+import no.nav.pto.veilarbportefolje.service.BrukerServiceV2;
+import no.nav.pto.veilarbportefolje.util.ValideringsRegler;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 import java.util.UUID;
+
+import static io.vavr.control.Validation.invalid;
+import static io.vavr.control.Validation.valid;
+import static java.lang.String.format;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +29,8 @@ public class FargekategoriService {
     private final FargekategoriRepository fargekategoriRepository;
     private final PdlIdentRepository pdlIdentRepository;
     private final OpensearchIndexerV2 opensearchIndexerV2;
+    private final AktorClient aktorClient;
+    private final BrukerServiceV2 brukerServiceV2;
 
     public Optional<FargekategoriEntity> hentFargekategoriForBruker(FargekategoriController.HentFargekategoriRequest request) {
         // TODO skal vi returnere FARGEKATEGORIVERDI.INGEN_KATEGORI om vi ikkje finn kategori i databasen?
@@ -43,4 +56,36 @@ public class FargekategoriService {
         }
     }
 
+    public Validation<String, Fnr> erVeilederForBruker(String fnr) {
+        VeilederId veilederId = AuthUtils.getInnloggetVeilederIdent();
+
+        boolean erVeilederForBruker =
+                ValideringsRegler
+                        .validerFnr(fnr)
+                        .map(validFnr -> erVeilederForBruker(validFnr, veilederId))
+                        .getOrElse(false);
+
+        if (erVeilederForBruker) {
+            return valid(Fnr.ofValidFnr(fnr));
+        }
+        return invalid(format("Veileder %s er ikke veileder for bruker med fnr %s", veilederId, fnr));
+    }
+
+
+    public Boolean erVeilederForBruker(Fnr fnr, VeilederId veilederId) {
+        return hentAktorId(fnr)
+                .map(aktoerId -> erVeilederForBruker(aktoerId, veilederId))
+                .getOrElse(false);
+    }
+
+    public Boolean erVeilederForBruker(AktorId aktoerId, VeilederId veilederId) {
+        return brukerServiceV2
+                .hentVeilederForBruker(aktoerId)
+                .map(currentVeileder -> currentVeileder.equals(veilederId))
+                .orElse(false);
+    }
+
+    private Try<AktorId> hentAktorId(Fnr fnr) {
+        return Try.of(() -> aktorClient.hentAktorId(fnr));
+    }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
@@ -19,6 +19,12 @@ public class FargekategoriService {
     private final PdlIdentRepository pdlIdentRepository;
     private final OpensearchIndexerV2 opensearchIndexerV2;
 
+    public Optional<FargekategoriEntity> hentFargekategoriForBruker(FargekategoriController.HentFargekategoriRequest request, VeilederId innloggetVeileder) {
+        // TODO: iplementer denne
+
+        return Optional.empty();
+    }
+
     public Optional<UUID> oppdaterFargekategoriForBruker(OppdaterFargekategoriRequest request, VeilederId sistEndretAv) {
         if (request.fargekategoriVerdi() == FargekategoriVerdi.INGEN_KATEGORI) {
             fargekategoriRepository.deleteFargekategori(request.fnr());
@@ -36,4 +42,5 @@ public class FargekategoriService {
             return Optional.of(oppdatertKategori);
         }
     }
+
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
@@ -19,10 +19,10 @@ public class FargekategoriService {
     private final PdlIdentRepository pdlIdentRepository;
     private final OpensearchIndexerV2 opensearchIndexerV2;
 
-    public Optional<FargekategoriEntity> hentFargekategoriForBruker(FargekategoriController.HentFargekategoriRequest request, VeilederId innloggetVeileder) {
-        // TODO: iplementer denne
+    public Optional<FargekategoriEntity> hentFargekategoriForBruker(FargekategoriController.HentFargekategoriRequest request) {
+        // TODO skal vi returnere FARGEKATEGORIVERDI.INGEN_KATEGORI om vi ikkje finn kategori i databasen?
 
-        return Optional.empty();
+        return fargekategoriRepository.hentFargekategoriForBruker(request.fnr());
     }
 
     public Optional<UUID> oppdaterFargekategoriForBruker(OppdaterFargekategoriRequest request, VeilederId sistEndretAv) {

--- a/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 
 import static no.nav.pto.veilarbportefolje.database.PostgresTable.FARGEKATEGORI.*;
 import static no.nav.pto.veilarbportefolje.postgres.PostgresUtils.queryForObjectOrNull;
-import static no.nav.pto.veilarbportefolje.util.DateUtils.toTimestamp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -85,7 +84,7 @@ public class FargekategoriControllerTest {
                 {
                     "id": "$uuid",
                     "fnr": "$fnr",
-                    "verdi": "$fargekategoriVerdi",
+                    "fargekategoriVerdi": "$fargekategoriVerdi",
                     "sistEndret": "$sistEndret",
                     "sistEndretAvVeilederIdent": "$endretAvVeileder"
                 }
@@ -156,7 +155,7 @@ public class FargekategoriControllerTest {
         // id genereres så vi sjekker bare på tilstedeværelse
         assertThat(opprettetFargekategoriEntity.id()).isNotNull();
         assertThat(opprettetFargekategoriEntity.fnr()).isEqualTo(FargekategoriControllerTestConfig.TESTBRUKER_FNR);
-        assertThat(opprettetFargekategoriEntity.verdi()).isEqualTo(FargekategoriVerdi.FARGEKATEGORI_A);
+        assertThat(opprettetFargekategoriEntity.fargekategoriVerdi()).isEqualTo(FargekategoriVerdi.FARGEKATEGORI_A);
         // sistEndret genereres så vi sjekker bare på tilstedeværelse
         assertThat(opprettetFargekategoriEntity.sistEndret()).isNotNull();
         assertThat(opprettetFargekategoriEntity.sistEndretAvVeilederIdent()).isEqualTo(FargekategoriControllerTestConfig.TESTVEILEDER);
@@ -243,7 +242,7 @@ public class FargekategoriControllerTest {
         assertThat(oppdatertFargekategoriEntity.fnr()).isEqualTo(opprettetFargekategoriEntity.fnr());
         assertThat(oppdatertFargekategoriEntity.sistEndretAvVeilederIdent()).isEqualTo(opprettetFargekategoriEntity.sistEndretAvVeilederIdent());
         assertThat(oppdatertFargekategoriEntity.sistEndret()).isNotEqualTo(opprettetFargekategoriEntity.sistEndret());
-        assertThat(oppdatertFargekategoriEntity.verdi()).isEqualTo(FargekategoriVerdi.FARGEKATEGORI_B);
+        assertThat(oppdatertFargekategoriEntity.fargekategoriVerdi()).isEqualTo(FargekategoriVerdi.FARGEKATEGORI_B);
     }
 
     @Test

--- a/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
@@ -104,11 +104,6 @@ public class FargekategoriControllerTest {
     }
 
     @Test
-    void skal_ikke_kunne_hente_fargekategori_uten_riktig_autentisering() throws Exception {
-        // TODO skriv testar
-    }
-
-    @Test
     void opprettelse_av_fargekategori_skal_returnere_forventet_respons() throws Exception {
         String request = """
                 {

--- a/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
@@ -27,6 +27,7 @@ import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import static no.nav.pto.veilarbportefolje.database.PostgresTable.FARGEKATEGORI.*;
+import static no.nav.pto.veilarbportefolje.fargekategori.FargekategoriControllerTestConfig.TESTBRUKER_FNR;
 import static no.nav.pto.veilarbportefolje.postgres.PostgresUtils.queryForObjectOrNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
@@ -57,7 +58,7 @@ public class FargekategoriControllerTest {
     @Test
     void henting_av_fargekategori_skal_returnere_forventet_respons() throws Exception {
         UUID uuid = UUID.randomUUID();
-        Fnr fnr = Fnr.of("11223312345");
+        Fnr fnr = TESTBRUKER_FNR;
         FargekategoriVerdi fargekategoriVerdi = FargekategoriVerdi.FARGEKATEGORI_D;
         ZonedDateTime sistEndret = ZonedDateTime.now();
         VeilederId sistEndretAv = AuthUtils.getInnloggetVeilederIdent();
@@ -91,6 +92,7 @@ public class FargekategoriControllerTest {
                 """.replace("$uuid", uuid.toString())
                 .replace("$fnr", fnr.get())
                 .replace("$fargekategoriVerdi", fargekategoriVerdi.name())
+                // TODO Finn ein måte å unngå å sjekke dette feltet på
                 .replace("$sistEndret", sistEndret.toString().substring(0, 32)) // substring gjer at vi unngår å få med [Paris/Oslo] i strengen
                 .replace("$endretAvVeileder", sistEndretAv.getValue());
 
@@ -143,13 +145,13 @@ public class FargekategoriControllerTest {
             return jdbcTemplate.queryForObject(
                     "SELECT * FROM fargekategori WHERE fnr=?",
                     mapTilFargekategoriEntity(),
-                    FargekategoriControllerTestConfig.TESTBRUKER_FNR.get());
+                    TESTBRUKER_FNR.get());
         });
 
         assertThat(opprettetFargekategoriEntity).isNotNull();
         // id genereres så vi sjekker bare på tilstedeværelse
         assertThat(opprettetFargekategoriEntity.id()).isNotNull();
-        assertThat(opprettetFargekategoriEntity.fnr()).isEqualTo(FargekategoriControllerTestConfig.TESTBRUKER_FNR);
+        assertThat(opprettetFargekategoriEntity.fnr()).isEqualTo(TESTBRUKER_FNR);
         assertThat(opprettetFargekategoriEntity.fargekategoriVerdi()).isEqualTo(FargekategoriVerdi.FARGEKATEGORI_A);
         // sistEndret genereres så vi sjekker bare på tilstedeværelse
         assertThat(opprettetFargekategoriEntity.sistEndret()).isNotNull();
@@ -214,7 +216,7 @@ public class FargekategoriControllerTest {
             return jdbcTemplate.queryForObject(
                     "SELECT * FROM fargekategori WHERE fnr=?",
                     mapTilFargekategoriEntity(),
-                    FargekategoriControllerTestConfig.TESTBRUKER_FNR.get());
+                    TESTBRUKER_FNR.get());
         });
 
         mockMvc.perform(
@@ -228,7 +230,7 @@ public class FargekategoriControllerTest {
             return jdbcTemplate.queryForObject(
                     "SELECT * FROM fargekategori WHERE fnr=?",
                     mapTilFargekategoriEntity(),
-                    FargekategoriControllerTestConfig.TESTBRUKER_FNR.get());
+                    TESTBRUKER_FNR.get());
         });
 
         assertThat(oppdatertFargekategoriEntity).isNotNull();
@@ -303,7 +305,7 @@ public class FargekategoriControllerTest {
             return jdbcTemplate.queryForObject(
                     "SELECT * FROM fargekategori WHERE fnr=?",
                     mapTilFargekategoriEntity(),
-                    FargekategoriControllerTestConfig.TESTBRUKER_FNR.get());
+                    TESTBRUKER_FNR.get());
         });
 
         assertThat(oppdatertFargekategoriEntity).isNull();
@@ -327,10 +329,10 @@ public class FargekategoriControllerTest {
         jdbcTemplate.update("TRUNCATE fargekategori");
         jdbcTemplate.update("TRUNCATE oppfolgingsbruker_arena_v2");
 
-        testDataClient.lagreBrukerUnderOppfolging(FargekategoriControllerTestConfig.TESTBRUKER_AKTOR_ID, FargekategoriControllerTestConfig.TESTBRUKER_FNR, FargekategoriControllerTestConfig.TESTENHET, VeilederId.of(FargekategoriControllerTestConfig.TESTVEILEDER.get()));
+        testDataClient.lagreBrukerUnderOppfolging(FargekategoriControllerTestConfig.TESTBRUKER_AKTOR_ID, TESTBRUKER_FNR, FargekategoriControllerTestConfig.TESTENHET, VeilederId.of(FargekategoriControllerTestConfig.TESTVEILEDER.get()));
 
         doNothing().when(authService).tilgangTilOppfolging();
-        doNothing().when(authService).tilgangTilBruker(FargekategoriControllerTestConfig.TESTBRUKER_FNR.get());
+        doNothing().when(authService).tilgangTilBruker(TESTBRUKER_FNR.get());
         doNothing().when(authService).tilgangTilEnhet(FargekategoriControllerTestConfig.TESTENHET.getValue());
     }
 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
@@ -6,8 +6,8 @@ import no.nav.common.types.identer.NavIdent;
 import no.nav.pto.veilarbportefolje.auth.AuthService;
 import no.nav.pto.veilarbportefolje.auth.AuthUtils;
 import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest;
+import no.nav.pto.veilarbportefolje.domene.AktorClient;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
-import no.nav.pto.veilarbportefolje.util.DateUtils;
 import no.nav.pto.veilarbportefolje.util.TestDataClient;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,9 +22,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import static no.nav.pto.veilarbportefolje.database.PostgresTable.FARGEKATEGORI.*;
@@ -34,6 +32,7 @@ import static no.nav.pto.veilarbportefolje.util.DateUtils.toLocalDate;
 import static no.nav.pto.veilarbportefolje.util.DateUtils.toTimestamp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -54,6 +53,9 @@ public class FargekategoriControllerTest {
 
     @MockBean
     private AuthService authService;
+
+    @MockBean
+    private AktorClient aktorClient;
 
     @Qualifier("fargekategoriControllerTestAuthService")
     private AuthContextHolder authContextHolder;
@@ -331,8 +333,9 @@ public class FargekategoriControllerTest {
         jdbcTemplate.update("TRUNCATE fargekategori");
         jdbcTemplate.update("TRUNCATE oppfolgingsbruker_arena_v2");
 
-        testDataClient.lagreBrukerUnderOppfolging(FargekategoriControllerTestConfig.TESTBRUKER_AKTOR_ID, TESTBRUKER_FNR, FargekategoriControllerTestConfig.TESTENHET, VeilederId.of(FargekategoriControllerTestConfig.TESTVEILEDER.get()));
+        testDataClient.lagreBrukerUnderOppfolging(TESTBRUKER_AKTOR_ID, TESTBRUKER_FNR, FargekategoriControllerTestConfig.TESTENHET, VeilederId.of(FargekategoriControllerTestConfig.TESTVEILEDER.get()));
 
+        when(aktorClient.hentAktorId(TESTBRUKER_FNR)).thenReturn(TESTBRUKER_AKTOR_ID);
         doNothing().when(authService).tilgangTilOppfolging();
         doNothing().when(authService).tilgangTilBruker(TESTBRUKER_FNR.get());
         doNothing().when(authService).tilgangTilEnhet(FargekategoriControllerTestConfig.TESTENHET.getValue());

--- a/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
@@ -86,7 +86,7 @@ public class FargekategoriControllerTest {
                     "fnr": "$fnr",
                     "fargekategoriVerdi": "$fargekategoriVerdi",
                     "sistEndret": "$sistEndret",
-                    "sistEndretAvVeilederIdent": "$endretAvVeileder"
+                    "endretAv": "$endretAvVeileder"
                 }
                 """.replace("$uuid", uuid.toString())
                 .replace("$fnr", fnr.get())
@@ -158,7 +158,7 @@ public class FargekategoriControllerTest {
         assertThat(opprettetFargekategoriEntity.fargekategoriVerdi()).isEqualTo(FargekategoriVerdi.FARGEKATEGORI_A);
         // sistEndret genereres så vi sjekker bare på tilstedeværelse
         assertThat(opprettetFargekategoriEntity.sistEndret()).isNotNull();
-        assertThat(opprettetFargekategoriEntity.sistEndretAvVeilederIdent()).isEqualTo(FargekategoriControllerTestConfig.TESTVEILEDER);
+        assertThat(opprettetFargekategoriEntity.endretAv()).isEqualTo(FargekategoriControllerTestConfig.TESTVEILEDER);
     }
 
     @Test
@@ -240,7 +240,7 @@ public class FargekategoriControllerTest {
         assertThat(opprettetFargekategoriEntity).isNotNull();
         assertThat(oppdatertFargekategoriEntity.id()).isEqualTo(opprettetFargekategoriEntity.id());
         assertThat(oppdatertFargekategoriEntity.fnr()).isEqualTo(opprettetFargekategoriEntity.fnr());
-        assertThat(oppdatertFargekategoriEntity.sistEndretAvVeilederIdent()).isEqualTo(opprettetFargekategoriEntity.sistEndretAvVeilederIdent());
+        assertThat(oppdatertFargekategoriEntity.endretAv()).isEqualTo(opprettetFargekategoriEntity.endretAv());
         assertThat(oppdatertFargekategoriEntity.sistEndret()).isNotEqualTo(opprettetFargekategoriEntity.sistEndret());
         assertThat(oppdatertFargekategoriEntity.fargekategoriVerdi()).isEqualTo(FargekategoriVerdi.FARGEKATEGORI_B);
     }

--- a/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
@@ -23,12 +23,15 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import static no.nav.pto.veilarbportefolje.database.PostgresTable.FARGEKATEGORI.*;
 import static no.nav.pto.veilarbportefolje.fargekategori.FargekategoriControllerTestConfig.TESTBRUKER_FNR;
 import static no.nav.pto.veilarbportefolje.postgres.PostgresUtils.queryForObjectOrNull;
+import static no.nav.pto.veilarbportefolje.util.DateUtils.toLocalDate;
+import static no.nav.pto.veilarbportefolje.util.DateUtils.toTimestamp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -60,7 +63,7 @@ public class FargekategoriControllerTest {
         UUID uuid = UUID.randomUUID();
         Fnr fnr = TESTBRUKER_FNR;
         FargekategoriVerdi fargekategoriVerdi = FargekategoriVerdi.FARGEKATEGORI_D;
-        ZonedDateTime sistEndret = ZonedDateTime.now();
+        LocalDate sistEndret = LocalDate.now();
         VeilederId sistEndretAv = AuthUtils.getInnloggetVeilederIdent();
 
         String request = """
@@ -78,7 +81,7 @@ public class FargekategoriControllerTest {
                             uuid,
                             fnr.get(),
                             fargekategoriVerdi.name(),
-                            Timestamp.from(sistEndret.toInstant()),
+                            toTimestamp(sistEndret),
                             sistEndretAv.getValue());
 
         String expected = """
@@ -92,8 +95,7 @@ public class FargekategoriControllerTest {
                 """.replace("$uuid", uuid.toString())
                 .replace("$fnr", fnr.get())
                 .replace("$fargekategoriVerdi", fargekategoriVerdi.name())
-                // TODO Finn ein måte å unngå å sjekke dette feltet på
-                .replace("$sistEndret", sistEndret.toString().substring(0, 32)) // substring gjer at vi unngår å få med [Paris/Oslo] i strengen
+                .replace("$sistEndret", sistEndret.toString())
                 .replace("$endretAvVeileder", sistEndretAv.getValue());
 
         mockMvc.perform(
@@ -317,7 +319,7 @@ public class FargekategoriControllerTest {
                 UUID.fromString(resultSet.getString(ID)),
                 Fnr.of(resultSet.getString(FNR)),
                 FargekategoriVerdi.valueOf(resultSet.getString(VERDI)),
-                DateUtils.toZonedDateTime(resultSet.getTimestamp(SIST_ENDRET)),
+                toLocalDate(resultSet.getTimestamp(SIST_ENDRET)),
                 NavIdent.of(resultSet.getString(SIST_ENDRET_AV_VEILEDERIDENT))
         );
     }

--- a/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
@@ -104,6 +104,11 @@ public class FargekategoriControllerTest {
     }
 
     @Test
+    void skal_ikke_kunne_hente_fargekategori_uten_riktig_autentisering() throws Exception {
+        // TODO skriv testar
+    }
+
+    @Test
     void opprettelse_av_fargekategori_skal_returnere_forventet_respons() throws Exception {
         String request = """
                 {

--- a/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
@@ -26,6 +26,7 @@ import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
+import static no.nav.pto.veilarbportefolje.database.PostgresTable.FARGEKATEGORI.*;
 import static no.nav.pto.veilarbportefolje.postgres.PostgresUtils.queryForObjectOrNull;
 import static no.nav.pto.veilarbportefolje.util.DateUtils.toTimestamp;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -317,11 +318,11 @@ public class FargekategoriControllerTest {
     @NotNull
     private static RowMapper<FargekategoriEntity> mapTilFargekategoriEntity() {
         return (resultSet, rowNum) -> new FargekategoriEntity(
-                UUID.fromString(resultSet.getString("id")),
-                Fnr.of(resultSet.getString("fnr")),
-                FargekategoriVerdi.valueOf(resultSet.getString("verdi")),
-                DateUtils.toZonedDateTime(resultSet.getTimestamp("sist_endret")),
-                NavIdent.of(resultSet.getString("sist_endret_av_veilederident"))
+                UUID.fromString(resultSet.getString(ID)),
+                Fnr.of(resultSet.getString(FNR)),
+                FargekategoriVerdi.valueOf(resultSet.getString(VERDI)),
+                DateUtils.toZonedDateTime(resultSet.getTimestamp(SIST_ENDRET)),
+                NavIdent.of(resultSet.getString(SIST_ENDRET_AV_VEILEDERIDENT))
         );
     }
 


### PR DESCRIPTION
## Describe your changes
Legg til endepunkt for å hente fargekategori for brukar.

Endepunktet er `POST /api/v1/hent-fargekategori`.
Responsen er på forma
```json
{
    "id": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
    "fnr": "DDMMYYXXXXX",
    "fargekategoriVerdi": "FARGEKATEGORI_A",
    "sistEndret": "[zoned-date-time]",
    "endretAv": "Z123456"
}
```


Vi har også fiksa autoriseringa av endring-av-fargekategori slik at det berre er tilordna veileder som har lov til å gjere det.


## Trello ticket number and link
TC-540 https://trello.com/c/kgjomKiP/540-endepunkt-for-%C3%A5-lese-fargekategori


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
