### PR TITLE
TC-578 Hent initiell oppfolgingsbruker-data ved start oppfølging + ignorer melding om endring på oppfølgingsbruker for brukere som ikke er under oppfølging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,10 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.4.0-b180830.0359</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
         <!-- database -->
         <dependency>
             <groupId>com.zaxxer</groupId>

--- a/src/main/java/no/nav/pto/veilarbportefolje/config/ClientConfig.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/config/ClientConfig.java
@@ -32,6 +32,7 @@ import static no.nav.common.utils.NaisUtils.getCredentials;
 @Configuration
 public class ClientConfig {
 
+    static final String APPLICATION_NAME = "veilarbportefolje";
     @Bean
     public PoaoTilgangWrapper poaoTilgangWrapper(AuthContextHolder authContextHolder, AzureAdMachineToMachineTokenClient tokenClient, EnvironmentProperties environmentProperties) {
         return new PoaoTilgangWrapper(authContextHolder, tokenClient, environmentProperties);
@@ -104,7 +105,8 @@ public class ClientConfig {
         return new VeilarbarenaClient(
                 environmentProperties.getVeilarbarenaUrl(),
                 tokenSupplier,
-                RestClient.baseClient()
+                RestClient.baseClient(),
+                APPLICATION_NAME
         );
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
@@ -68,12 +68,12 @@ public class FargekategoriService {
     }
 
     private void slettIOpensearch(Fnr fnr) {
-        AktorId aktorId = Optional.ofNullable(pdlIdentRepository.hentAktorId(fnr)).orElseThrow(RuntimeException::new);
+        AktorId aktorId = Optional.ofNullable(pdlIdentRepository.hentAktorIdForAktivBruker(fnr)).orElseThrow(RuntimeException::new);
         opensearchIndexerV2.slettFargekategori(aktorId);
     }
 
     private void oppdaterIOpensearch(Fnr fnr, FargekategoriVerdi fargekategoriVerdi) {
-        AktorId aktorId = Optional.ofNullable(pdlIdentRepository.hentAktorId(fnr)).orElseThrow(RuntimeException::new);
+        AktorId aktorId = Optional.ofNullable(pdlIdentRepository.hentAktorIdForAktivBruker(fnr)).orElseThrow(RuntimeException::new);
         opensearchIndexerV2.updateFargekategori(aktorId, fargekategoriVerdi.name());
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import static io.vavr.control.Validation.invalid;
 import static io.vavr.control.Validation.valid;

--- a/src/main/java/no/nav/pto/veilarbportefolje/huskelapp/HuskelappService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/huskelapp/HuskelappService.java
@@ -143,7 +143,7 @@ public class HuskelappService {
     }
 
     private Optional<AktorId> hentAktorId(Fnr fnr) {
-        return Optional.ofNullable(pdlIdentRepository.hentAktorId(fnr));
+        return Optional.ofNullable(pdlIdentRepository.hentAktorIdForAktivBruker(fnr));
     }
 
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/huskelapp/controller/HuskelappController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/huskelapp/controller/HuskelappController.java
@@ -133,7 +133,7 @@ public class HuskelappController {
     }
 
     private Optional<AktorId> hentAktorId(Fnr fnr) {
-        return Optional.ofNullable(pdlIdentRepository.hentAktorId(fnr));
+        return Optional.ofNullable(pdlIdentRepository.hentAktorIdForAktivBruker(fnr));
     }
 
     private void validerOppfolgingOgBrukerOgEnhet(String fnr, String enhetId) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingAvsluttetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingAvsluttetService.java
@@ -44,7 +44,7 @@ public class OppfolgingAvsluttetService {
     private final FargekategoriService fargekategoriService;
 
     public void avsluttOppfolging(AktorId aktoerId) {
-        Optional<Fnr> maybeFnr = Optional.ofNullable(pdlIdentRepository.hentFnr(aktoerId));
+        Optional<Fnr> maybeFnr = Optional.ofNullable(pdlIdentRepository.hentFnrForAktivBruker(aktoerId));
 
         oppfolgingRepositoryV2.slettOppfolgingData(aktoerId);
         registreringService.slettRegistering(aktoerId);

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingAvsluttetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingAvsluttetService.java
@@ -7,7 +7,6 @@ import no.nav.common.types.identer.Fnr;
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteService;
 import no.nav.pto.veilarbportefolje.cv.CVRepositoryV2;
 import no.nav.pto.veilarbportefolje.ensligforsorger.EnsligeForsorgereService;
-import no.nav.pto.veilarbportefolje.fargekategori.FargekategoriRepository;
 import no.nav.pto.veilarbportefolje.fargekategori.FargekategoriService;
 import no.nav.pto.veilarbportefolje.huskelapp.HuskelappService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
@@ -30,6 +30,13 @@ public class OppfolgingStartetService {
         oppfolgingRepositoryV2.settUnderOppfolging(aktorId, oppfolgingStartetDate);
 
         siste14aVedtakService.hentOgLagreSiste14aVedtak(aktorId);
+
+        // TODO: Håndtere identer; hva hvis aktorId er historisk?
+        //  Dette er et litt søkt scenario, men teoretisk sett kan en ident (her gitt ved aktorId-argumentet)
+        //  bli satt som historisk før linjen under blir utført (fordi di vi lever i en multi-trådet verden osv.)
+        //  Dersom man skal hesynta dette kan det være interessant å få litt innsikt i hvordan dette skjer, og
+        //  eventuelt hvor vanlig det er med historiske Aktør-IDer
+        //  Dersom det viser seg at Aktør-IDer aldri blir historiske, kan dette ignoreres.
         oppfolgingsbrukerServiceV2.hentOgLagreOppfolgingsbruker(aktorId);
 
         opensearchIndexer.indekser(aktorId);

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
+import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerServiceV2;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlService;
 import no.nav.pto.veilarbportefolje.siste14aVedtak.Siste14aVedtakService;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,7 @@ public class OppfolgingStartetService {
     private final OpensearchIndexer opensearchIndexer;
     private final PdlService pdlService;
     private final Siste14aVedtakService siste14aVedtakService;
+    private final OppfolgingsbrukerServiceV2 oppfolgingsbrukerServiceV2;
 
     public void startOppfolging(AktorId aktorId, ZonedDateTime oppfolgingStartetDate) {
         pdlService.hentOgLagrePdlData(aktorId);
@@ -28,8 +30,10 @@ public class OppfolgingStartetService {
         oppfolgingRepositoryV2.settUnderOppfolging(aktorId, oppfolgingStartetDate);
 
         siste14aVedtakService.hentOgLagreSiste14aVedtak(aktorId);
+        oppfolgingsbrukerServiceV2.hentOgLagreOppfolgingsbruker(aktorId);
 
         opensearchIndexer.indekser(aktorId);
         secureLog.info("Bruker {} har startet oppfølging: {}", aktorId, oppfolgingStartetDate);
     }
+
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
@@ -24,6 +24,10 @@ public class OppfolgingStartetService {
     private final Siste14aVedtakService siste14aVedtakService;
     private final OppfolgingsbrukerServiceV2 oppfolgingsbrukerServiceV2;
 
+        // TODO: Dersom en eller flere av disse operasjonene feiler og kaster exception vil
+        //  kafka-meldingen bli lagret og retryet. Dette kan resultere i at vi mellomlagrer data
+        //  vi ikke skal. Mulig vi burde wrappe dette i en try-catch slik at vi kan rydde opp
+        //  i catch-en.
     public void startOppfolging(AktorId aktorId, ZonedDateTime oppfolgingStartetDate) {
         pdlService.hentOgLagrePdlData(aktorId);
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
@@ -28,23 +28,17 @@ public class OppfolgingStartetService {
         //  kafka-meldingen bli lagret og retryet. Dette kan resultere i at vi mellomlagrer data
         //  vi ikke skal. Mulig vi burde wrappe dette i en try-catch slik at vi kan rydde opp
         //  i catch-en.
+        //  Dette vil også muligens bidra til å gjøre usikkerheten rundt hvordan vi håndterer
+        //  scenarier der AktorID/Fnr blir historisk før startOppfolging fullfører.
     public void startOppfolging(AktorId aktorId, ZonedDateTime oppfolgingStartetDate) {
         pdlService.hentOgLagrePdlData(aktorId);
 
         oppfolgingRepositoryV2.settUnderOppfolging(aktorId, oppfolgingStartetDate);
 
         siste14aVedtakService.hentOgLagreSiste14aVedtak(aktorId);
-
-        // TODO: Håndtere identer; hva hvis aktorId er historisk?
-        //  Dette er et litt søkt scenario, men teoretisk sett kan en ident (her gitt ved aktorId-argumentet)
-        //  bli satt som historisk før linjen under blir utført (fordi di vi lever i en multi-trådet verden osv.)
-        //  Dersom man skal hesynta dette kan det være interessant å få litt innsikt i hvordan dette skjer, og
-        //  eventuelt hvor vanlig det er med historiske Aktør-IDer
-        //  Dersom det viser seg at Aktør-IDer aldri blir historiske, kan dette ignoreres.
         oppfolgingsbrukerServiceV2.hentOgLagreOppfolgingsbruker(aktorId);
 
         opensearchIndexer.indekser(aktorId);
         secureLog.info("Bruker {} har startet oppfølging: {}", aktorId, oppfolgingStartetDate);
     }
-
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetService.java
@@ -47,7 +47,7 @@ public class VeilederTilordnetService extends KafkaCommonConsumerService<Veilede
         secureLog.info("Oppdatert bruker: {}, til veileder med id: {}", aktoerId, veilederId);
 
         final boolean harByttetNavKontor = arbeidslisteService.brukerHarByttetNavKontor(aktoerId);
-        Optional<Fnr> maybeFnr = Optional.ofNullable(pdlIdentRepository.hentFnr(aktoerId));
+        Optional<Fnr> maybeFnr = Optional.ofNullable(pdlIdentRepository.hentFnrForAktivBruker(aktoerId));
         if (harByttetNavKontor) {
             arbeidslisteService.slettArbeidsliste(aktoerId, maybeFnr);
         }

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerServiceV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerServiceV2.java
@@ -9,6 +9,7 @@ import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository;
+import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLIdent;
 import no.nav.pto.veilarbportefolje.service.BrukerServiceV2;
 import no.nav.pto.veilarbportefolje.vedtakstotte.Kafka14aStatusendring;
 import no.nav.pto.veilarbportefolje.vedtakstotte.Utkast14aStatusRepository;
@@ -20,7 +21,9 @@ import org.springframework.stereotype.Service;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static no.nav.pto.veilarbportefolje.config.FeatureToggle.brukOppfolgingsbrukerPaPostgres;
 import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
@@ -83,8 +86,7 @@ public class OppfolgingsbrukerServiceV2 extends KafkaCommonConsumerService<Endri
     }
 
     public void hentOgLagreOppfolgingsbruker(AktorId aktorId) {
-        Fnr fnr = brukerServiceV2.hentFnr(aktorId)
-                .orElseThrow(() -> new RuntimeException("Fant ikke fnr for aktorId: " + aktorId));
+        Fnr fnr = pdlIdentRepository.hentFnrForAktivBruker(aktorId);
 
         OppfolgingsbrukerDTO oppfolgingsbrukerDTO = veilarbarenaClient.hentOppfolgingsbruker(fnr)
                 .orElseThrow(() -> new RuntimeException("Fant ikke oppfolgingsbruker for fnr: " + fnr));

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerServiceV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerServiceV2.java
@@ -28,7 +28,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Service
 @RequiredArgsConstructor
 public class OppfolgingsbrukerServiceV2 extends KafkaCommonConsumerService<EndringPaaOppfoelgingsBrukerV2> {
-    private final OppfolgingsbrukerRepositoryV3 oppfolgingsbrukerRepository;
+    private final OppfolgingsbrukerRepositoryV3 oppfolgingsbrukerRepositoryV3;
     private final BrukerServiceV2 brukerServiceV2;
     private final OpensearchIndexerV2 opensearchIndexerV2;
     private final OpensearchIndexer opensearchIndexer;
@@ -42,13 +42,15 @@ public class OppfolgingsbrukerServiceV2 extends KafkaCommonConsumerService<Endri
                 .orElse(null);
 
         OppfolgingsbrukerEntity oppfolgingsbruker = new OppfolgingsbrukerEntity(
-                kafkaMelding.getFodselsnummer(), kafkaMelding.getFormidlingsgruppe().name(),
+                kafkaMelding.getFodselsnummer(),
+                kafkaMelding.getFormidlingsgruppe().name(),
                 iservDato,
-                kafkaMelding.getOppfolgingsenhet(), Optional.ofNullable(kafkaMelding.getKvalifiseringsgruppe()).map(Kvalifiseringsgruppe::name).orElse(null),
+                kafkaMelding.getOppfolgingsenhet(),
+                Optional.ofNullable(kafkaMelding.getKvalifiseringsgruppe()).map(Kvalifiseringsgruppe::name).orElse(null),
                 Optional.ofNullable(kafkaMelding.getRettighetsgruppe()).map(Rettighetsgruppe::name).orElse(null),
                 Optional.ofNullable(kafkaMelding.getHovedmaal()).map(Hovedmaal::name).orElse(null),
                 kafkaMelding.getSistEndretDato());
-        oppfolgingsbrukerRepository.leggTilEllerEndreOppfolgingsbruker(oppfolgingsbruker);
+        oppfolgingsbrukerRepositoryV3.leggTilEllerEndreOppfolgingsbruker(oppfolgingsbruker);
 
         brukerServiceV2.hentAktorId(Fnr.of(kafkaMelding.getFodselsnummer()))
                 .ifPresent(id -> {

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClient.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClient.kt
@@ -20,7 +20,8 @@ import java.util.function.Supplier
 class VeilarbarenaClient(
     private val url: String,
     private val tokenSupplier: Supplier<String>,
-    private val client: OkHttpClient
+    private val client: OkHttpClient,
+    private val consumerId: String
 ) {
     companion object {
         // Objectmapperen i common-java-modules har p.t ikke mulighet til å konfigureres. Vi trenger å registrere jackson-kotlin-module for at deserialisering skal fungere med kotlin.
@@ -41,6 +42,7 @@ class VeilarbarenaClient(
         val request: Request = Request.Builder()
             .url(joinPaths(url, "/api/v3/hent-oppfolgingsbruker"))
             .header(HttpHeaders.AUTHORIZATION, tokenSupplier.get())
+            .header("Nav-Consumer-Id", consumerId)
             .post(toJsonRequestBody(HentOppfolgingsbrukerRequest(fnr)))
             .build()
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClient.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClient.kt
@@ -41,7 +41,7 @@ class VeilarbarenaClient(
     fun hentOppfolgingsbruker(fnr: Fnr): Optional<OppfolgingsbrukerDTO> {
         val request: Request = Request.Builder()
             .url(joinPaths(url, "/api/v3/hent-oppfolgingsbruker"))
-            .header(HttpHeaders.AUTHORIZATION, tokenSupplier.get())
+            .header(HttpHeaders.AUTHORIZATION, "Bearer ${tokenSupplier.get()}")
             .header("Nav-Consumer-Id", consumerId)
             .post(toJsonRequestBody(HentOppfolgingsbrukerRequest(fnr)))
             .build()

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClient.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClient.kt
@@ -45,7 +45,6 @@ class VeilarbarenaClient(
     }
 }
 
-
 data class OppfolgingsbrukerDTO(
     val fodselsnr: String? = null,
     val formidlingsgruppekode: String? = null,

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClient.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClient.kt
@@ -51,6 +51,8 @@ data class OppfolgingsbrukerDTO(
     val formidlingsgruppekode: String? = null,
     @get:JsonProperty("nav_kontor")
     val navKontor: String? = null,
+    @get:JsonProperty("iserv_fra_dato")
+    val iservFraDato: ZonedDateTime? = null,
     val kvalifiseringsgruppekode: String? = null,
     val rettighetsgruppekode: String? = null,
     val hovedmaalkode: String? = null,

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClient.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClient.kt
@@ -23,7 +23,7 @@ class VeilarbarenaClient(
 
     fun hentOppfolgingsbruker(fnr: Fnr): Optional<OppfolgingsbrukerDTO> {
         val request: Request = Request.Builder()
-            .url(joinPaths(url, "/api/v2/hent-oppfolgingsbruker"))
+            .url(joinPaths(url, "/api/v3/hent-oppfolgingsbruker"))
             .header(HttpHeaders.AUTHORIZATION, tokenSupplier.get())
             .post(toJsonRequestBody(HentOppfolgingsbrukerRequest(fnr)))
             .build()
@@ -49,25 +49,18 @@ class VeilarbarenaClient(
 data class OppfolgingsbrukerDTO(
     val fodselsnr: String? = null,
     val formidlingsgruppekode: String? = null,
-    @get:JsonProperty("nav_kontor")
     val navKontor: String? = null,
-    @get:JsonProperty("iserv_fra_dato")
     val iservFraDato: ZonedDateTime? = null,
     val kvalifiseringsgruppekode: String? = null,
     val rettighetsgruppekode: String? = null,
     val hovedmaalkode: String? = null,
-    @get:JsonProperty("sikkerhetstiltak_type_kode")
     val sikkerhetstiltakTypeKode: String? = null,
-    @get:JsonProperty("fr_kode")
     val frKode: String? = null,
-    @get:JsonProperty("har_oppfolgingssak")
     val harOppfolgingssak: Boolean? = null,
-    @get:JsonProperty("sperret_ansatt")
     val sperretAnsatt: Boolean? = null,
-    @get:JsonProperty("er_doed")
     val erDoed: Boolean? = null,
-    @get:JsonProperty("doed_fra_dato")
-    val doedFraDato: ZonedDateTime? = null
+    val doedFraDato: ZonedDateTime? = null,
+    val sistEndretDato: ZonedDateTime? = null
 )
 
 data class HentOppfolgingsbrukerRequest(val fnr: Fnr)

--- a/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepository.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepository.java
@@ -92,19 +92,33 @@ public class PdlIdentRepository {
                 .stream().map(rs -> (String) rs.get("person")).toList();
     }
 
-    public Fnr hentFnr(AktorId aktorId) {
+    /**
+     * Henter fnr for en aktiv bruker/ident. Dvs. det må eksistere en aktiv {@code fnr<-->aktorId} mapping for brukeren.
+     * Denne metoden vil f.eks. returnere {@code null} dersom {@code bruker} er en historisk aktorId.
+     *
+     * @param bruker {@code AktorId} for brukeren
+     * @return {@code Fnr} for brukeren, eller {@code null} hvis brukeren ikke er aktiv
+     */
+    public Fnr hentFnrForAktivBruker(AktorId bruker) {
         return queryForObjectOrNull(
                 () -> db.queryForObject("select fnr from aktive_identer where aktorid = ?",
                         (rs, i) -> Optional.ofNullable(rs.getString("fnr")).map(Fnr::of).orElse(null),
-                        aktorId.get()
+                        bruker.get()
                 ));
     }
 
-    public AktorId hentAktorId(Fnr fnr) {
+    /**
+     * Henter aktorId for en aktiv bruker/ident. Dvs. det må eksistere en aktiv {@code fnr<-->aktorId} mapping for brukeren.
+     * Denne metoden vil f.eks. returnere {@code null} dersom {@code bruker} er et historisk fnr.
+     *
+     * @param bruker {@code Fnr} for brukeren
+     * @return {@code AktorId} for brukeren, eller {@code null} hvis brukeren ikke er aktiv
+     */
+    public AktorId hentAktorIdForAktivBruker(Fnr bruker) {
         return queryForObjectOrNull(
                 () -> db.queryForObject("select aktorid from aktive_identer where fnr = ?",
                         (rs, i) -> Optional.ofNullable(rs.getString("aktorid")).map(AktorId::of).orElse(null),
-                        fnr.get())
+                        bruker.get())
         );
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/service/BrukerServiceV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/service/BrukerServiceV2.java
@@ -22,15 +22,15 @@ public class BrukerServiceV2 {
     private final OppfolgingRepositoryV2 oppfolgingRepositoryV2;
 
     public Optional<AktorId> hentAktorId(Fnr fnr) {
-        return Optional.ofNullable(pdlIdentRepository.hentAktorId(fnr));
+        return Optional.ofNullable(pdlIdentRepository.hentAktorIdForAktivBruker(fnr));
     }
 
     public Optional<Fnr> hentFnr(AktorId aktorId) {
-        return Optional.ofNullable(pdlIdentRepository.hentFnr(aktorId));
+        return Optional.ofNullable(pdlIdentRepository.hentFnrForAktivBruker(aktorId));
     }
 
     public Optional<NavKontor> hentNavKontor(AktorId aktoerId) {
-        Fnr fnr = pdlIdentRepository.hentFnr(aktoerId);
+        Fnr fnr = pdlIdentRepository.hentFnrForAktivBruker(aktoerId);
         return hentNavKontor(fnr);
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/siste14aVedtak/Siste14aVedtakService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/siste14aVedtak/Siste14aVedtakService.java
@@ -35,7 +35,7 @@ public class Siste14aVedtakService extends KafkaCommonConsumerService<Siste14aVe
     }
 
     public void hentOgLagreSiste14aVedtak(AktorId aktorId) {
-        Fnr fnr = pdlIdentRepository.hentFnr(aktorId);
+        Fnr fnr = pdlIdentRepository.hentFnrForAktivBruker(aktorId);
 
         vedtaksstotteClient.hentSiste14aVedtak(fnr)
                 .map(siste14aVedtak -> Siste14aVedtak.fraApiDto(siste14aVedtak, aktorId.get()))

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterOpensearchIntegrasjonTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterOpensearchIntegrasjonTest.java
@@ -309,7 +309,7 @@ public class AktiviteterOpensearchIntegrasjonTest extends EndToEndTest {
     }
 
     private void settSperretAnsatt(AktorId aktorId, NavKontor navKontor) {
-        Fnr fnr = pdlIdentRepository.hentFnr(aktorId);
+        Fnr fnr = pdlIdentRepository.hentFnrForAktivBruker(aktorId);
         oppfolgingsbrukerRepository.leggTilEllerEndreOppfolgingsbruker(
                 new OppfolgingsbrukerEntity(fnr.get(), null, null,
                         navKontor.getValue(),  null, null,

--- a/src/test/java/no/nav/pto/veilarbportefolje/config/ApplicationConfigTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/config/ApplicationConfigTest.java
@@ -43,6 +43,7 @@ import no.nav.pto.veilarbportefolje.opensearch.domene.OpensearchClientConfig;
 import no.nav.pto.veilarbportefolje.oppfolging.*;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerRepositoryV3;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerServiceV2;
+import no.nav.pto.veilarbportefolje.oppfolgingsbruker.VeilarbarenaClient;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlPersonRepository;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlPortefoljeClient;
@@ -350,5 +351,8 @@ public class ApplicationConfigTest {
         return poaoTilgangWrapper;
     }
 
-
+    @Bean
+    public VeilarbarenaClient veilarbarenaClient() {
+        return mock(VeilarbarenaClient.class);
+    }
 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/config/ApplicationConfigTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/config/ApplicationConfigTest.java
@@ -41,6 +41,7 @@ import no.nav.pto.veilarbportefolje.mock.MetricsClientMock;
 import no.nav.pto.veilarbportefolje.opensearch.*;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OpensearchClientConfig;
 import no.nav.pto.veilarbportefolje.oppfolging.*;
+import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerDTO;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerRepositoryV3;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerServiceV2;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.VeilarbarenaClient;
@@ -91,6 +92,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static no.nav.common.utils.IdUtils.generateId;
@@ -353,6 +355,8 @@ public class ApplicationConfigTest {
 
     @Bean
     public VeilarbarenaClient veilarbarenaClient() {
-        return mock(VeilarbarenaClient.class);
+        VeilarbarenaClient veilarbarenaClientMock = mock(VeilarbarenaClient.class);
+        when(veilarbarenaClientMock.hentOppfolgingsbruker(any())).thenReturn(Optional.of(mock(OppfolgingsbrukerDTO.class)));
+        return veilarbarenaClientMock;
     }
 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetOgAvsluttetServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetOgAvsluttetServiceTest.java
@@ -183,17 +183,7 @@ class OppfolgingStartetOgAvsluttetServiceTest extends EndToEndTest {
 
     @Test
     void når_oppfolging_startes_skal_oppfolgingsbrukerdata_hentes_og_oppdateres_naar_vi_har_oppfolgingsbruker_data_fra_foer() {
-        OppfolgingsbrukerEntity oppfolgingsbruker = new OppfolgingsbrukerEntity(
-                fnr.get(),
-                Formidlingsgruppe.ARBS.name(),
-                null,
-                "1234",
-                Kvalifiseringsgruppe.BATT.name(),
-                null,
-                Hovedmaal.BEHOLDEA.name(),
-                ZonedDateTime.parse("2024-04-04T00:00:00+02:00").minusDays(2)
-        );
-        oppfolgingsbrukerRepositoryV3.leggTilEllerEndreOppfolgingsbruker(oppfolgingsbruker);
+        insertOppfolgingsbrukerEntity(ZonedDateTime.parse("2024-04-04T00:00:00+02:00").minusDays(2));
 
         mockPdlIdenterRespons(aktorId, fnr);
         mockPdlPersonRespons(fnr);
@@ -210,17 +200,7 @@ class OppfolgingStartetOgAvsluttetServiceTest extends EndToEndTest {
 
     @Test
     void når_oppfolging_startes_skal_oppfolgingsbrukerdata_hentes_og_ignoreres_naar_vi_har_oppfolgingsbruker_data_fra_foer() {
-        OppfolgingsbrukerEntity oppfolgingsbruker = new OppfolgingsbrukerEntity(
-                fnr.get(),
-                Formidlingsgruppe.ARBS.name(),
-                null,
-                "1234",
-                Kvalifiseringsgruppe.BATT.name(),
-                null,
-                Hovedmaal.BEHOLDEA.name(),
-                ZonedDateTime.parse("2024-04-04T00:00:00+02:00").plusDays(2)
-        );
-        oppfolgingsbrukerRepositoryV3.leggTilEllerEndreOppfolgingsbruker(oppfolgingsbruker);
+        insertOppfolgingsbrukerEntity(ZonedDateTime.parse("2024-04-04T00:00:00+02:00").plusDays(2));
 
         mockPdlIdenterRespons(aktorId, fnr);
         mockPdlPersonRespons(fnr);
@@ -382,5 +362,19 @@ class OppfolgingStartetOgAvsluttetServiceTest extends EndToEndTest {
         String file = readFileAsJsonString("/oppfolgingsbruker.json", getClass());
         OppfolgingsbrukerDTO oppfolgingsbrukerDTO = JsonUtils.fromJson(file, OppfolgingsbrukerDTO.class);
         when(veilarbarenaClient.hentOppfolgingsbruker(fnr)).thenReturn(Optional.of(oppfolgingsbrukerDTO));
+    }
+
+    private void insertOppfolgingsbrukerEntity(ZonedDateTime endret_dato) {
+        OppfolgingsbrukerEntity oppfolgingsbruker = new OppfolgingsbrukerEntity(
+                fnr.get(),
+                Formidlingsgruppe.ARBS.name(),
+                null,
+                "1234",
+                Kvalifiseringsgruppe.BATT.name(),
+                null,
+                Hovedmaal.BEHOLDEA.name(),
+                endret_dato
+        );
+        oppfolgingsbrukerRepositoryV3.leggTilEllerEndreOppfolgingsbruker(oppfolgingsbruker);
     }
 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerServiceV2Test.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerServiceV2Test.java
@@ -1,8 +1,10 @@
 package no.nav.pto.veilarbportefolje.oppfolgingsbruker;
 
+import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
 import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest;
 import no.nav.pto.veilarbportefolje.util.DateUtils;
+import no.nav.pto.veilarbportefolje.util.EndToEndTest;
 import no.nav.pto_schema.enums.arena.Formidlingsgruppe;
 import no.nav.pto_schema.enums.arena.Hovedmaal;
 import no.nav.pto_schema.enums.arena.Kvalifiseringsgruppe;
@@ -19,16 +21,17 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
+import static no.nav.pto.veilarbportefolje.util.TestDataUtils.randomAktorId;
 import static no.nav.pto.veilarbportefolje.util.TestDataUtils.randomFnr;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@SpringBootTest(classes = ApplicationConfigTest.class)
-public class OppfolgingsbrukerServiceV2Test {
+public class OppfolgingsbrukerServiceV2Test extends EndToEndTest {
     private final JdbcTemplate db;
     private final OppfolgingsbrukerServiceV2 oppfolginsbrukerService;
     private final OppfolgingsbrukerRepositoryV3 oppfolgingsbrukerRepositoryV3;
     private final Fnr fnr = randomFnr();
+    private final AktorId aktorId = randomAktorId();
 
     @Autowired
     public OppfolgingsbrukerServiceV2Test(JdbcTemplate db, OppfolgingsbrukerServiceV2 oppfolginsbrukerService, OppfolgingsbrukerRepositoryV3 oppfolgingsbrukerRepositoryV3) {
@@ -45,12 +48,22 @@ public class OppfolgingsbrukerServiceV2Test {
 
 
     @Test
-    public void skalKonsumereOgLagreData() {
+    public void skalKonsumereOgLagreDataNaarBrukerErUnderOppfolging() {
+        insertOppfolgingsInformasjon(aktorId, fnr);
+
         LocalDate iserv_fra_dato = ZonedDateTime.now().minusDays(2).toLocalDate();
         ZonedDateTime endret_dato = DateUtils.now();
 
-        OppfolgingsbrukerEntity forventetResultat = new OppfolgingsbrukerEntity(fnr.get(), "RARBS", ZonedDateTime.of(iserv_fra_dato.atStartOfDay(), ZoneId.systemDefault()),
-                 "007", "BKART", "AAP", "SKAFFEA", endret_dato);
+        OppfolgingsbrukerEntity forventetResultat = new OppfolgingsbrukerEntity(
+                fnr.get(),
+                "RARBS",
+                ZonedDateTime.of(iserv_fra_dato.atStartOfDay(), ZoneId.systemDefault()),
+                "007",
+                "BKART",
+                "AAP",
+                "SKAFFEA",
+                endret_dato
+        );
 
         EndringPaaOppfoelgingsBrukerV2 kafkaMelding = EndringPaaOppfoelgingsBrukerV2.builder().fodselsnummer(fnr.get()).formidlingsgruppe(Formidlingsgruppe.RARBS).iservFraDato(iserv_fra_dato)
                 .oppfolgingsenhet("007").kvalifiseringsgruppe(Kvalifiseringsgruppe.BKART).rettighetsgruppe(Rettighetsgruppe.AAP).hovedmaal(Hovedmaal.SKAFFEA)
@@ -63,7 +76,9 @@ public class OppfolgingsbrukerServiceV2Test {
     }
 
     @Test
-    public void skalKonsumereData() {
+    public void skalKonsumereDataNaarBrukerErUnderOppfolging() {
+        insertOppfolgingsInformasjon(aktorId, fnr);
+
         ZonedDateTime endret_dato = DateUtils.now();
 
         EndringPaaOppfoelgingsBrukerV2 kafkaMelding = EndringPaaOppfoelgingsBrukerV2.builder().fodselsnummer(fnr.get()).formidlingsgruppe(Formidlingsgruppe.ARBS).iservFraDato(null)

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClientTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClientTest.kt
@@ -24,7 +24,8 @@ class VeilarbarenaClientTest {
         val client = VeilarbarenaClient(
             "http://localhost:" + wireMockRule.port(),
             { "TOKEN" },
-            RestClient.baseClient()
+            RestClient.baseClient(),
+            "veilarbportefolje"
         )
 
         val responseBody = """
@@ -83,7 +84,8 @@ class VeilarbarenaClientTest {
         val client = VeilarbarenaClient(
             "http://localhost:" + wireMockRule.port(),
             { "TOKEN" },
-            RestClient.baseClient()
+            RestClient.baseClient(),
+            "veilarbportefolje"
         )
 
         WireMock.givenThat(
@@ -106,7 +108,8 @@ class VeilarbarenaClientTest {
         val client = VeilarbarenaClient(
             "http://localhost:" + wireMockRule.port(),
             { "TOKEN" },
-            RestClient.baseClient()
+            RestClient.baseClient(),
+            "veilarbportefolje"
         )
 
         WireMock.givenThat(

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClientTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClientTest.kt
@@ -31,22 +31,23 @@ class VeilarbarenaClientTest {
                     {
                       "fodselsnr": "17858998980",
                       "formidlingsgruppekode": "ARBS",
-                      "iserv_fra_dato": "2024-04-04T00:00:00+02:00",
-                      "nav_kontor": "0220",
+                      "iservFraDato": "2024-04-04T00:00:00+02:00",
+                      "navKontor": "0220",
                       "kvalifiseringsgruppekode": "BATT",
                       "rettighetsgruppekode": "INDS",
                       "hovedmaalkode": "SKAFFEA",
-                      "sikkerhetstiltak_type_kode": "TFUS",
-                      "fr_kode": "6",
-                      "har_oppfolgingssak": true,
-                      "sperret_ansatt": false,
-                      "er_doed": false,
-                      "doed_fra_dato": null
+                      "sikkerhetstiltakTypeKode": "TFUS",
+                      "frKode": "6",
+                      "harOppfolgingssak": true,
+                      "sperretAnsatt": false,
+                      "erDoed": false,
+                      "doedFraDato": null,
+                      "sistEndretDato": "2024-04-04T00:00:00+02:00"
                     }
                 """.trimIndent()
 
         WireMock.givenThat(
-            WireMock.post(WireMock.urlEqualTo("/api/v2/hent-oppfolgingsbruker")).withRequestBody(
+            WireMock.post(WireMock.urlEqualTo("/api/v3/hent-oppfolgingsbruker")).withRequestBody(
                 WireMock.equalToJson(
                     "{\"fnr\":\"$fnr\"}"
                 )
@@ -68,7 +69,8 @@ class VeilarbarenaClientTest {
             harOppfolgingssak = true,
             sperretAnsatt = false,
             erDoed = false,
-            doedFraDato = null
+            doedFraDato = null,
+            sistEndretDato = ZonedDateTime.parse("2024-04-04T00:00:00+02:00")
         )
 
         Assertions.assertThat(response).isEqualTo(Optional.of(forventet))
@@ -85,7 +87,7 @@ class VeilarbarenaClientTest {
         )
 
         WireMock.givenThat(
-            WireMock.post(WireMock.urlEqualTo("/api/v2/hent-oppfolgingsbruker")).withRequestBody(
+            WireMock.post(WireMock.urlEqualTo("/api/v3/hent-oppfolgingsbruker")).withRequestBody(
                 WireMock.equalToJson(
                     "{\"fnr\":\"$fnr\"}"
                 )
@@ -108,7 +110,7 @@ class VeilarbarenaClientTest {
         )
 
         WireMock.givenThat(
-            WireMock.post(WireMock.urlEqualTo("/api/v2/hent-oppfolgingsbruker")).withRequestBody(
+            WireMock.post(WireMock.urlEqualTo("/api/v3/hent-oppfolgingsbruker")).withRequestBody(
                 WireMock.equalToJson(
                     "{\"fnr\":\"$fnr\"}"
                 )

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClientTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/VeilarbarenaClientTest.kt
@@ -7,6 +7,7 @@ import no.nav.common.types.identer.Fnr
 import org.assertj.core.api.Assertions
 import org.junit.Rule
 import org.junit.Test
+import java.time.ZonedDateTime
 import java.util.*
 import java.util.function.Supplier
 
@@ -30,7 +31,7 @@ class VeilarbarenaClientTest {
                     {
                       "fodselsnr": "17858998980",
                       "formidlingsgruppekode": "ARBS",
-                      "iserv_fra_dato": null,
+                      "iserv_fra_dato": "2024-04-04T00:00:00+02:00",
                       "nav_kontor": "0220",
                       "kvalifiseringsgruppekode": "BATT",
                       "rettighetsgruppekode": "INDS",
@@ -58,6 +59,7 @@ class VeilarbarenaClientTest {
             fodselsnr = "17858998980",
             formidlingsgruppekode = "ARBS",
             navKontor = "0220",
+            iservFraDato = ZonedDateTime.parse("2024-04-04T00:00:00+02:00"),
             kvalifiseringsgruppekode = "BATT",
             rettighetsgruppekode = "INDS",
             hovedmaalkode = "SKAFFEA",

--- a/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepositoryTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepositoryTest.java
@@ -69,15 +69,18 @@ public class PdlIdentRepositoryTest {
     public void oppfolgingAvsluttet_flereIdenterUnderOppfolging_lokalIdentLagringSkalIkkeSlettes() {
         AktorId historiskIdent = randomAktorId();
         AktorId ident = randomAktorId();
+        Fnr fnr = randomFnr();
         List<PDLIdent> identer = List.of(
                 new PDLIdent(historiskIdent.get(), true, AKTORID),
                 new PDLIdent(ident.get(), false, AKTORID),
-                new PDLIdent(randomFnr().get(), false, FOLKEREGISTERIDENT)
+                new PDLIdent(fnr.get(), false, FOLKEREGISTERIDENT)
         );
         pdlIdentRepository.upsertIdenter(identer);
+//        IdenterForBruker _identer = pdlIdentRepository.hentIdenterForBruker(historiskIdent.get());
 
         var historiskOppfolgingStart = new SisteOppfolgingsperiodeV1(null, historiskIdent.get(), ZonedDateTime.now(), null);
         var nyOppfolgingStart = new SisteOppfolgingsperiodeV1(null, ident.get(), ZonedDateTime.now(), null);
+
         var nyOppfolgingAvslutt = new SisteOppfolgingsperiodeV1(null, ident.get(), ZonedDateTime.now(), ZonedDateTime.now());
 
         oppfolgingPeriodeService.behandleKafkaMeldingLogikk(historiskOppfolgingStart);

--- a/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepositoryTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepositoryTest.java
@@ -76,7 +76,6 @@ public class PdlIdentRepositoryTest {
                 new PDLIdent(fnr.get(), false, FOLKEREGISTERIDENT)
         );
         pdlIdentRepository.upsertIdenter(identer);
-//        IdenterForBruker _identer = pdlIdentRepository.hentIdenterForBruker(historiskIdent.get());
 
         var historiskOppfolgingStart = new SisteOppfolgingsperiodeV1(null, historiskIdent.get(), ZonedDateTime.now(), null);
         var nyOppfolgingStart = new SisteOppfolgingsperiodeV1(null, ident.get(), ZonedDateTime.now(), null);

--- a/src/test/resources/oppfolgingsbruker.json
+++ b/src/test/resources/oppfolgingsbruker.json
@@ -1,0 +1,16 @@
+{
+  "fodselsnr": "17858998980",
+  "formidlingsgruppekode": "ARBS",
+  "iservFraDato": "2024-04-04T00:00:00+02:00",
+  "navKontor": "0220",
+  "kvalifiseringsgruppekode": "BATT",
+  "rettighetsgruppekode": "INDS",
+  "hovedmaalkode": "SKAFFEA",
+  "sikkerhetstiltakTypeKode": "TFUS",
+  "frKode": "6",
+  "harOppfolgingssak": true,
+  "sperretAnsatt": false,
+  "erDoed": false,
+  "doedFraDato": null,
+  "sistEndretDato": "2024-04-04T00:00:00+02:00"
+}


### PR DESCRIPTION
## Describe your changes

I denne PR-en gjøres hovedsaklig to ting:

* endrer oppførselen i forbindelse med endringer på oppfølgingsbruker (`pto.endring-paa-oppfolgingsbruker-v2`): nå ignorerer vi meldinger for brukere som ikke er under oppfølging, for å unngå å lagre data vi ikke skal ha
* endrer oppførselen i forbindelse med start oppfølging: henter initielle oppfølgingsbruker-data når oppfølgingsperiode starter for en bruker

---

Dette er en del av arbeidet med dataminimering i Oversikten der vi ønsker å unngå å lagre data unødvendig (for brukere som ikke er under oppfølging ennå). Det gjenstår noe arbeid, f.eks. at vi må slette oppfølgingsbruker-data ved utgang fra oppfølging, samt gjøre en større slettejobb i DB-en for data om brukere som p.t. ikke er under oppfølging. Dette vil gjøres i separate PR-er. Se Trello-kortet for gjenværende oppgaver og beskrivelse.

## Trello ticket number and link

[TC-578](https://trello.com/c/P2oHJmAU/578-dataminimering-i-veilarbportefolje-oppfolgingsbrukerarenav2)

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
