### PR TITLE
Utvider responseobjekt til batchupdate å inneholde fargekategoriVerdi

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriController.java
@@ -94,7 +94,7 @@ public class FargekategoriController {
         authService.innloggetVeilederHarTilgangTilOppfolging();
 
         BatchUpsertResponse responseEtterValidering = validerRequest(request);
-        if (responseEtterValidering.errors.size() > 0) {
+        if (!responseEtterValidering.errors.isEmpty()) {
             return ResponseEntity.status(400).body(responseEtterValidering);
         }
 
@@ -112,7 +112,7 @@ public class FargekategoriController {
                     request.fnr);
             secureLog.error(melding, e);
 
-            return ResponseEntity.internalServerError().body(new BatchUpsertResponse(Collections.emptyList(), request.fnr));
+            return ResponseEntity.internalServerError().body(new BatchUpsertResponse(Collections.emptyList(), request.fnr, request.fargekategoriVerdi));
         }
     }
 
@@ -130,7 +130,7 @@ public class FargekategoriController {
             }
         });
 
-        return new BatchUpsertResponse(sjekkGikkOK.stream().toList(), sjekkFeilet.stream().toList());
+        return new BatchUpsertResponse(sjekkGikkOK.stream().toList(), sjekkFeilet.stream().toList(), request.fargekategoriVerdi);
     }
 
     private BatchUpsertResponse sjekkVeilederautorisering(BatchoppdaterFargekategoriRequest request) {
@@ -166,7 +166,7 @@ public class FargekategoriController {
             }
         });
 
-        return new BatchUpsertResponse(sjekkGikkOK.stream().toList(), sjekkFeilet.stream().toList());
+        return new BatchUpsertResponse(sjekkGikkOK.stream().toList(), sjekkFeilet.stream().toList(), request.fargekategoriVerdi);
     }
 
     private static void validerRequest(Fnr fnr) {
@@ -197,6 +197,6 @@ public class FargekategoriController {
         public BatchoppdaterFargekategoriRequest {}
     }
 
-    public record BatchUpsertResponse(List<Fnr> data, List<Fnr> errors) {
+    public record BatchUpsertResponse(List<Fnr> data, List<Fnr> errors, FargekategoriVerdi fargekategoriVerdi) {
     }
 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriControllerTest.java
@@ -364,6 +364,7 @@ public class FargekategoriControllerTest {
                 {
                     "data": ["11111111111","22222222222","33333333333"],
                     "errors": [],
+                    "fargekategoriVerdi":"FARGEKATEGORI_B"
                 }
                 """;
 


### PR DESCRIPTION
## Describe your changes
For at det skal gå mer smertefritt i frontend utvider vi responseobjektet til fargekategorier med selvefargekategorien.
## Trello ticket number and link

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
