### PR TITLE
Få med endringsinfo på huskelapp inn i opensearch

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/database/PostgresTable.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/database/PostgresTable.java
@@ -35,6 +35,8 @@ public class PostgresTable {
 
         public static final String HL_FRIST = "HL_FRIST";
         public static final String HL_KOMMENTAR = "HL_KOMMENTAR";
+        public static final String HL_ENDRET_DATO = "HL_ENDRET_DATO";
+        public static final String HL_ENDRET_AV = "HL_ENDRET_AV";
 
         public static final String BRUKERS_SITUASJON = "BRUKERS_SITUASJON";
         public static final String UTDANNING = "UTDANNING";

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/HuskelappForBruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/HuskelappForBruker.java
@@ -6,7 +6,9 @@ import java.time.LocalDate;
 
 public record HuskelappForBruker(
     LocalDate frist,
-    String kommentar
+    String kommentar,
+    LocalDate endretDato,
+    String endretAv
 ) {
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public HuskelappForBruker {

--- a/src/main/java/no/nav/pto/veilarbportefolje/huskelapp/HuskelappService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/huskelapp/HuskelappService.java
@@ -16,6 +16,7 @@ import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository;
 import no.nav.pto.veilarbportefolje.service.BrukerServiceV2;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -38,12 +39,12 @@ public class HuskelappService {
             UUID huskelappId = huskelappRepository.opprettHuskelapp(huskelappOpprettRequest, veilederId);
 
             AktorId aktorId = hentAktorId(huskelappOpprettRequest.brukerFnr()).orElseThrow(RuntimeException::new);
-            opensearchIndexerV2.updateHuskelapp(aktorId, new HuskelappForBruker(huskelappOpprettRequest.frist(), huskelappOpprettRequest.kommentar()));
+            opensearchIndexerV2.updateHuskelapp(aktorId, new HuskelappForBruker(huskelappOpprettRequest.frist(), huskelappOpprettRequest.kommentar(), LocalDate.now(), veilederId.getValue()));
 
             return huskelappId;
         } catch (Exception e) {
-            secureLog.error("Kunne ikke opprette huskelapp for fnr: " + huskelappOpprettRequest.brukerFnr());
-            throw new RuntimeException("Kunne ikke opprette huskelapp", e);
+            secureLog.error("Kunne ikke opprette huskelapp for fnr: " + huskelappOpprettRequest.brukerFnr(), e);
+            throw new RuntimeException("Kunne ikke opprette huskelapp");
         }
     }
 
@@ -52,11 +53,11 @@ public class HuskelappService {
             huskelappRepository.redigerHuskelapp(huskelappRedigerRequest, veilederId);
 
             AktorId aktorId = hentAktorId(huskelappRedigerRequest.brukerFnr()).orElseThrow(RuntimeException::new);
-            opensearchIndexerV2.updateHuskelapp(aktorId, new HuskelappForBruker(huskelappRedigerRequest.frist(), huskelappRedigerRequest.kommentar()));
+            opensearchIndexerV2.updateHuskelapp(aktorId, new HuskelappForBruker(huskelappRedigerRequest.frist(), huskelappRedigerRequest.kommentar(), LocalDate.now(), veilederId.getValue()));
 
         } catch (Exception e) {
-            secureLog.error("Kunne ikke redigere huskelapp for fnr: " + huskelappRedigerRequest.brukerFnr() + " HuskelappId: " + huskelappRedigerRequest.huskelappId().toString());
-            throw new RuntimeException("Kunne ikke redigere huskelapp", e);
+            secureLog.error("Kunne ikke redigere huskelapp for fnr: " + huskelappRedigerRequest.brukerFnr() + " HuskelappId: " + huskelappRedigerRequest.huskelappId().toString(), e);
+            throw new RuntimeException("Kunne ikke redigere huskelapp");
         }
     }
 
@@ -64,8 +65,8 @@ public class HuskelappService {
         try {
             return huskelappRepository.hentAktivHuskelapp(enhetId, veilederId);
         } catch (Exception e) {
-            secureLog.error("Kunne ikke hente huskelapper for enhet: " + enhetId + ", og veileder: " + veilederId);
-            throw new RuntimeException("Kunne ikke hente huskelapper", e);
+            secureLog.error("Kunne ikke hente huskelapper for enhet: " + enhetId + ", og veileder: " + veilederId, e);
+            throw new RuntimeException("Kunne ikke hente huskelapper");
         }
     }
 
@@ -73,7 +74,7 @@ public class HuskelappService {
         try {
             return huskelappRepository.hentAktivHuskelapp(huskelappId);
         } catch (Exception e) {
-            secureLog.error("Kunne ikke hente huskelapp for id: " + huskelappId + "Stacktrace: " + e.getCause());
+            secureLog.error("Kunne ikke hente huskelapp for id: " + huskelappId + "Stacktrace: " + e.getCause(), e);
             throw new RuntimeException("Kunne ikke hente huskelapp");
         }
     }
@@ -82,8 +83,8 @@ public class HuskelappService {
         try {
             return huskelappRepository.hentAktivHuskelapp(brukerFnr);
         } catch (Exception e) {
-            secureLog.error("Kunne ikke hente huskelapp for bruker: " + brukerFnr);
-            throw new RuntimeException("Kunne ikke hente huskelapp", e);
+            secureLog.error("Kunne ikke hente huskelapp for bruker: " + brukerFnr, e);
+            throw new RuntimeException("Kunne ikke hente huskelapp");
         }
     }
 
@@ -94,8 +95,8 @@ public class HuskelappService {
             AktorId aktorId = hentAktorId(brukerFnr).orElseThrow(RuntimeException::new);
             opensearchIndexerV2.slettHuskelapp(aktorId);
         } catch (Exception e) {
-            secureLog.error("Kunne ikke sette huskelapp til inaktiv for bruker: " + brukerFnr);
-            throw new RuntimeException("Kunne ikke inaktivere huskelapp", e);
+            secureLog.error("Kunne ikke sette huskelapp til inaktiv for bruker: " + brukerFnr, e);
+            throw new RuntimeException("Kunne ikke inaktivere huskelapp");
         }
     }
 
