### PR TITLE
Oppdater fargekategori-felt i OpenSearch ved modifikasjon av Arbeidsliste

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
@@ -61,7 +61,10 @@ public class ArbeidslisteService {
         dto.setNavKontorForArbeidsliste(navKontorForBruker.getValue());
 
         return arbeidslisteRepositoryV2.insertArbeidsliste(dto)
-                .onSuccess(opensearchIndexerV2::updateArbeidsliste);
+                .onSuccess((result) -> {
+                    opensearchIndexerV2.updateArbeidsliste(result);
+                    opensearchIndexerV2.updateFargekategori(result.getAktorId(), ArbeidslisteMapper.mapTilFargekategoriVerdi(result.kategori));
+                });
     }
 
     public Try<ArbeidslisteDTO> updateArbeidsliste(ArbeidslisteDTO data) {
@@ -72,7 +75,10 @@ public class ArbeidslisteService {
         data.setAktorId(aktoerId.get());
 
         return arbeidslisteRepositoryV2.updateArbeidsliste(data)
-                .onSuccess(opensearchIndexerV2::updateArbeidsliste);
+                .onSuccess((result) -> {
+                    opensearchIndexerV2.updateArbeidsliste(result);
+                    opensearchIndexerV2.updateFargekategori(result.getAktorId(), ArbeidslisteMapper.mapTilFargekategoriVerdi(result.kategori));
+                });
     }
 
     public void slettArbeidsliste(Fnr fnr) {
@@ -93,6 +99,7 @@ public class ArbeidslisteService {
         }
 
         opensearchIndexerV2.slettArbeidsliste(aktoerId);
+        opensearchIndexerV2.slettFargekategori(aktoerId);
     }
 
     private Try<AktorId> hentAktorId(Fnr fnr) {


### PR DESCRIPTION
## Describe your changes

Fikser en bug der `fargekategori`-feltet i OpenSearch ikke ble oppdatert når en arbeidsliste ble opprettet/oppdatert/slettet. Vi er nødt å gjøre denne synkroniseringen frem til arebeidslista fases ut.

## Trello ticket number and link

[TC-562](https://trello.com/c/m7Yu0eRb/562-m%C3%A5-indeksere-oppdatere-fargekategori-i-opensearch-n%C3%A5r-arbeidsliste-oppdateres)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
