### PR TITLE
Oppdatert Oppdaterfargekategori-responseobjektet til å inneholde fagrekategori of fnr i steden for uuid

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriRepository.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriRepository.java
@@ -38,7 +38,7 @@ public class FargekategoriRepository {
     }
 
     @Transactional
-    public UUID upsertFargekateori(OppdaterFargekategoriRequest request, VeilederId sistEndretAv) {
+    public FargekategoriEntity upsertFargekateori(OppdaterFargekategoriRequest request, VeilederId sistEndretAv) {
         Timestamp sistEndret = toTimestamp(ZonedDateTime.now());
 
         String upsertSql = """
@@ -59,8 +59,8 @@ public class FargekategoriRepository {
                 sistEndretAv.getValue());
 
         return jdbcTemplate.queryForObject(
-                "SELECT id FROM fargekategori WHERE fnr=?",
-                (resultSet, rowNum) -> UUID.fromString(resultSet.getString("id")),
+                "SELECT * FROM fargekategori WHERE fnr=?",
+                (resultSet, rowNum) -> FargekategoriMapper.fargekategoriMapper(resultSet),
                 request.fnr().get()
         );
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
@@ -38,7 +38,7 @@ public class FargekategoriService {
         return fargekategoriRepository.hentFargekategoriForBruker(request.fnr());
     }
 
-    public Optional<UUID> oppdaterFargekategoriForBruker(OppdaterFargekategoriRequest request, VeilederId sistEndretAv) {
+    public Optional<FargekategoriEntity> oppdaterFargekategoriForBruker(OppdaterFargekategoriRequest request, VeilederId sistEndretAv) {
         if (request.fargekategoriVerdi() == FargekategoriVerdi.INGEN_KATEGORI) {
             fargekategoriRepository.deleteFargekategori(request.fnr());
 
@@ -46,7 +46,7 @@ public class FargekategoriService {
 
             return Optional.empty();
         } else {
-            UUID oppdatertKategori = fargekategoriRepository.upsertFargekateori(request, sistEndretAv);
+            FargekategoriEntity oppdatertKategori = fargekategoriRepository.upsertFargekateori(request, sistEndretAv);
 
             oppdaterIOpensearch(request.fnr(), request.fargekategoriVerdi());
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
@@ -8,6 +8,7 @@ import no.nav.pto.veilarbportefolje.auth.AuthUtils;
 import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest;
 import no.nav.pto.veilarbportefolje.domene.AktorClient;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
+import no.nav.pto.veilarbportefolje.huskelapp.controller.dto.HuskelappResponse;
 import no.nav.pto.veilarbportefolje.util.TestDataClient;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +29,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static no.nav.common.json.JsonUtils.fromJson;
 import static no.nav.pto.veilarbportefolje.database.PostgresTable.FARGEKATEGORI.*;
 import static no.nav.pto.veilarbportefolje.fargekategori.FargekategoriControllerTestConfig.*;
 import static no.nav.pto.veilarbportefolje.postgres.PostgresUtils.queryForObjectOrNull;
@@ -148,7 +150,7 @@ public class FargekategoriControllerTest {
                 .andExpect(status().is(200))
                 .andReturn().getResponse().getContentAsString();
 
-        assertThat(responseJson.contains("\"id\":")).isTrue();
+        assertThat(responseJson.contains("{\"fnr\":\"11111111111\",\"fargekategoriVerdi\":\"FARGEKATEGORI_A\"}")).isTrue();
     }
 
     @Test
@@ -199,6 +201,8 @@ public class FargekategoriControllerTest {
                 }
                 """;
 
+
+
         String opprettJson = mockMvc.perform(
                         put("/api/v1/fargekategori")
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -206,14 +210,16 @@ public class FargekategoriControllerTest {
                 )
                 .andExpect(status().is(200))
                 .andReturn().getResponse().getContentAsString();
+        assertThat(opprettJson).isEqualTo("{\"fnr\":\"11111111111\",\"fargekategoriVerdi\":\"FARGEKATEGORI_A\"}");
 
-        mockMvc.perform(
+        String resultatAvOppdatering = mockMvc.perform(
                         put("/api/v1/fargekategori")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(oppdaterRequest)
                 )
                 .andExpect(status().is(200))
-                .andExpect(content().json(opprettJson));
+                .andReturn().getResponse().getContentAsString();
+        assertThat(resultatAvOppdatering).isEqualTo("{\"fnr\":\"11111111111\",\"fargekategoriVerdi\":\"FARGEKATEGORI_B\"}");
     }
 
     @Test
@@ -288,6 +294,7 @@ public class FargekategoriControllerTest {
                   "fargekategoriVerdi":"INGEN_KATEGORI"
                 }
                 """;
+        String expectedResponse = "{\"fnr\":\"11111111111\",\"fargekategoriVerdi\":\"INGEN_KATEGORI\"}";
 
         mockMvc.perform(
                         put("/api/v1/fargekategori")
@@ -296,12 +303,13 @@ public class FargekategoriControllerTest {
                 )
                 .andExpect(status().is(200));
 
-        mockMvc.perform(
+        String result = mockMvc.perform(
                         put("/api/v1/fargekategori")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(slettRequest)
-                )
-                .andExpect(status().is(204));
+                ).andReturn().getResponse().getContentAsString();
+
+        assertThat(result).isEqualTo(expectedResponse);
     }
 
     @Test
@@ -318,7 +326,7 @@ public class FargekategoriControllerTest {
                   "fargekategoriVerdi":"INGEN_KATEGORI"
                 }
                 """;
-
+        String expectedResponse = "{\"fnr\":\"11111111111\",\"fargekategoriVerdi\":\"INGEN_KATEGORI\"}";
         mockMvc.perform(
                         put("/api/v1/fargekategori")
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -326,12 +334,12 @@ public class FargekategoriControllerTest {
                 )
                 .andExpect(status().is(200));
 
-        mockMvc.perform(
+        String result = mockMvc.perform(
                         put("/api/v1/fargekategori")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(slettRequest)
-                )
-                .andExpect(status().is(204));
+                ).andExpect(status().is(200)).andReturn().getResponse().getContentAsString();
+        assertThat(result).isEqualTo(expectedResponse);
 
         FargekategoriEntity oppdatertFargekategoriEntity = queryForObjectOrNull(() -> {
             return jdbcTemplate.queryForObject(


### PR DESCRIPTION
## Describe your changes
Endrer responseobjektet `FargekategoriResponse` for å kunne ta i bruk doThenDispatch-funksjonen i frontenden for fargekategorier.

## Trello ticket number and link

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
