### PR TITLE
Pdl exception

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlService.java
@@ -9,7 +9,6 @@ import no.nav.pto.veilarbportefolje.persononinfo.barnUnder18Aar.BarnUnder18AarSe
 import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLIdent;
 import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLPerson;
 import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLPersonBarn;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,7 +26,7 @@ public class PdlService {
 
     private final BarnUnder18AarService barnUnder18AarService;
     private final PdlPortefoljeClient pdlClient;
-    
+
     public void hentOgLagrePdlData(AktorId aktorId) {
         List<PDLIdent> identer = hentOgLagreIdenter(aktorId);
         Fnr fnr = hentAktivFnr(identer);
@@ -41,6 +40,7 @@ public class PdlService {
             lagreBrukerData(fnrPerson, personData);
         } catch (Exception e) {
             secureLog.error("Kan ikke lagre bruker data for person: " + fnrPerson, e);
+            throw new RuntimeException("Kunne ikke hente data fra PDL", e);
         }
     }
 


### PR DESCRIPTION
## Describe your changes

In some cases we get timeout from PDL when we are asking for their data, and that error can influence that user doesnt have name in our db, and that will cause further errors in frontend application. 

Since this function is mostly called when we get `oppfolging start `kafka message , solution is to throw exception if we cant get Pdl data, and to try to process that kafka message in a few minutes again (this is built in mechanisam in our kafka library).

## Trello ticket number and link

n/a

## Type of change

Please delete options that are not relevant.

[ ✔️ ] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [✔️] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