@@ -145,7 +146,4 @@ public class HuskelappService {
         return Optional.ofNullable(pdlIdentRepository.hentAktorId(fnr));
     }
 
-    private Optional<Fnr> hentFnr(AktorId aktorId) {
-        return Optional.ofNullable(pdlIdentRepository.hentFnr(aktorId));
-    }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
@@ -99,6 +99,8 @@ public class OpensearchIndexerV2 {
                 .startObject("huskelapp")
                 .field("frist", huskelapp.frist())
                 .field("kommentar", huskelapp.kommentar())
+                .field("endretAv", huskelapp.endretAv())
+                .field("endretDato", huskelapp.endretDato())
                 .endObject()
                 .endObject();
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteMapper;
 import no.nav.pto.veilarbportefolje.domene.HuskelappForBruker;
+import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.kodeverk.KodeverkService;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OppfolgingsBruker;
 import no.nav.pto.veilarbportefolje.persononinfo.personopprinelse.Landgruppe;
@@ -72,7 +73,9 @@ public class BrukerRepositoryV2 {
                                ARB.NAV_KONTOR_FOR_ARBEIDSLISTE  as ARB_NAV_KONTOR_FOR_ARBEIDSLISTE,
                                FAR.verdi                        as FAR_VERDI,
                                HL.frist							as HL_FRIST,
-                               HL.kommentar						as HL_KOMMENTAR
+                               HL.kommentar						as HL_KOMMENTAR,
+                               HL.endret_dato                   as HL_ENDRET_DATO,
+                               hl.endret_av_veileder            as HL_ENDRET_AV
                         FROM OPPFOLGING_DATA OD
                                 inner join aktive_identer ai on OD.aktoerid = ai.aktorid
                                  left join oppfolgingsbruker_arena_v2 ob on ob.fodselsnr = ai.fnr
@@ -223,8 +226,10 @@ public class BrukerRepositoryV2 {
     private void setHuskelapp(OppfolgingsBruker oppfolgingsBruker, ResultSet rs) {
         LocalDate frist = toLocalDate(rs.getTimestamp(HL_FRIST));
         String kommentar = rs.getString(HL_KOMMENTAR);
+        LocalDate endretDato = toLocalDate(rs.getTimestamp(HL_ENDRET_DATO));
+        VeilederId endretAv = VeilederId.veilederIdOrNull(rs.getString(HL_ENDRET_AV));
         if (frist != null || kommentar != null) {
-            oppfolgingsBruker.setHuskelapp(new HuskelappForBruker(frist, kommentar));
+            oppfolgingsBruker.setHuskelapp(new HuskelappForBruker(frist, kommentar, endretDato, endretAv.getValue()));
         }
     }
 

--- a/src/main/resources/opensearch_settings.json
+++ b/src/main/resources/opensearch_settings.json
@@ -251,6 +251,12 @@
           },
           "frist": {
             "type": "date"
+          },
+          "endretDato": {
+            "type": "date"
+          },
+          "endretAv": {
+            "type": "keyword"
           }
         }
       }

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -556,7 +556,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setOppfolging(true)
                 .setEnhet_id(TEST_ENHET)
                 .setVeileder_id(TEST_VEILEDER_0)
