### PR TITLE
Prodsette: Slette gammel arbeidssoekerperiode før man setter inn ny på bruker i db

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
@@ -142,6 +142,7 @@ class ArbeidssoekerService(
         secureLog.info("Lagret opplysninger om arbeidssøker for bruker med fnr: $fnr")
     }
 
+    @Transactional
     fun behandleKafkaMeldingLogikk(kafkaMelding: ProfileringKafkaMelding) {
         if (!FeatureToggle.brukNyttArbeidssoekerregisterKafka(defaultUnleash)) {
             secureLog.info("Bryter for å lytte på kafkameldinger fra nytt arbeidssøkerregister er skrudd av. Ignorerer melding.")
@@ -197,6 +198,7 @@ class ArbeidssoekerService(
             return
         }
 
+        sisteArbeidssoekerPeriodeRepository.slettSisteArbeidssoekerPeriode(fnr)
         sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(fnr, aktivArbeidssoekerperiode.periodeId)
         secureLog.info("Lagret siste arbeidssøkerperiode for bruker med fnr: $fnr")
 


### PR DESCRIPTION
## Describe your changes
Glemt å slette gammel arbeidssoekerperiode før vi forsøker å sette inn ny data ved oppfolging startet. Etterhvert skal ikke det være nødvendig fordi vi ikke lytter på meldinger på brukere som ikke er under oppfølging og sletter data når bruker går ut av oppfølging. Men under utvikling er vi i en mellomfase som gjør det nødvendig.

## Trello ticket number and link

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)