### PR TITLE
Gå mot GCP-instans av kodeverk

### DIFF
--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -99,6 +99,6 @@ spec:
     - name: POAO_TILGANG_TOKEN_SCOPE
       value: "api://dev-fss.poao.poao-tilgang/.default"
     - name: KODEVERK_URL
-      value: "http://kodeverk.team-rocket.svc.nais.local"
+      value: "https://kodeverk-api.nav.no"
     - name: KODEVERK_SCOPE
-      value: "api://dev-fss.team-rocket.kodeverk/.default"
+      value: "api://dev-gcp.team-rocket.kodeverk-api/.default"

--- a/.nais/application/application-config-prod.yaml
+++ b/.nais/application/application-config-prod.yaml
@@ -101,6 +101,6 @@ spec:
     - name: POAO_TILGANG_TOKEN_SCOPE
       value: "api://prod-fss.poao.poao-tilgang/.default"
     - name: KODEVERK_URL
-      value: "http://kodeverk.team-rocket.svc.nais.local"
+      value: "https://kodeverk-api.nav.no"
     - name: KODEVERK_SCOPE
-      value: "api://prod-fss.team-rocket.kodeverk/.default"
+      value: "api://prod-gcp.team-rocket.kodeverk-api/.default"


### PR DESCRIPTION
## Describe your changes

Rundt 1. april skrur Team Rocket av FSS-instansen av kodeverk, vi må derfor bytte over til GCP (`kodeverk-api`).

## Trello ticket number and link

n/a

## Type of change

Please delete options that are not relevant.

- [X] Maintenance

## Checklist before requesting a review
- [X] I have performed a self-review of my code
