### PR TITLE
Utvide slettarbeidsliste med slettFargekategori-flagg

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/Arbeidsliste.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/Arbeidsliste.java
@@ -90,4 +90,19 @@ public class Arbeidsliste {
         this.kategori = kategori;
         this.navkontorForArbeidsliste = navkontorForArbeidsliste;
     }
+
+    public Arbeidsliste(
+            Kategori kategori
+    ) {
+        this.sistEndretAv = null;
+        this.endringstidspunkt = null;
+        this.overskrift = null;
+        this.kommentar = null;
+        this.frist = null;
+        this.isOppfolgendeVeileder = null;
+        this.arbeidslisteAktiv = null;
+        this.harVeilederTilgang = null;
+        this.kategori = kategori;
+        this.navkontorForArbeidsliste = null;
+    }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteRepositoryV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteRepositoryV2.java
@@ -144,6 +144,28 @@ public class ArbeidslisteRepositoryV2 {
         return (oppdaterteRaderArbeidsliste + oppdaterteRaderFargekategori);
     }
 
+    @Transactional
+    public int slettArbeidslisteUtenFargekategori(AktorId aktoerId) {
+        if (aktoerId == null) {
+            return 0;
+        }
+        secureLog.info("Sletter arbeidsliste pa bruker: {}", aktoerId);
+
+        int oppdaterteRaderArbeidsliste = db.update(String.format("DELETE FROM %s WHERE %s = ?", TABLE_NAME, AKTOERID), aktoerId.get());
+
+        if (oppdaterteRaderArbeidsliste > 1) {
+            secureLog.error(String.format(
+                    "Fant flere rader i ARBEIDSLISTE-tabell. AktørID: %s - antall rader i ARBEIDSLISTE: %s.",
+                    aktoerId.get(),
+                    oppdaterteRaderArbeidsliste
+            ));
+
+            throw new SlettArbeidslisteException("Fant flere rader i ARBEIDSLISTE-tabell for bruker.");
+        }
+
+        return oppdaterteRaderArbeidsliste;
+    }
+
     private void upsert(String aktoerId, ArbeidslisteDTO dto) {
         secureLog.info("Upsert arbeidsliste pa bruker: {}", aktoerId);
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
@@ -81,14 +81,18 @@ public class ArbeidslisteService {
                 });
     }
 
