### PR TITLE
Sorter huskelapper med frist først, nærmeste dato øverst

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -623,11 +623,16 @@ public class OpensearchQueryBuilder {
 
     private static void sorterHuskelappEksistere(SearchSourceBuilder builder, SortOrder order) {
         String expresion = """
-                if (!doc['huskelapp.kommentar'].empty || !doc['huskelapp.frist'].empty) {
-                    return 1;
+                if (!doc['huskelapp.frist'].empty) {
+                    // Når man sorterer huskelapp-kolonnen (ikon-knappen), skal de som har frist sorteres først, med nærmeste utløpsdato øverst
+                    // Trekker fra 01.01.2050 i millis
+                    return doc['huskelapp.frist'].value.toInstant().toEpochMilli() - 2524653462000.0;
+                }
+                else if (!doc['huskelapp.kommentar'].empty) {
+                    return 0;
                 }
                 else {
-                  return 0;
+                  return 1;
                 }
                 """;
         Script script = new Script(expresion);


### PR DESCRIPTION
## Describe your changes
Når man sorterer på huskelapp ved å bruke ikon-knappen, så skal de med huskelapp komme først, ikke sist. I tillegg så skal de med frist komme før de uten, i stigende rekkefølge på fristdatoen.

## Trello ticket number and link

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code