### PR TITLE
La være å kaste exception når fnr-parameter er tom

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerServiceV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerServiceV2.java
@@ -114,7 +114,7 @@ public class OppfolgingsbrukerServiceV2 extends KafkaCommonConsumerService<Endri
     public void slettOppfolgingsbruker(AktorId aktorId, Optional<Fnr> maybeFnr) {
         if (maybeFnr.isEmpty()) {
             secureLog.warn("Kunne ikke slette oppfolgingsbruker med Aktør-ID {}. Årsak fødselsnummer-parameter var tom.", aktorId.get());
-            throw new IllegalStateException("Fødselsnummer mangler");
+            return;
         }
 
         try {


### PR DESCRIPTION
## Describe your changes

Dersom fnr-parameteret er tomt og det kastes exception vil vi forsøke å prosessere Kafka-meldingen på nytt (retry). Dette vil derimot ikke ha noen effekt siden selve bruker-identenene (Aktør-ID og fnr) blir fullstendig slettet tidligere i programeksekveringen (se `OppfolgingAvsluttetService.avsluttOppfolging` --> `pdlService.slettPdlData`). Dette vil resultere i at vi aldri kommer oss ut at retry-en fordi det hele tiden kastes exception.

Endrer derfor til å bare returnere, som er likt med hvordan det gjøres i de andre sletteoperasjonene i de andre service-klassene.

_For tilfeller der det ikke er en aktiv AktørID<-->Fnr mapping må vi (per nå) løse det manuelt._

## Trello ticket number and link

n/a

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
