### PR TITLE
Henter og lagrer profilering fra nytt arbeidssøkerregister

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDomene.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDomene.kt
@@ -1,5 +1,6 @@
 package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
 
+import no.nav.common.types.identer.Fnr
 import java.time.ZonedDateTime
 import java.util.UUID
 
@@ -13,12 +14,47 @@ data class OpplysningerOmArbeidssoeker(
     val opplysningerOmJobbsituasjon: OpplysningerOmArbeidssoekerJobbsituasjon
 )
 
-
 data class OpplysningerOmArbeidssoekerJobbsituasjon(
     val opplysningerOmArbeidssoekerId: UUID,
     val jobbsituasjon: List<String>
 )
 
+data class ArbeidssoekerPeriode(
+    val arbeidssoekerperiodeId: UUID,
+    val fnr: Fnr
+)
+
+data class Profilering(
+    val periodeId: UUID,
+    val profileringsresultat: Profileringsresultat,
+    val sendtInnTidspunkt: ZonedDateTime
+)
+
+enum class Profileringsresultat {
+    UKJENT_VERDI,
+    UDEFINERT,
+    ANTATT_GODE_MULIGHETER,
+    ANTATT_BEHOV_FOR_VEILEDNING,
+    OPPGITT_HINDRINGER
+}
+
+data class ProfileringResponse(
+    val profileringId: UUID,
+    val periodeId: UUID,
+    val opplysningerOmArbeidssoekerId: UUID,
+    val sendtInnAv: MetadataResponse,
+    val profilertTil: ProfilertTil,
+    val jobbetSammenhengendeSeksAvTolvSisteManeder: Boolean?,
+    val alder: Int?
+)
+
+fun ProfileringResponse.toProfilering(): Profilering {
+    return Profilering(
+        periodeId = this.periodeId,
+        profileringsresultat = Profileringsresultat.valueOf(this.profilertTil.name),
+        sendtInnTidspunkt = this.sendtInnAv.tidspunkt
+    )
+}
 
 fun OpplysningerOmArbeidssoekerResponse.toOpplysningerOmArbeidssoeker() = OpplysningerOmArbeidssoeker(
     opplysningerOmArbeidssoekerId = this.opplysningerOmArbeidssoekerId,

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerPeriode.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerPeriode.kt
@@ -1,9 +1,0 @@
-package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
-
-import no.nav.common.types.identer.Fnr
-import java.util.UUID
-
-data class ArbeidssoekerPeriode(
-    val arbeidssoekerperiodeId: UUID,
-    val fnr: Fnr
-)

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
@@ -42,7 +42,7 @@ class ArbeidssoekerService(
             return
         }
 
-        sisteArbeidssoekerPeriodeRepository.upsertSisteArbeidssoekerPeriode(fnr, aktivArbeidssoekerperiode.periodeId)
+        sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(fnr, aktivArbeidssoekerperiode.periodeId)
         secureLog.info("Lagret siste arbeidssøkerperiode for bruker med fnr: $fnr")
 
         val opplysningerOmArbeidssoeker: List<OpplysningerOmArbeidssoekerResponse>? =
@@ -60,7 +60,7 @@ class ArbeidssoekerService(
             return
         }
 
-        opplysningerOmArbeidssoekerRepository.upsertOpplysningerOmArbeidssoeker(sisteOpplysningerOmArbeidssoeker.toOpplysningerOmArbeidssoeker())
+        opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(sisteOpplysningerOmArbeidssoeker.toOpplysningerOmArbeidssoeker())
         secureLog.info("Lagret opplysninger om arbeidssøker for bruker med fnr: $fnr")
 
         secureLog.info("Henter opplysninger om arbeidssøker for bruker med fnr: $fnr")
@@ -74,7 +74,7 @@ class ArbeidssoekerService(
             return
         }
 
-        profileringRepository.upsertProfilering(sisteProfilering.toProfilering())
+        profileringRepository.insertProfilering(sisteProfilering.toProfilering())
         secureLog.info("Lagret profilering for bruker med fnr: $fnr")
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
@@ -14,9 +14,18 @@ class ArbeidssoekerService(
     private val pdlIdentRepository: PdlIdentRepository,
     private val opplysningerOmArbeidssoekerRepository: OpplysningerOmArbeidssoekerRepository,
     private val sisteArbeidssoekerPeriodeRepository: SisteArbeidssoekerPeriodeRepository,
+    private val profileringRepository: ProfileringRepository,
 ) {
+    /**
+     * Henter og lagrer arbeidssøkerdata for bruker med aktørId.
+     * Med arbeidssøkerdata menes:
+     *
+     * - Siste arbeidssøkerperiode
+     * - Siste opplysninger om arbeidssøker
+     * - Siste profilering av bruker
+     */
     @Transactional
-    fun hentOgLagreSisteArbeidssoekerPeriodeForBruker(aktorId: AktorId) {
+    fun hentOgLagreArbeidssoekerdataForBruker(aktorId: AktorId) {
         val fnr: Fnr? = pdlIdentRepository.hentFnrForAktivBruker(aktorId)
         if (fnr == null) {
             secureLog.info("Fant ingen fødselsnummer for bruker med aktorId: $aktorId")
@@ -54,6 +63,19 @@ class ArbeidssoekerService(
         opplysningerOmArbeidssoekerRepository.upsertOpplysningerOmArbeidssoeker(sisteOpplysningerOmArbeidssoeker.toOpplysningerOmArbeidssoeker())
         secureLog.info("Lagret opplysninger om arbeidssøker for bruker med fnr: $fnr")
 
+        secureLog.info("Henter opplysninger om arbeidssøker for bruker med fnr: $fnr")
+        val sisteProfilering: ProfileringResponse? =
+            oppslagArbeidssoekerregisteretClient.hentProfilering(fnr.get(), aktivArbeidssoekerperiode.periodeId)
+                ?.filter { it.opplysningerOmArbeidssoekerId == sisteOpplysningerOmArbeidssoeker.opplysningerOmArbeidssoekerId }
+                ?.maxByOrNull { it.sendtInnAv.tidspunkt }
+
+        if(sisteProfilering == null) {
+            secureLog.info("Fant ingen profilering for bruker med fnr: $fnr")
+            return
+        }
+
+        profileringRepository.upsertProfilering(sisteProfilering.toProfilering())
+        secureLog.info("Lagret profilering for bruker med fnr: $fnr")
     }
 
     fun slettArbeidssoekerData(aktorId: AktorId, maybeFnr: Optional<Fnr>) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
@@ -63,7 +63,7 @@ class ArbeidssoekerService(
         opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(sisteOpplysningerOmArbeidssoeker.toOpplysningerOmArbeidssoeker())
         secureLog.info("Lagret opplysninger om arbeidssøker for bruker med fnr: $fnr")
 
-        secureLog.info("Henter opplysninger om arbeidssøker for bruker med fnr: $fnr")
+        secureLog.info("Henter profilering for bruker med fnr: $fnr")
         val sisteProfilering: ProfileringResponse? =
             oppslagArbeidssoekerregisteretClient.hentProfilering(fnr.get(), aktivArbeidssoekerperiode.periodeId)
                 ?.filter { it.opplysningerOmArbeidssoekerId == sisteOpplysningerOmArbeidssoeker.opplysningerOmArbeidssoekerId }

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OpplysningerOmArbeidssoekerRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OpplysningerOmArbeidssoekerRepository.kt
@@ -15,12 +15,12 @@ import java.util.*
 class OpplysningerOmArbeidssoekerRepository(
     private val db: JdbcTemplate
 ) {
-    fun upsertOpplysningerOmArbeidssoeker(opplysningerOmArbeidssoeker: OpplysningerOmArbeidssoeker) {
+    fun insertOpplysningerOmArbeidssoekerOgJobbsituasjon(opplysningerOmArbeidssoeker: OpplysningerOmArbeidssoeker) {
         insertOpplysningerOmArbeidssoeker(opplysningerOmArbeidssoeker)
         insertOpplysningerOmArbeidssoekerJobbsituasjon(opplysningerOmArbeidssoeker.opplysningerOmJobbsituasjon)
     }
 
-    fun insertOpplysningerOmArbeidssoeker(opplysningerOmArbeidssoeker: OpplysningerOmArbeidssoeker) {
+    private fun insertOpplysningerOmArbeidssoeker(opplysningerOmArbeidssoeker: OpplysningerOmArbeidssoeker) {
         val sqlString = """INSERT INTO ${OPPLYSNINGER_OM_ARBEIDSSOEKER.TABLE_NAME} ( 
                     ${OPPLYSNINGER_OM_ARBEIDSSOEKER.OPPLYSNINGER_OM_ARBEIDSSOEKER_ID}, 
                     ${OPPLYSNINGER_OM_ARBEIDSSOEKER.PERIODE_ID},
@@ -41,7 +41,7 @@ class OpplysningerOmArbeidssoekerRepository(
         )
     }
 
-    fun insertOpplysningerOmArbeidssoekerJobbsituasjon(opplysningerOmArbeidssoekerJobbsituasjon: OpplysningerOmArbeidssoekerJobbsituasjon) {
+    private fun insertOpplysningerOmArbeidssoekerJobbsituasjon(opplysningerOmArbeidssoekerJobbsituasjon: OpplysningerOmArbeidssoekerJobbsituasjon) {
         val sqlString = """INSERT INTO ${OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.TABLE_NAME} ( 
                     ${OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.OPPLYSNINGER_OM_ARBEIDSSOEKER_ID}, 
                     ${OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.JOBBSITUASJON}

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OppslagArbeidssoekerregisteretClient.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OppslagArbeidssoekerregisteretClient.kt
@@ -133,7 +133,7 @@ data class HelseResponse(
 )
 
 data class UtdanningResponse(
-    val nus: String,    // TODO: Legg til kommentar som beskriver hva nus er
+    val nus: String,    // NUS = Standard for utdanningsgruppering (https://www.ssb.no/klass/klassifikasjoner/36/)
     val bestaatt: JaNeiVetIkke?,
     val godkjent: JaNeiVetIkke?
 )

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OppslagArbeidssoekerregisteretClient.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OppslagArbeidssoekerregisteretClient.kt
@@ -103,7 +103,7 @@ data class OpplysningerOmArbeidssoekerResponse(
 
 data class BeskrivelseMedDetaljerResponse(
     val beskrivelse: JobbSituasjonBeskrivelse,
-    val detaljer: Map<String, String>   // TODO: Litt usikker på om typene er riktig for key/value
+    val detaljer: Map<String, String>
 )
 
 enum class JobbSituasjonBeskrivelse {
@@ -140,16 +140,6 @@ data class UtdanningResponse(
 
 // Profilering typer
 data class ProfileringRequest(val identitetsnummer: String, val periodeId: UUID)
-
-data class ProfileringResponse(
-    val profileringId: UUID,
-    val periodeId: UUID,
-    val opplysningerOmArbeidssoekerId: UUID,
-    val sendtInnAv: MetadataResponse,
-    val profilertTil: ProfilertTil,
-    val jobbetSammenhengendeSeksAvTolvSisteManeder: Boolean?,
-    val alder: Int?
-)
 
 enum class ProfilertTil {
     UKJENT_VERDI,

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OppslagArbeidssoekerregisteretClient.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OppslagArbeidssoekerregisteretClient.kt
@@ -146,12 +146,12 @@ data class ProfileringResponse(
     val periodeId: UUID,
     val opplysningerOmArbeidssoekerId: UUID,
     val sendtInnAv: MetadataResponse,
-    val profilertTil: ProfileringsResultat,
+    val profilertTil: ProfilertTil,
     val jobbetSammenhengendeSeksAvTolvSisteManeder: Boolean?,
     val alder: Int?
 )
 
-enum class ProfileringsResultat {
+enum class ProfilertTil {
     UKJENT_VERDI,
     UDEFINERT,
     ANTATT_GODE_MULIGHETER,

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ProfileringRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ProfileringRepository.kt
@@ -1,0 +1,42 @@
+package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
+
+import no.nav.pto.veilarbportefolje.database.PostgresTable
+import no.nav.pto.veilarbportefolje.util.DateUtils
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import java.time.ZonedDateTime
+import java.util.*
+
+@Repository
+class ProfileringRepository(private val db: JdbcTemplate) {
+    fun upsertProfilering(sisteProfilering: Profilering) {
+        db.update(
+            """INSERT INTO ${PostgresTable.PROFILERING.TABLE_NAME} values (?,?,?)""",
+            sisteProfilering.periodeId,
+            sisteProfilering.profileringsresultat.name,
+            DateUtils.toTimestamp(sisteProfilering.sendtInnTidspunkt)
+        )
+    }
+}
+
+data class Profilering(
+    val periodeId: UUID,
+    val profileringsresultat: Profileringsresultat,
+    val sendtInnTidspunkt: ZonedDateTime
+)
+
+enum class Profileringsresultat {
+    UKJENT_VERDI,
+    UDEFINERT,
+    ANTATT_GODE_MULIGHETER,
+    ANTATT_BEHOV_FOR_VEILEDNING,
+    OPPGITT_HINDRINGER
+}
+
+fun ProfileringResponse.toProfilering(): Profilering {
+    return Profilering(
+        periodeId = this.periodeId,
+        profileringsresultat = Profileringsresultat.valueOf(this.profilertTil.name),
+        sendtInnTidspunkt = this.sendtInnAv.tidspunkt
+    )
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ProfileringRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ProfileringRepository.kt
@@ -1,12 +1,9 @@
 package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
 
-import no.nav.pto.veilarbportefolje.database.PostgresTable
 import no.nav.pto.veilarbportefolje.database.PostgresTable.*
 import no.nav.pto.veilarbportefolje.util.DateUtils
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
-import java.time.ZonedDateTime
-import java.util.*
 
 @Repository
 class ProfileringRepository(private val db: JdbcTemplate) {
@@ -22,26 +19,4 @@ class ProfileringRepository(private val db: JdbcTemplate) {
             DateUtils.toTimestamp(sisteProfilering.sendtInnTidspunkt)
         )
     }
-}
-
-data class Profilering(
-    val periodeId: UUID,
-    val profileringsresultat: Profileringsresultat,
-    val sendtInnTidspunkt: ZonedDateTime
-)
-
-enum class Profileringsresultat {
-    UKJENT_VERDI,
-    UDEFINERT,
-    ANTATT_GODE_MULIGHETER,
-    ANTATT_BEHOV_FOR_VEILEDNING,
-    OPPGITT_HINDRINGER
-}
-
-fun ProfileringResponse.toProfilering(): Profilering {
-    return Profilering(
-        periodeId = this.periodeId,
-        profileringsresultat = Profileringsresultat.valueOf(this.profilertTil.name),
-        sendtInnTidspunkt = this.sendtInnAv.tidspunkt
-    )
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ProfileringRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ProfileringRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
 
 import no.nav.pto.veilarbportefolje.database.PostgresTable
+import no.nav.pto.veilarbportefolje.database.PostgresTable.*
 import no.nav.pto.veilarbportefolje.util.DateUtils
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
@@ -11,7 +12,11 @@ import java.util.*
 class ProfileringRepository(private val db: JdbcTemplate) {
     fun insertProfilering(sisteProfilering: Profilering) {
         db.update(
-            """INSERT INTO ${PostgresTable.PROFILERING.TABLE_NAME} values (?,?,?)""",
+            """INSERT INTO ${PROFILERING.TABLE_NAME} (
+                    ${PROFILERING.PERIODE_ID}, 
+                    ${PROFILERING.PROFILERING_RESULTAT}, 
+                    ${PROFILERING.SENDT_INN_TIDSPUNKT}
+                ) VALUES (?,?,?)""",
             sisteProfilering.periodeId,
             sisteProfilering.profileringsresultat.name,
             DateUtils.toTimestamp(sisteProfilering.sendtInnTidspunkt)

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ProfileringRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ProfileringRepository.kt
@@ -9,7 +9,7 @@ import java.util.*
 
 @Repository
 class ProfileringRepository(private val db: JdbcTemplate) {
-    fun upsertProfilering(sisteProfilering: Profilering) {
+    fun insertProfilering(sisteProfilering: Profilering) {
         db.update(
             """INSERT INTO ${PostgresTable.PROFILERING.TABLE_NAME} values (?,?,?)""",
             sisteProfilering.periodeId,

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/SisteArbeidssoekerPeriodeRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/SisteArbeidssoekerPeriodeRepository.kt
@@ -10,7 +10,7 @@ import java.util.*
 class SisteArbeidssoekerPeriodeRepository(
     private val db: JdbcTemplate
 ) {
-    fun upsertSisteArbeidssoekerPeriode(fnr: Fnr, periodeId: UUID) {
+    fun insertSisteArbeidssoekerPeriode(fnr: Fnr, periodeId: UUID) {
         db.update(
             """INSERT INTO ${PostgresTable.SISTE_ARBEIDSSOEKER_PERIODE.TABLE_NAME} values (?,?)""",
             periodeId,

--- a/src/main/java/no/nav/pto/veilarbportefolje/database/PostgresTable.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/database/PostgresTable.java
@@ -266,6 +266,16 @@ public class PostgresTable {
 
     }
 
+    public static final class PROFILERING {
+        private PROFILERING() { /* no-op */ }
+
+        public static final String TABLE_NAME = "PROFILERING";
+        public static final String PERIODE_ID = "PERIODE_ID";
+        public static final String PROFILERING_RESULTAT = "PROFILERING_RESULTAT";
+        public static final String SENDT_INN_TIDSPUNKT = "SENDT_INN_TIDSPUNKT";
+
+    }
+
     public static final class BRUKER_CV {
 
         private BRUKER_CV() { /* no-op */ }

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
@@ -43,7 +43,7 @@ public class OppfolgingStartetService {
         siste14aVedtakService.hentOgLagreSiste14aVedtak(aktorId);
         oppfolgingsbrukerServiceV2.hentOgLagreOppfolgingsbruker(aktorId);
         if ( FeatureToggle.brukNyttArbeidssoekerregister(defaultUnleash)) {
-            arbeidssoekerService.hentOgLagreSisteArbeidssoekerPeriodeForBruker(aktorId);
+            arbeidssoekerService.hentOgLagreArbeidssoekerdataForBruker(aktorId);
         }
 
         opensearchIndexer.indekser(aktorId);

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
@@ -30,11 +30,11 @@ public class OppfolgingStartetService {
     private final DefaultUnleash defaultUnleash;
 
     // TODO: Dersom en eller flere av disse operasjonene feiler og kaster exception vil
-        //  kafka-meldingen bli lagret og retryet. Dette kan resultere i at vi mellomlagrer data
-        //  vi ikke skal. Mulig vi burde wrappe dette i en try-catch slik at vi kan rydde opp
-        //  i catch-en.
-        //  Dette vil også muligens bidra til å gjøre usikkerheten rundt hvordan vi håndterer
-        //  scenarier der AktorID/Fnr blir historisk før startOppfolging fullfører.
+    //  kafka-meldingen bli lagret og retryet. Dette kan resultere i at vi mellomlagrer data
+    //  vi ikke skal. Mulig vi burde wrappe dette i en try-catch slik at vi kan rydde opp
+    //  i catch-en.
+    //  Dette vil også muligens bidra til å gjøre usikkerheten rundt hvordan vi håndterer
+    //  scenarier der AktorID/Fnr blir historisk før startOppfolging fullfører.
     public void startOppfolging(AktorId aktorId, ZonedDateTime oppfolgingStartetDate) {
         pdlService.hentOgLagrePdlData(aktorId);
 
@@ -42,7 +42,8 @@ public class OppfolgingStartetService {
 
         siste14aVedtakService.hentOgLagreSiste14aVedtak(aktorId);
         oppfolgingsbrukerServiceV2.hentOgLagreOppfolgingsbruker(aktorId);
-        if ( FeatureToggle.brukNyttArbeidssoekerregister(defaultUnleash)) {
+
+        if (FeatureToggle.brukNyttArbeidssoekerregister(defaultUnleash)) {
             arbeidssoekerService.hentOgLagreArbeidssoekerdataForBruker(aktorId);
         }
 

--- a/src/main/resources/db/postgres/V1_84__profilering.sql
+++ b/src/main/resources/db/postgres/V1_84__profilering.sql
@@ -1,0 +1,7 @@
+CREATE TABLE PROFILERING
+(
+    ID                   SERIAL PRIMARY KEY,
+    PERIODE_ID            UUID        NOT NULL REFERENCES siste_arbeidssoeker_periode (arbeidssoker_periode_id) ON DELETE CASCADE,
+    PROFILERING_RESULTAT VARCHAR(40) NOT NULL,
+    SENDT_INN_TIDSPUNKT  TIMESTAMP   NOT NULL
+);

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerServiceTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerServiceTest.kt
@@ -22,7 +22,7 @@ class ArbeidssoekerServiceTest {
         oppslagArbeidssoekerregisteretClient,
         pdlIdentRepository,
         opplysningerOmArbeidssoekerRepository,
-        sisteArbeidssoekerPeriodeRepository
+        sisteArbeidssoekerPeriodeRepository,
     )
 
     @Test

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerServiceTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerServiceTest.kt
@@ -15,6 +15,7 @@ class ArbeidssoekerServiceTest {
     private val db = SingletonPostgresContainer.init().createJdbcTemplate()
     private val sisteArbeidssoekerPeriodeRepository = SisteArbeidssoekerPeriodeRepository(db)
     private val opplysningerOmArbeidssoekerRepository = OpplysningerOmArbeidssoekerRepository(db)
+    private val profileringRepository = ProfileringRepository(db)
     private val oppslagArbeidssoekerregisteretClient = mock(OppslagArbeidssoekerregisteretClient::class.java)
     private val pdlIdentRepository = mock(PdlIdentRepository::class.java)
 
@@ -23,6 +24,7 @@ class ArbeidssoekerServiceTest {
         pdlIdentRepository,
         opplysningerOmArbeidssoekerRepository,
         sisteArbeidssoekerPeriodeRepository,
+        profileringRepository
     )
 
     @Test

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerServiceTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerServiceTest.kt
@@ -37,12 +37,12 @@ class ArbeidssoekerServiceTest {
         val opplysningerOmArbeidssoekerId2 = UUID.randomUUID()
         `when`(pdlIdentRepository.hentFnrForAktivBruker(aktorId)).thenReturn(fnr1)
 
-        sisteArbeidssoekerPeriodeRepository.upsertSisteArbeidssoekerPeriode(fnr1, periodeId1)
-        sisteArbeidssoekerPeriodeRepository.upsertSisteArbeidssoekerPeriode(fnr2, periodeId2)
-        opplysningerOmArbeidssoekerRepository.upsertOpplysningerOmArbeidssoeker(
+        sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(fnr1, periodeId1)
+        sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(fnr2, periodeId2)
+        opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(
             genererRandomOpplysningerOmArbeidssoeker(periodeId1, opplysningerOmArbeidssoekerId1)
         )
-        opplysningerOmArbeidssoekerRepository.upsertOpplysningerOmArbeidssoeker(
+        opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(
             genererRandomOpplysningerOmArbeidssoeker(periodeId2, opplysningerOmArbeidssoekerId2)
         )
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OpplysningerOmArbeidssoekerRepositoryTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OpplysningerOmArbeidssoekerRepositoryTest.kt
@@ -60,7 +60,7 @@ class OpplysningerOmArbeidssoekerRepositoryTest {
                 andreForholdHindrerArbeid = JaNeiVetIkke.NEI
             )
         ).toOpplysningerOmArbeidssoeker()
-        opplysningerOmArbeidssoeker.upsertOpplysningerOmArbeidssoeker(opplysningerOmArbeidssoekerObjekt)
+        opplysningerOmArbeidssoeker.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(opplysningerOmArbeidssoekerObjekt)
 
 
         val resultatOpplysninger: OpplysningerOmArbeidssoeker? =

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OppslagArbeidssoekerregisteretClient.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OppslagArbeidssoekerregisteretClient.kt
@@ -216,7 +216,7 @@ class OppslagArbeidssoekerregisteretClientTest {
                     kilde = "null-null",
                     aarsak = "opplysninger-mottatt"
                 ),
-                profilertTil = ProfileringsResultat.ANTATT_BEHOV_FOR_VEILEDNING,
+                profilertTil = ProfilertTil.ANTATT_BEHOV_FOR_VEILEDNING,
                 jobbetSammenhengendeSeksAvTolvSisteManeder = false,
                 alder = 42
             )

--- a/src/test/java/no/nav/pto/veilarbportefolje/config/ApplicationConfigTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/config/ApplicationConfigTest.java
@@ -16,10 +16,7 @@ import no.nav.pto.veilarbportefolje.aktiviteter.AktivitetService;
 import no.nav.pto.veilarbportefolje.aktiviteter.AktiviteterRepositoryV2;
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteRepositoryV2;
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteService;
-import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerService;
-import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.OpplysningerOmArbeidssoekerRepository;
-import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.OppslagArbeidssoekerregisteretClient;
-import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.SisteArbeidssoekerPeriodeRepository;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.*;
 import no.nav.pto.veilarbportefolje.arenapakafka.aktiviteter.*;
 import no.nav.pto.veilarbportefolje.arenapakafka.ytelser.YtelsesRepositoryV2;
 import no.nav.pto.veilarbportefolje.arenapakafka.ytelser.YtelsesService;
@@ -178,7 +175,8 @@ import static org.mockito.Mockito.when;
         FargekategoriRepository.class,
         ArbeidssoekerService.class,
         OpplysningerOmArbeidssoekerRepository.class,
-        SisteArbeidssoekerPeriodeRepository.class
+        SisteArbeidssoekerPeriodeRepository.class,
+        ProfileringRepository.class
 })
 public class ApplicationConfigTest {
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetOgAvsluttetServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetOgAvsluttetServiceTest.java
@@ -237,6 +237,7 @@ class OppfolgingStartetOgAvsluttetServiceTest extends EndToEndTest {
         mockHentOppfolgingsbrukerResponse(fnr);
         mockHentArbeidssoekerPerioderResponse(fnr);
         mockHentOpplysningerOmArbeidssoekerResponse(fnr, periodeId);
+        mockHentProfileringResponse(fnr, periodeId);
 
         oppfolgingPeriodeService.behandleKafkaMeldingLogikk(genererStartetOppfolgingsperiode(aktorId));
 
@@ -250,6 +251,8 @@ class OppfolgingStartetOgAvsluttetServiceTest extends EndToEndTest {
 
         assertThat(opplysningerOmArbeidssoekerJobbsituasjon.getJobbsituasjon().get(1)).isEqualTo(JobbSituasjonBeskrivelse.ER_PERMITTERT.name());
 
+        Profilering profilering = TestDataClient.getProfileringFraDb(jdbcTemplate, periodeId);
+        assertNotNull(profilering);
     }
 
     @Test
@@ -461,6 +464,13 @@ class OppfolgingStartetOgAvsluttetServiceTest extends EndToEndTest {
         List<OpplysningerOmArbeidssoekerResponse> opplysningerOmArbeidssoekerResponse = getObjectMapper().readValue(file, new TypeReference<>() {
         });
         when(oppslagArbeidssoekerregisteretClient.hentOpplysningerOmArbeidssoeker(fnr.get(), periodeId)).thenReturn(opplysningerOmArbeidssoekerResponse);
+    }
+
+    private void mockHentProfileringResponse(Fnr fnr, UUID periodeId) throws JsonProcessingException {
+        String file = readFileAsJsonString("/profilering.json", getClass());
+        List<ProfileringResponse> profileringResponse = getObjectMapper().readValue(file, new TypeReference<>() {
+        });
+        when(oppslagArbeidssoekerregisteretClient.hentProfilering(fnr.get(), periodeId)).thenReturn(profileringResponse);
     }
 
     private void insertOppfolgingsbrukerEntity(ZonedDateTime endret_dato) {

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetOgAvsluttetServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetOgAvsluttetServiceTest.java
@@ -334,7 +334,7 @@ class OppfolgingStartetOgAvsluttetServiceTest extends EndToEndTest {
 
         testDataClient.lagreBrukerUnderOppfolging(aktorId, fnr);
 
-        arbeidssoekerService.hentOgLagreSisteArbeidssoekerPeriodeForBruker(aktorId);
+        arbeidssoekerService.hentOgLagreArbeidssoekerdataForBruker(aktorId);
 
         ArbeidssoekerPeriode sisteArbeidssoekerPeriodeFørAvsluttet = TestDataClient.getArbeidssoekerPeriodeFraDb(jdbcTemplate, UUID.fromString("ea0ad984-8b99-4fff-afd6-07737ab19d16"));
         assertThat(sisteArbeidssoekerPeriodeFørAvsluttet).isNotNull();

--- a/src/test/java/no/nav/pto/veilarbportefolje/util/TestDataClient.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/util/TestDataClient.kt
@@ -8,6 +8,8 @@ import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteDTO
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteRepositoryV2
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v1.registrering.ArbeidssokerRegistreringRepositoryV2
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.Profileringsresultat
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.Profilering
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerPeriode
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.OpplysningerOmArbeidssoeker
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.OpplysningerOmArbeidssoekerJobbsituasjon
@@ -268,6 +270,25 @@ class TestDataClient(
                     jobbSituasjoner
                 )
 
+        }
+
+        @JvmStatic
+        fun getProfileringFraDb(jdbcTemplate: JdbcTemplate, periodeId: UUID): Profilering? {
+            return try {
+                jdbcTemplate.queryForObject(
+                    """SELECT * FROM ${PostgresTable.PROFILERING.TABLE_NAME} WHERE ${PostgresTable.PROFILERING.PERIODE_ID} =?""",
+                    { rs: ResultSet, _ ->
+                        Profilering(
+                            rs.getObject(PostgresTable.PROFILERING.PERIODE_ID, UUID::class.java),
+                            Profileringsresultat.valueOf(rs.getString(PostgresTable.PROFILERING.PROFILERING_RESULTAT)),
+                            DateUtils.toZonedDateTime(rs.getTimestamp(PostgresTable.PROFILERING.SENDT_INN_TIDSPUNKT))
+                        )
+                    },
+                    periodeId
+                )
+            } catch (e: EmptyResultDataAccessException) {
+                null
+            }
         }
     }
 }

--- a/src/test/resources/profilering.json
+++ b/src/test/resources/profilering.json
@@ -1,0 +1,18 @@
+[
+  {
+    "profileringId": "7c9a2feb-0b31-4101-825a-0c4a3d465e01",
+    "periodeId": "ea0ad984-8b99-4fff-afd6-07737ab19d16",
+    "opplysningerOmArbeidssoekerId": "913161a3-dde9-4448-abf8-2a01a043f8cd",
+    "sendtInnAv": {
+      "tidspunkt": "2024-04-25T08:19:53.612Z",
+      "utfoertAv": {
+        "type": "SYSTEM"
+      },
+      "kilde": "null-null",
+      "aarsak": "opplysninger-mottatt"
+    },
+    "profilertTil": "OPPGITT_HINDRINGER",
+    "jobbetSammenhengendeSeksAvTolvSisteManeder": false,
+    "alder": 33
+  }
+]


### PR DESCRIPTION
## Describe your changes
Ved start av oppfølging henter vi inn data om profilering fra nytt arbeidssøkerregister. I denne PRen bryr vi oss kun om henting og lagring. Populering av etiketter gjøres i en senere PR.

## Trello ticket number and link
[TC-587](https://trello.com/c/N46wEHKr/587-veilarbregistrering-blir-skrudd-av-vi-m%C3%A5-koble-oss-p%C3%A5-nye-kafkastr%C3%B8mmer-og-endepunkt-for-besvarelse-fra-registrering-profilering)

## Type of change
- [x] Maintenance

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.