-                .setHuskelapp(new HuskelappForBruker(LocalDate.now(), "test huskelapp"));
+                .setHuskelapp(new HuskelappForBruker(LocalDate.now(), "test huskelapp", LocalDate.now(), TEST_VEILEDER_0));
 
         var testBruker2 = new OppfolgingsBruker()
                 .setAktoer_id(randomAktorId().toString())
@@ -3775,10 +3775,10 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
 
     @Test
     public void test_sortering_huskelapp() {
-        var huskelapp1 = new HuskelappForBruker(LocalDate.now().plusDays(20), "dddd Ringe fastlege");
-        var huskelapp2 = new HuskelappForBruker(LocalDate.now().plusDays(30), "bbbb Ha et møte");
-        var huskelapp3 = new HuskelappForBruker(LocalDate.now().plusMonths(2), "aaaa Snakke om idrett");
-        var huskelapp4 = new HuskelappForBruker(LocalDate.now().plusDays(3), "cccc Huddle med Julie");
+        var huskelapp1 = new HuskelappForBruker(LocalDate.now().plusDays(20), "dddd Ringe fastlege", LocalDate.now(), TEST_VEILEDER_0);
+        var huskelapp2 = new HuskelappForBruker(LocalDate.now().plusDays(30), "bbbb Ha et møte", LocalDate.now(), TEST_VEILEDER_0);
+        var huskelapp3 = new HuskelappForBruker(LocalDate.now().plusMonths(2), "aaaa Snakke om idrett", LocalDate.now(), TEST_VEILEDER_0);
+        var huskelapp4 = new HuskelappForBruker(LocalDate.now().plusDays(3), "cccc Huddle med Julie", LocalDate.now(), TEST_VEILEDER_0);
 
         var bruker1 = new OppfolgingsBruker()
                 .setFnr(randomFnr().toString())


### PR DESCRIPTION
## Describe your changes
For at veileder ikke skal se en oppdatering på huskelapp ved at vi først viser huskelapp, men så må vente på et kall fra backend før "endret av og endre dato" blir satt på huskelappen tar vi det med fra opensearch så vi slepper den ventingen.

## Trello ticket number and link
549: https://trello.com/c/yquSiYjU/549-legge-ved-endretav-og-endretdato-til-huskelapp-i-opensearch
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