-    public void slettArbeidsliste(Fnr fnr) {
+    public void slettArbeidsliste(Fnr fnr, Boolean slettFargekategori) {
         Optional<AktorId> aktoerId = brukerServiceV2.hentAktorId(fnr);
 
         if (aktoerId.isEmpty()) {
             throw new SlettArbeidslisteException(String.format("Kunne ikke slette arbeidsliste. Årsak: fant ikke aktørId på fnr: %s", fnr.get()));
         }
 
-        slettArbeidsliste(aktoerId.get(), Optional.of(fnr));
+        if(slettFargekategori) {
+            slettArbeidsliste(aktoerId.get(), Optional.of(fnr));
+        } else {
+            slettArbeidslisteUtenFargekategori(aktoerId.get());
+        }
     }
 
     public void slettArbeidsliste(AktorId aktoerId, Optional<Fnr> fnr) {
@@ -100,6 +104,16 @@ public class ArbeidslisteService {
 
         opensearchIndexerV2.slettArbeidsliste(aktoerId);
         opensearchIndexerV2.slettFargekategori(aktoerId);
+    }
+
+    public void slettArbeidslisteUtenFargekategori(AktorId aktoerId) {
+        final int antallSlettedeArbeidslister = arbeidslisteRepositoryV2.slettArbeidslisteUtenFargekategori(aktoerId);
+
+        if (antallSlettedeArbeidslister <= 0) {
+            return;
+        }
+
+        opensearchIndexerV2.slettArbeidsliste(aktoerId);
     }
 
     private Try<AktorId> hentAktorId(Fnr fnr) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/v1/ArbeidsListeController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/v1/ArbeidsListeController.java
@@ -145,7 +145,7 @@ public class ArbeidsListeController {
         sjekkTilgangTilEnhet(Fnr.ofValidFnr(fnr));
 
         try {
-            arbeidslisteService.slettArbeidsliste(Fnr.ofValidFnr(fnr));
+            arbeidslisteService.slettArbeidsliste(Fnr.ofValidFnr(fnr), true);
         } catch (SlettArbeidslisteException e) {
             VeilederId veilederId = AuthUtils.getInnloggetVeilederIdent();
             NavKontor enhet = brukerService.hentNavKontor(Fnr.ofValidFnr(fnr)).orElse(null);
@@ -180,7 +180,7 @@ public class ArbeidsListeController {
                     .orElse(new AktorId("uten aktør-ID"));
 
             try {
-                arbeidslisteService.slettArbeidsliste(fnr);
+                arbeidslisteService.slettArbeidsliste(fnr, true);
                 okFnrs.add(fnr.get());
                 secureLog.info("Arbeidsliste for aktoerid {} slettet", aktoerId.get());
             } catch (SlettArbeidslisteException e) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/v2/ArbeidsListeV2Controller.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/v2/ArbeidsListeV2Controller.java
@@ -5,14 +5,14 @@ import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.QueryParam;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.Fnr;
-import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
-import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteDTO;
-import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteService;
-import no.nav.pto.veilarbportefolje.arbeidsliste.SlettArbeidslisteException;
+import no.nav.pto.veilarbportefolje.arbeidsliste.*;
 import no.nav.pto.veilarbportefolje.auth.AuthService;
 import no.nav.pto.veilarbportefolje.auth.AuthUtils;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
+import no.nav.pto.veilarbportefolje.fargekategori.FargekategoriController;
+import no.nav.pto.veilarbportefolje.fargekategori.FargekategoriEntity;
+import no.nav.pto.veilarbportefolje.fargekategori.FargekategoriService;
 import no.nav.pto.veilarbportefolje.service.BrukerServiceV2;
 import no.nav.pto.veilarbportefolje.util.ValideringsRegler;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +22,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Optional;
 
 import static no.nav.common.utils.StringUtils.nullOrEmpty;
 import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
@@ -34,6 +35,7 @@ public class ArbeidsListeV2Controller {
     private final ArbeidslisteService arbeidslisteService;
     private final BrukerServiceV2 brukerService;
     private final AuthService authService;
+    private FargekategoriService fargekategoriService;
 
     @Autowired
     public ArbeidsListeV2Controller(
@@ -112,7 +114,10 @@ public class ArbeidsListeV2Controller {
     }
 
     @DeleteMapping("/arbeidsliste")
-    public Arbeidsliste deleteArbeidsliste(@RequestBody ArbeidslisteForBrukerRequest arbeidslisteForBrukerRequest, @RequestParam(value = "slettFargekategori", required = false, defaultValue = "true") Boolean slettFargekategori) {
+    public Arbeidsliste deleteArbeidsliste(
+            @RequestBody ArbeidslisteForBrukerRequest arbeidslisteForBrukerRequest,
+            @RequestParam(value = "slettFargekategori", required = false, defaultValue = "true") Boolean slettFargekategori
+    ) {
         validerOppfolgingOgBruker(arbeidslisteForBrukerRequest.fnr().get());
         validerErVeilederForBruker(arbeidslisteForBrukerRequest.fnr().get());
         Fnr gyldigFnr = Fnr.ofValidFnr(arbeidslisteForBrukerRequest.fnr().get());
@@ -128,7 +133,17 @@ public class ArbeidsListeV2Controller {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Kunne ikke slette. Fant ikke arbeidsliste for bruker");
         }
 
-        return emptyArbeidsliste().setHarVeilederTilgang(true).setIsOppfolgendeVeileder(true);
+        if (slettFargekategori) {
+            return emptyArbeidsliste().setHarVeilederTilgang(true).setIsOppfolgendeVeileder(true);
+        } else {
+            Optional<FargekategoriEntity> maybeKategori = fargekategoriService.hentFargekategoriForBruker(new FargekategoriController.HentFargekategoriRequest(gyldigFnr));
+
+            return maybeKategori.map(kategori ->
+                    new Arbeidsliste(ArbeidslisteMapper.mapFraFargekategoriTilKategori(kategori.fargekategoriVerdi().name()))
+                            .setHarVeilederTilgang(true)
+                            .setIsOppfolgendeVeileder(true)
+            ).orElse(emptyArbeidsliste().setHarVeilederTilgang(true).setIsOppfolgendeVeileder(true));
+        }
     }
 
     private void sjekkTilgangTilEnhet(Fnr fnr) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/v2/ArbeidsListeV2Controller.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/v2/ArbeidsListeV2Controller.java
@@ -1,6 +1,8 @@
 package no.nav.pto.veilarbportefolje.arbeidsliste.v2;
 
 import io.vavr.control.Validation;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.QueryParam;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.Fnr;
 import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
@@ -110,14 +112,14 @@ public class ArbeidsListeV2Controller {
     }
 
     @DeleteMapping("/arbeidsliste")
-    public Arbeidsliste deleteArbeidsliste(@RequestBody ArbeidslisteForBrukerRequest arbeidslisteForBrukerRequest) {
+    public Arbeidsliste deleteArbeidsliste(@RequestBody ArbeidslisteForBrukerRequest arbeidslisteForBrukerRequest, @RequestParam(value = "slettFargekategori", required = false, defaultValue = "true") Boolean slettFargekategori) {
         validerOppfolgingOgBruker(arbeidslisteForBrukerRequest.fnr().get());
         validerErVeilederForBruker(arbeidslisteForBrukerRequest.fnr().get());
         Fnr gyldigFnr = Fnr.ofValidFnr(arbeidslisteForBrukerRequest.fnr().get());
         sjekkTilgangTilEnhet(gyldigFnr);
 
         try {
-            arbeidslisteService.slettArbeidsliste(gyldigFnr);
+            arbeidslisteService.slettArbeidsliste(gyldigFnr, slettFargekategori);
         } catch (SlettArbeidslisteException e) {
             VeilederId veilederId = AuthUtils.getInnloggetVeilederIdent();
             NavKontor enhet = brukerService.hentNavKontor(gyldigFnr).orElse(null);


### PR DESCRIPTION
## Describe your changes
Fordi vi er i en mellomfase hvor vi både må støtte sletting av arbeidsliste og migrering fra arbeidsliste til huskelapp så har vi laget mulighet til å slette arbeidsliste uten å slette huskelapp.

Vi har utvidet selve endepunktet, men har laget separate funksjoner i servicen.
Dette vil bli ryddet når vi har fått slettet alle arbeidslister og vi kun står igjen med huskelapper og separate fargekategorier.

Med tanke på hvordan frontenden fungerer pt. er det lettest å returnere en tom arbeidsliste, men som fortsatt har kategori dersom man skal slette arbeidsliste uten å slette fargekategori. 

## Trello ticket number and link

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
