### PR TITLE
Ny populerere svar fra registrerings filter

### DIFF
--- a/.intelliJ_ddl/DDL.sql
+++ b/.intelliJ_ddl/DDL.sql
@@ -417,7 +417,8 @@ CREATE TABLE public.fargekategori (
     fnr character varying(11) NOT NULL,
     verdi character varying(25),
     sist_endret timestamp without time zone NOT NULL,
-    sist_endret_av_veilederident character varying(7)
+    sist_endret_av_veilederident character varying(7),
+    enhet_id character varying(4)
 );
 
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDataRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDataRepository.kt
@@ -6,12 +6,13 @@ import no.nav.pto.veilarbportefolje.database.PostgresTable.OPPLYSNINGER_OM_ARBEI
 import no.nav.pto.veilarbportefolje.database.PostgresTable.SISTE_ARBEIDSSOEKER_PERIODE
 import no.nav.pto.veilarbportefolje.database.PostgresTable.PROFILERING
 import no.nav.pto.veilarbportefolje.util.DateUtils
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
 
 @Repository
 class ArbeidssoekerDataRepository(
-    private val db: JdbcTemplate
+    @Qualifier("PostgresJdbcReadOnly") private val db: JdbcTemplate
 ) {
 
     fun hentOpplysningerOmArbeidssoeker(fnrs: List<Fnr>): Map<String, OpplysningerOmArbeidssoeker> {

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDataRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDataRepository.kt
@@ -1,0 +1,89 @@
+package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
+
+import no.nav.common.types.identer.Fnr
+import no.nav.pto.veilarbportefolje.database.PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER
+import no.nav.pto.veilarbportefolje.database.PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON
+import no.nav.pto.veilarbportefolje.database.PostgresTable.SISTE_ARBEIDSSOEKER_PERIODE
+import no.nav.pto.veilarbportefolje.database.PostgresTable.PROFILERING
+import no.nav.pto.veilarbportefolje.util.DateUtils
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class ArbeidssoekerDataRepository(
+    private val db: JdbcTemplate
+) {
+
+    fun hentOpplysningerOmArbeidssoeker(fnrs: List<Fnr>): Map<String, OpplysningerOmArbeidssoeker> {
+        val arbeidssoekerDataPaaBruker = mutableMapOf<String, OpplysningerOmArbeidssoeker>()
+
+
+        val fnrsPostgresArray = "{${fnrs.joinToString(",") { it.get() }}}"
+        val sqlString = """
+            SELECT 
+                sap.${SISTE_ARBEIDSSOEKER_PERIODE.FNR},
+                ooa.*,
+                ooaj.${OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.JOBBSITUASJON} 
+            FROM ${OPPLYSNINGER_OM_ARBEIDSSOEKER.TABLE_NAME} ooa
+            INNER JOIN ${SISTE_ARBEIDSSOEKER_PERIODE.TABLE_NAME} sap ON ooa.${OPPLYSNINGER_OM_ARBEIDSSOEKER.PERIODE_ID} = sap.${SISTE_ARBEIDSSOEKER_PERIODE.ARBEIDSSOKER_PERIODE_ID}
+            INNER JOIN ${OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.TABLE_NAME} ooaj ON ooa.${OPPLYSNINGER_OM_ARBEIDSSOEKER.OPPLYSNINGER_OM_ARBEIDSSOEKER_ID} = ooaj.${OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.OPPLYSNINGER_OM_ARBEIDSSOEKER_ID}
+            WHERE sap.${SISTE_ARBEIDSSOEKER_PERIODE.FNR} = ANY ('$fnrsPostgresArray'::varchar[])
+        """.trimIndent()
+
+        db.query(sqlString) { rs, _ ->
+            val fnr = rs.getString(SISTE_ARBEIDSSOEKER_PERIODE.FNR)
+            val opplysningPaaBruker = arbeidssoekerDataPaaBruker[fnr]
+            if (opplysningPaaBruker != null) {
+                arbeidssoekerDataPaaBruker[fnr] = opplysningPaaBruker.copy(
+                    jobbsituasjoner = opplysningPaaBruker.jobbsituasjoner + JobbSituasjonBeskrivelse.valueOf(
+                        rs.getString(
+                            OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.JOBBSITUASJON
+                        )
+                    )
+                )
+            } else {
+                arbeidssoekerDataPaaBruker[fnr] = OpplysningerOmArbeidssoeker(
+                    sendtInnTidspunkt = DateUtils.toZonedDateTime(rs.getTimestamp(OPPLYSNINGER_OM_ARBEIDSSOEKER.SENDT_INN_TIDSPUNKT)),
+                    utdanning = mapTilUtdanning(rs.getString(OPPLYSNINGER_OM_ARBEIDSSOEKER.UTDANNING_NUS_KODE)),
+                    utdanningBestatt = JaNeiVetIkke.valueOf(rs.getString(OPPLYSNINGER_OM_ARBEIDSSOEKER.UTDANNING_BESTATT)),
+                    utdanningGodkjent = JaNeiVetIkke.valueOf(rs.getString(OPPLYSNINGER_OM_ARBEIDSSOEKER.UTDANNING_GODKJENT)),
+                    jobbsituasjoner = listOf(
+                        JobbSituasjonBeskrivelse.valueOf(
+                            rs.getString(
+                                OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.JOBBSITUASJON
+                            )
+                        )
+                    )
+                )
+            }
+        }
+        return arbeidssoekerDataPaaBruker.toMap()
+    }
+
+    fun hentProfileringsresultatListe(fnrs: List<Fnr>): Map<String, Profilering> {
+        val profileringsresultatPaaBruker = mutableMapOf<String, Profilering>()
+
+        val fnrsPostgresArray = "{${fnrs.joinToString(",") { it.get() }}}"
+        val sqlString = """
+            SELECT 
+                sap.${SISTE_ARBEIDSSOEKER_PERIODE.FNR},
+                p.${PROFILERING.PROFILERING_RESULTAT},
+                p.${PROFILERING.SENDT_INN_TIDSPUNKT}
+            FROM ${PROFILERING.TABLE_NAME} p
+            INNER JOIN ${SISTE_ARBEIDSSOEKER_PERIODE.TABLE_NAME} sap ON p.${PROFILERING.PERIODE_ID} = sap.${SISTE_ARBEIDSSOEKER_PERIODE.ARBEIDSSOKER_PERIODE_ID}
+            WHERE sap.${SISTE_ARBEIDSSOEKER_PERIODE.FNR} = ANY ('$fnrsPostgresArray'::varchar[])
+        """.trimIndent()
+
+        db.query(sqlString) { rs, _ ->
+            val fnr = rs.getString(SISTE_ARBEIDSSOEKER_PERIODE.FNR)
+            profileringsresultatPaaBruker[fnr] = Profilering(
+                profileringsresultat = Profileringsresultat.valueOf(rs.getString(PROFILERING.PROFILERING_RESULTAT)),
+                sendtInnTidspunkt = DateUtils.toZonedDateTime(rs.getTimestamp(PROFILERING.SENDT_INN_TIDSPUNKT))
+            )
+        }
+        return profileringsresultatPaaBruker.toMap()
+
+    }
+
+
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDataRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDataRepository.kt
@@ -42,11 +42,13 @@ class ArbeidssoekerDataRepository(
                     )
                 )
             } else {
+                val utdanningBestatt = rs.getString(OPPLYSNINGER_OM_ARBEIDSSOEKER.UTDANNING_BESTATT)
+                val utdanningGodkjent = rs.getString(OPPLYSNINGER_OM_ARBEIDSSOEKER.UTDANNING_GODKJENT)
                 arbeidssoekerDataPaaBruker[fnr] = OpplysningerOmArbeidssoeker(
                     sendtInnTidspunkt = DateUtils.toZonedDateTime(rs.getTimestamp(OPPLYSNINGER_OM_ARBEIDSSOEKER.SENDT_INN_TIDSPUNKT)),
                     utdanning = mapTilUtdanning(rs.getString(OPPLYSNINGER_OM_ARBEIDSSOEKER.UTDANNING_NUS_KODE)),
-                    utdanningBestatt = JaNeiVetIkke.valueOf(rs.getString(OPPLYSNINGER_OM_ARBEIDSSOEKER.UTDANNING_BESTATT)),
-                    utdanningGodkjent = JaNeiVetIkke.valueOf(rs.getString(OPPLYSNINGER_OM_ARBEIDSSOEKER.UTDANNING_GODKJENT)),
+                    utdanningBestatt = if(utdanningBestatt != null) JaNeiVetIkke.valueOf(utdanningBestatt) else null,
+                    utdanningGodkjent = if (utdanningGodkjent != null) JaNeiVetIkke.valueOf(utdanningGodkjent) else null,
                     jobbsituasjoner = listOf(
                         JobbSituasjonBeskrivelse.valueOf(
                             rs.getString(

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDomene.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDomene.kt
@@ -41,7 +41,8 @@ enum class JobbSituasjonBeskrivelse {
     DELTIDSJOBB_VIL_MER,
     NY_JOBB,
     KONKURS,
-    ANNET
+    ANNET,
+    INGEN_DATA
 }
 
 data class Profilering(

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDomene.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDomene.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 import no.nav.paw.arbeidssokerregisteret.api.v4.OpplysningerOmArbeidssoeker as OpplysningerOmArbeidssoekerKafkaMelding
 import no.nav.paw.arbeidssokerregisteret.api.v1.Profilering as ProfileringKafkaMelding
 
-data class OpplysningerOmArbeidssoeker(
+/*data class OpplysningerOmArbeidssoeker(
     val opplysningerOmArbeidssoekerId: UUID,
     val periodeId: UUID,
     val sendtInnTidspunkt: ZonedDateTime,
@@ -15,12 +15,12 @@ data class OpplysningerOmArbeidssoeker(
     val utdanningBestatt: String?,
     val utdanningGodkjent: String?,
     val opplysningerOmJobbsituasjon: OpplysningerOmArbeidssoekerJobbsituasjon
-)
+)*/
 
-data class OpplysningerOmArbeidssoekerJobbsituasjon(
+/*data class OpplysningerOmArbeidssoekerJobbsituasjon(
     val opplysningerOmArbeidssoekerId: UUID,
     val jobbsituasjon: List<JobbSituasjonBeskrivelse>
-)
+)*/
 
 enum class JobbSituasjonBeskrivelse {
     UKJENT_VERDI,
@@ -40,16 +40,16 @@ enum class JobbSituasjonBeskrivelse {
     ANNET
 }
 
-data class ArbeidssoekerPeriode(
+/*data class ArbeidssoekerPeriode(
     val arbeidssoekerperiodeId: UUID,
     val fnr: Fnr
-)
+)*/
 
-data class Profilering(
+/*data class Profilering(
     val periodeId: UUID,
     val profileringsresultat: Profileringsresultat,
     val sendtInnTidspunkt: ZonedDateTime
-)
+)*/
 
 enum class Profileringsresultat {
     UKJENT_VERDI,
@@ -59,50 +59,9 @@ enum class Profileringsresultat {
     OPPGITT_HINDRINGER
 }
 
-data class ProfileringResponse(
-    val profileringId: UUID,
-    val periodeId: UUID,
-    val opplysningerOmArbeidssoekerId: UUID,
-    val sendtInnAv: MetadataResponse,
-    val profilertTil: ProfilertTil,
-    val jobbetSammenhengendeSeksAvTolvSisteManeder: Boolean?,
-    val alder: Int?
-)
 
-fun ProfileringResponse.toProfilering(): Profilering {
-    return Profilering(
-        periodeId = this.periodeId,
-        profileringsresultat = Profileringsresultat.valueOf(this.profilertTil.name),
-        sendtInnTidspunkt = this.sendtInnAv.tidspunkt
-    )
-}
 
-fun OpplysningerOmArbeidssoekerResponse.toOpplysningerOmArbeidssoeker() = OpplysningerOmArbeidssoeker(
-    opplysningerOmArbeidssoekerId = this.opplysningerOmArbeidssoekerId,
-    periodeId = this.periodeId,
-    sendtInnTidspunkt = this.sendtInnAv.tidspunkt,
-    utdanningNusKode = this.utdanning?.nus,
-    utdanningBestatt = this.utdanning?.bestaatt?.name,
-    utdanningGodkjent = this.utdanning?.godkjent?.name,
-    opplysningerOmJobbsituasjon = OpplysningerOmArbeidssoekerJobbsituasjon(
-        this.opplysningerOmArbeidssoekerId,
-        this.jobbsituasjon.map { JobbSituasjonBeskrivelse.valueOf(it.beskrivelse.name) })
-)
 
-fun OpplysningerOmArbeidssoekerKafkaMelding.toOpplysningerOmArbeidssoeker() = OpplysningerOmArbeidssoeker(
-    opplysningerOmArbeidssoekerId = this.id,
-    periodeId = this.periodeId,
-    sendtInnTidspunkt = DateUtils.toZonedDateTime(this.sendtInnAv.tidspunkt),
-    utdanningNusKode = this.utdanning?.nus?.toString(),
-    utdanningBestatt = this.utdanning?.bestaatt?.name,
-    utdanningGodkjent = this.utdanning?.godkjent?.name,
-    opplysningerOmJobbsituasjon = OpplysningerOmArbeidssoekerJobbsituasjon(
-        this.id,
-        this.jobbsituasjon.beskrivelser.map { JobbSituasjonBeskrivelse.valueOf(it.beskrivelse.name) })
-)
 
-fun ProfileringKafkaMelding.toProfilering() = Profilering(
-    periodeId = this.periodeId,
-    profileringsresultat = Profileringsresultat.valueOf(this.profilertTil.name),
-    sendtInnTidspunkt = DateUtils.toZonedDateTime(this.sendtInnAv.tidspunkt)
-)
+
+

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDomene.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDomene.kt
@@ -1,26 +1,30 @@
 package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
 
 import no.nav.common.types.identer.Fnr
-import no.nav.pto.veilarbportefolje.util.DateUtils
 import java.time.ZonedDateTime
-import java.util.UUID
-import no.nav.paw.arbeidssokerregisteret.api.v4.OpplysningerOmArbeidssoeker as OpplysningerOmArbeidssoekerKafkaMelding
-import no.nav.paw.arbeidssokerregisteret.api.v1.Profilering as ProfileringKafkaMelding
+data class ArbeidssoekerData(
+    val fnr: Fnr,
+    val opplysningerOmArbeidssoeker: OpplysningerOmArbeidssoeker? = null,
+    val profilering: Profilering? = null
+)
 
-/*data class OpplysningerOmArbeidssoeker(
-    val opplysningerOmArbeidssoekerId: UUID,
-    val periodeId: UUID,
+data class OpplysningerOmArbeidssoeker(
     val sendtInnTidspunkt: ZonedDateTime,
-    val utdanningNusKode: String?,
-    val utdanningBestatt: String?,
-    val utdanningGodkjent: String?,
-    val opplysningerOmJobbsituasjon: OpplysningerOmArbeidssoekerJobbsituasjon
-)*/
+    val utdanning: Utdanning,
+    val utdanningBestatt: JaNeiVetIkke,
+    val utdanningGodkjent: JaNeiVetIkke,
+    val jobbsituasjoner: List<JobbSituasjonBeskrivelse>
+)
 
-/*data class OpplysningerOmArbeidssoekerJobbsituasjon(
-    val opplysningerOmArbeidssoekerId: UUID,
-    val jobbsituasjon: List<JobbSituasjonBeskrivelse>
-)*/
+enum class Utdanning {
+    INGEN_UTDANNING,
+    GRUNNSKOLE,
+    VIDEREGAENDE_GRUNNUTDANNING,
+    VIDEREGAENDE_FAGBREV_SVENNEBREV,
+    HOYERE_UTDANNING_1_TIL_4,
+    HOYERE_UTDANNING_5_ELLER_MER,
+    INGEN_SVAR
+}
 
 enum class JobbSituasjonBeskrivelse {
     UKJENT_VERDI,
@@ -40,16 +44,10 @@ enum class JobbSituasjonBeskrivelse {
     ANNET
 }
 
-/*data class ArbeidssoekerPeriode(
-    val arbeidssoekerperiodeId: UUID,
-    val fnr: Fnr
-)*/
-
-/*data class Profilering(
-    val periodeId: UUID,
+data class Profilering(
     val profileringsresultat: Profileringsresultat,
     val sendtInnTidspunkt: ZonedDateTime
-)*/
+)
 
 enum class Profileringsresultat {
     UKJENT_VERDI,

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDomene.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDomene.kt
@@ -11,8 +11,8 @@ data class ArbeidssoekerData(
 data class OpplysningerOmArbeidssoeker(
     val sendtInnTidspunkt: ZonedDateTime,
     val utdanning: Utdanning,
-    val utdanningBestatt: JaNeiVetIkke,
-    val utdanningGodkjent: JaNeiVetIkke,
+    val utdanningBestatt: JaNeiVetIkke? = null,
+    val utdanningGodkjent: JaNeiVetIkke? = null,
     val jobbsituasjoner: List<JobbSituasjonBeskrivelse>
 )
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerEntity.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerEntity.kt
@@ -35,9 +35,9 @@ fun OpplysningerOmArbeidssoekerResponse.toOpplysningerOmArbeidssoekerEntity() = 
     opplysningerOmArbeidssoekerId = this.opplysningerOmArbeidssoekerId,
     periodeId = this.periodeId,
     sendtInnTidspunkt = DateUtils.toTimestamp(this.sendtInnAv.tidspunkt),
-    utdanningNusKode = this.utdanning?.nus.orEmpty(),
-    utdanningBestatt = this.utdanning?.bestaatt?.name.orEmpty(),
-    utdanningGodkjent = this.utdanning?.godkjent?.name.orEmpty(),
+    utdanningNusKode = this.utdanning?.nus,
+    utdanningBestatt = this.utdanning?.bestaatt?.name,
+    utdanningGodkjent = this.utdanning?.godkjent?.name,
     opplysningerOmJobbsituasjon = OpplysningerOmArbeidssoekerJobbsituasjonEntity(
         this.opplysningerOmArbeidssoekerId,
         this.jobbsituasjon.map { it.beskrivelse.name })

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerEntity.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerEntity.kt
@@ -1,0 +1,70 @@
+package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
+
+import no.nav.pto.veilarbportefolje.util.DateUtils
+import java.sql.Timestamp
+import java.util.*
+
+data class OpplysningerOmArbeidssoekerEntity(
+    val opplysningerOmArbeidssoekerId: UUID,
+    val periodeId: UUID,
+    val sendtInnTidspunkt: Timestamp,
+    val utdanningNusKode: String?,
+    val utdanningBestatt: String?,
+    val utdanningGodkjent: String?,
+    val opplysningerOmJobbsituasjon: OpplysningerOmArbeidssoekerJobbsituasjonEntity
+)
+
+data class OpplysningerOmArbeidssoekerJobbsituasjonEntity(
+    val opplysningerOmArbeidssoekerId: UUID,
+    val jobbsituasjon: List<String>
+)
+
+data class ArbeidssoekerPeriodeEntity(
+    val arbeidssoekerperiodeId: UUID,
+    val fnr: String
+)
+
+data class ProfileringEntity(
+    val periodeId: UUID,
+    val profileringsresultat: String,
+    val sendtInnTidspunkt: Timestamp
+)
+
+
+fun OpplysningerOmArbeidssoekerResponse.toOpplysningerOmArbeidssoekerEntity() = OpplysningerOmArbeidssoekerEntity(
+    opplysningerOmArbeidssoekerId = this.opplysningerOmArbeidssoekerId,
+    periodeId = this.periodeId,
+    sendtInnTidspunkt = DateUtils.toTimestamp(this.sendtInnAv.tidspunkt),
+    utdanningNusKode = this.utdanning?.nus.orEmpty(),
+    utdanningBestatt = this.utdanning?.bestaatt?.name.orEmpty(),
+    utdanningGodkjent = this.utdanning?.godkjent?.name.orEmpty(),
+    opplysningerOmJobbsituasjon = OpplysningerOmArbeidssoekerJobbsituasjonEntity(
+        this.opplysningerOmArbeidssoekerId,
+        this.jobbsituasjon.map { it.beskrivelse.name })
+)
+
+fun no.nav.paw.arbeidssokerregisteret.api.v4.OpplysningerOmArbeidssoeker.toOpplysningerOmArbeidssoekerEntity() = OpplysningerOmArbeidssoekerEntity(
+    opplysningerOmArbeidssoekerId = this.id,
+    periodeId = this.periodeId,
+    sendtInnTidspunkt = Timestamp.from(this.sendtInnAv.tidspunkt),
+    utdanningNusKode = this.utdanning?.nus.toString(),
+    utdanningBestatt = this.utdanning?.bestaatt?.name,
+    utdanningGodkjent = this.utdanning?.godkjent?.name,
+    opplysningerOmJobbsituasjon = OpplysningerOmArbeidssoekerJobbsituasjonEntity(
+        this.id,
+        this.jobbsituasjon.beskrivelser.map { it.beskrivelse.name })
+)
+
+fun ProfileringResponse.toProfileringEntity(): ProfileringEntity {
+    return ProfileringEntity(
+        periodeId = this.periodeId,
+        profileringsresultat = this.profilertTil.name,
+        sendtInnTidspunkt = DateUtils.toTimestamp(this.sendtInnAv.tidspunkt)
+    )
+}
+
+fun no.nav.paw.arbeidssokerregisteret.api.v1.Profilering.toProfileringEntity() = ProfileringEntity(
+    periodeId = this.periodeId,
+    profileringsresultat = this.profilertTil.name,
+    sendtInnTidspunkt = Timestamp.from(this.sendtInnAv.tidspunkt)
+)

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerMapper.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerMapper.kt
@@ -1,5 +1,7 @@
 package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
 
+import no.nav.pto.veilarbportefolje.domene.filtervalg.DinSituasjonSvar
+
 fun mapTilUtdanning(nus: String?): Utdanning {
     return when (nus) {
         "0" -> Utdanning.INGEN_UTDANNING
@@ -10,4 +12,25 @@ fun mapTilUtdanning(nus: String?): Utdanning {
         "7" -> Utdanning.HOYERE_UTDANNING_5_ELLER_MER
         else -> Utdanning.INGEN_SVAR
     }
+}
+
+
+fun mapJobbsituasjonTilSituasjonFraGammelRegistrering(jobbsituasjon: String?): List<String> {
+    if(JobbSituasjonBeskrivelse.HAR_BLITT_SAGT_OPP.name == jobbsituasjon) {
+        return listOf(JobbSituasjonBeskrivelse.HAR_BLITT_SAGT_OPP.name, DinSituasjonSvar.MISTET_JOBBEN.name, DinSituasjonSvar.OPPSIGELSE.name, )
+    }
+    if(JobbSituasjonBeskrivelse.ER_PERMITTERT.name == jobbsituasjon) {
+        return listOf(JobbSituasjonBeskrivelse.ER_PERMITTERT.name, DinSituasjonSvar.ENDRET_PERMITTERINGSPROSENT.name, DinSituasjonSvar.TILBAKE_TIL_JOBB.name )
+    }
+    if(JobbSituasjonBeskrivelse.HAR_SAGT_OPP.name == jobbsituasjon) {
+        return listOf(JobbSituasjonBeskrivelse.HAR_SAGT_OPP.name, DinSituasjonSvar.SAGT_OPP.name)
+    }
+    if(JobbSituasjonBeskrivelse.IKKE_VAERT_I_JOBB_SISTE_2_AAR.name == jobbsituasjon) {
+        return listOf(JobbSituasjonBeskrivelse.IKKE_VAERT_I_JOBB_SISTE_2_AAR.name, DinSituasjonSvar.JOBB_OVER_2_AAR.name)
+    }
+    if(JobbSituasjonBeskrivelse.ANNET.name == jobbsituasjon) {
+        return listOf(JobbSituasjonBeskrivelse.ANNET.name, DinSituasjonSvar.VIL_FORTSETTE_I_JOBB.name)
+    }
+    return if (jobbsituasjon != null) listOf(jobbsituasjon) else emptyList()
+
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerMapper.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerMapper.kt
@@ -1,0 +1,13 @@
+package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
+
+fun mapTilUtdanning(nus: String): Utdanning {
+    return when (nus) {
+        "0" -> Utdanning.INGEN_UTDANNING
+        "2" -> Utdanning.GRUNNSKOLE
+        "3" -> Utdanning.VIDEREGAENDE_GRUNNUTDANNING
+        "4" -> Utdanning.VIDEREGAENDE_FAGBREV_SVENNEBREV
+        "6" -> Utdanning.HOYERE_UTDANNING_1_TIL_4
+        "7" -> Utdanning.HOYERE_UTDANNING_5_ELLER_MER
+        else -> Utdanning.INGEN_SVAR
+    }
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerMapper.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerMapper.kt
@@ -1,6 +1,6 @@
 package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
 
-fun mapTilUtdanning(nus: String): Utdanning {
+fun mapTilUtdanning(nus: String?): Utdanning {
     return when (nus) {
         "0" -> Utdanning.INGEN_UTDANNING
         "2" -> Utdanning.GRUNNSKOLE

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerMapper.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerMapper.kt
@@ -14,23 +14,13 @@ fun mapTilUtdanning(nus: String?): Utdanning {
     }
 }
 
-
-fun mapJobbsituasjonTilSituasjonFraGammelRegistrering(jobbsituasjon: String?): List<String> {
-    if(JobbSituasjonBeskrivelse.HAR_BLITT_SAGT_OPP.name == jobbsituasjon) {
-        return listOf(JobbSituasjonBeskrivelse.HAR_BLITT_SAGT_OPP.name, DinSituasjonSvar.MISTET_JOBBEN.name, DinSituasjonSvar.OPPSIGELSE.name, )
+fun inkludereSituasjonerFraBadeVeilarbregistreringOgArbeidssoekerregistrering(jobbsituasjon: JobbSituasjonBeskrivelse?): List<String> {
+    return when(jobbsituasjon) {
+        JobbSituasjonBeskrivelse.HAR_BLITT_SAGT_OPP -> listOf(JobbSituasjonBeskrivelse.HAR_BLITT_SAGT_OPP.name, DinSituasjonSvar.MISTET_JOBBEN.name, DinSituasjonSvar.OPPSIGELSE.name)
+        JobbSituasjonBeskrivelse.ER_PERMITTERT -> listOf(JobbSituasjonBeskrivelse.ER_PERMITTERT.name, DinSituasjonSvar.ENDRET_PERMITTERINGSPROSENT.name, DinSituasjonSvar.TILBAKE_TIL_JOBB.name )
+        JobbSituasjonBeskrivelse.HAR_SAGT_OPP -> listOf(JobbSituasjonBeskrivelse.HAR_SAGT_OPP.name, DinSituasjonSvar.SAGT_OPP.name)
+        JobbSituasjonBeskrivelse.IKKE_VAERT_I_JOBB_SISTE_2_AAR -> listOf(JobbSituasjonBeskrivelse.IKKE_VAERT_I_JOBB_SISTE_2_AAR.name, DinSituasjonSvar.JOBB_OVER_2_AAR.name)
+        JobbSituasjonBeskrivelse.ANNET -> listOf(JobbSituasjonBeskrivelse.ANNET.name, DinSituasjonSvar.VIL_FORTSETTE_I_JOBB.name)
+        else -> if (jobbsituasjon != null) listOf(jobbsituasjon.name) else emptyList()
     }
-    if(JobbSituasjonBeskrivelse.ER_PERMITTERT.name == jobbsituasjon) {
-        return listOf(JobbSituasjonBeskrivelse.ER_PERMITTERT.name, DinSituasjonSvar.ENDRET_PERMITTERINGSPROSENT.name, DinSituasjonSvar.TILBAKE_TIL_JOBB.name )
-    }
-    if(JobbSituasjonBeskrivelse.HAR_SAGT_OPP.name == jobbsituasjon) {
-        return listOf(JobbSituasjonBeskrivelse.HAR_SAGT_OPP.name, DinSituasjonSvar.SAGT_OPP.name)
-    }
-    if(JobbSituasjonBeskrivelse.IKKE_VAERT_I_JOBB_SISTE_2_AAR.name == jobbsituasjon) {
-        return listOf(JobbSituasjonBeskrivelse.IKKE_VAERT_I_JOBB_SISTE_2_AAR.name, DinSituasjonSvar.JOBB_OVER_2_AAR.name)
-    }
-    if(JobbSituasjonBeskrivelse.ANNET.name == jobbsituasjon) {
-        return listOf(JobbSituasjonBeskrivelse.ANNET.name, DinSituasjonSvar.VIL_FORTSETTE_I_JOBB.name)
-    }
-    return if (jobbsituasjon != null) listOf(jobbsituasjon) else emptyList()
-
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
@@ -71,11 +71,11 @@ class ArbeidssoekerService(
         }
 
         sisteArbeidssoekerPeriodeRepository.slettSisteArbeidssoekerPeriode(fnr)
-        sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(fnr, periodeId)
+        sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(ArbeidssoekerPeriodeEntity(periodeId, fnr.get()))
         secureLog.info("Lagret siste arbeidssøkerperiode for bruker med fnr: $fnr")
 
-        val opplysningerOmArbeidssoeker: OpplysningerOmArbeidssoeker? =
-            hentSisteOpplysningerOmArbeidssoeker(fnr, periodeId)?.toOpplysningerOmArbeidssoeker()
+        val opplysningerOmArbeidssoeker: OpplysningerOmArbeidssoekerEntity? =
+            hentSisteOpplysningerOmArbeidssoeker(fnr, periodeId)?.toOpplysningerOmArbeidssoekerEntity()
         if (opplysningerOmArbeidssoeker == null) {
             secureLog.info("Fant ingen opplysninger om arbeidssøker for bruker med fnr: $fnr")
             return
@@ -86,11 +86,11 @@ class ArbeidssoekerService(
         secureLog.info("Lagret opplysninger om arbeidssøker for bruker med fnr: $fnr")
 
 
-        val profilering: Profilering? = hentSisteProfilering(
+        val profilering: ProfileringEntity? = hentSisteProfilering(
             fnr,
             periodeId,
             opplysningerOmArbeidssoeker.opplysningerOmArbeidssoekerId
-        )?.toProfilering()
+        )?.toProfileringEntity()
 
         if (profilering == null) {
             secureLog.info("Fant ingen profilering for bruker med fnr: $fnr")
@@ -121,9 +121,9 @@ class ArbeidssoekerService(
         }
 
         val fnr = sisteArbeidssoekerPeriode.fnr
-        if (!pdlIdentRepository.erBrukerUnderOppfolging(fnr.get())) {
+        if (!pdlIdentRepository.erBrukerUnderOppfolging(fnr)) {
             secureLog.info(
-                "Bruker med fnr ${fnr.get()} er ikke under oppfølging, men har arbeidssøkerpeiode lagret. " +
+                "Bruker med fnr ${fnr} er ikke under oppfølging, men har arbeidssøkerpeiode lagret. " +
                         "Dette betyr at arbeidssøkerdata ikke har blitt slettet riktig når bruker gikk ut av oppfølging. " +
                         "Ignorer melding, data må slettes manuelt og slettelogikk ved utgang av oppfølging bør kontrollsjekkes for feil."
             )
@@ -138,7 +138,7 @@ class ArbeidssoekerService(
         }
 
         opplysningerOmArbeidssoekerRepository.slettOpplysningerOmArbeidssoeker(sisteArbeidssoekerPeriode.arbeidssoekerperiodeId)
-        opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(opplysninger.toOpplysningerOmArbeidssoeker())
+        opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(opplysninger.toOpplysningerOmArbeidssoekerEntity())
         secureLog.info("Lagret opplysninger om arbeidssøker for bruker med fnr: $fnr")
     }
 
@@ -159,16 +159,16 @@ class ArbeidssoekerService(
         }
 
         val fnr = sisteArbeidssoekerPeriode.fnr
-        if (!pdlIdentRepository.erBrukerUnderOppfolging(fnr.get())) {
+        if (!pdlIdentRepository.erBrukerUnderOppfolging(fnr)) {
             secureLog.info(
-                "Bruker med fnr ${fnr.get()} er ikke under oppfølging, men har arbeidssøkerpeiode lagret. " +
+                "Bruker med fnr ${fnr} er ikke under oppfølging, men har arbeidssøkerpeiode lagret. " +
                         "Dette betyr at arbeidssøkerdata ikke har blitt slettet riktig når bruker gikk ut av oppfølging. " +
                         "Ignorer melding, data må slettes manuelt og slettelogikk ved utgang av oppfølging bør kontrollsjekkes for feil."
             )
             return
         }
 
-        profileringRepository.insertProfilering(kafkaMelding.toProfilering())
+        profileringRepository.insertProfilering(kafkaMelding.toProfileringEntity())
         secureLog.info("Lagret profilering for bruker med fnr: $fnr")
     }
 
@@ -199,7 +199,7 @@ class ArbeidssoekerService(
         }
 
         sisteArbeidssoekerPeriodeRepository.slettSisteArbeidssoekerPeriode(fnr)
-        sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(fnr, aktivArbeidssoekerperiode.periodeId)
+        sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(ArbeidssoekerPeriodeEntity(aktivArbeidssoekerperiode.periodeId, fnr.get()))
         secureLog.info("Lagret siste arbeidssøkerperiode for bruker med fnr: $fnr")
 
         val sisteOpplysningerOmArbeidssoeker =
@@ -212,7 +212,7 @@ class ArbeidssoekerService(
         }
 
         opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(
-            sisteOpplysningerOmArbeidssoeker.toOpplysningerOmArbeidssoeker()
+            sisteOpplysningerOmArbeidssoeker.toOpplysningerOmArbeidssoekerEntity()
         )
         secureLog.info("Lagret opplysninger om arbeidssøker for bruker med fnr: $fnr")
 
@@ -228,7 +228,7 @@ class ArbeidssoekerService(
             return
         }
 
-        profileringRepository.insertProfilering(sisteProfilering.toProfilering())
+        profileringRepository.insertProfilering(sisteProfilering.toProfileringEntity())
         secureLog.info("Lagret profilering for bruker med fnr: $fnr")
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OpplysningerOmArbeidssoekerRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OpplysningerOmArbeidssoekerRepository.kt
@@ -16,12 +16,12 @@ import java.util.*
 class OpplysningerOmArbeidssoekerRepository(
     private val db: JdbcTemplate
 ) {
-    fun insertOpplysningerOmArbeidssoekerOgJobbsituasjon(opplysningerOmArbeidssoeker: OpplysningerOmArbeidssoeker) {
-        insertOpplysningerOmArbeidssoeker(opplysningerOmArbeidssoeker)
-        insertOpplysningerOmArbeidssoekerJobbsituasjon(opplysningerOmArbeidssoeker.opplysningerOmJobbsituasjon)
+    fun insertOpplysningerOmArbeidssoekerOgJobbsituasjon(opplysningerOmArbeidssoekerEntity: OpplysningerOmArbeidssoekerEntity) {
+        insertOpplysningerOmArbeidssoeker(opplysningerOmArbeidssoekerEntity)
+        insertOpplysningerOmArbeidssoekerJobbsituasjon(opplysningerOmArbeidssoekerEntity.opplysningerOmJobbsituasjon)
     }
 
-    private fun insertOpplysningerOmArbeidssoeker(opplysningerOmArbeidssoeker: OpplysningerOmArbeidssoeker) {
+    private fun insertOpplysningerOmArbeidssoeker(opplysningerOmArbeidssoekerEntity: OpplysningerOmArbeidssoekerEntity) {
         val sqlString = """INSERT INTO $TABLE_NAME ( 
                     $OPPLYSNINGER_OM_ARBEIDSSOEKER_ID, 
                     $PERIODE_ID,
@@ -33,16 +33,16 @@ class OpplysningerOmArbeidssoekerRepository(
                 VALUES (?, ?, ?, ?, ?, ?)"""
         db.update(
             sqlString,
-            opplysningerOmArbeidssoeker.opplysningerOmArbeidssoekerId,
-            opplysningerOmArbeidssoeker.periodeId,
-            DateUtils.toTimestamp(opplysningerOmArbeidssoeker.sendtInnTidspunkt),
-            opplysningerOmArbeidssoeker.utdanningNusKode,
-            opplysningerOmArbeidssoeker.utdanningBestatt,
-            opplysningerOmArbeidssoeker.utdanningGodkjent
+            opplysningerOmArbeidssoekerEntity.opplysningerOmArbeidssoekerId,
+            opplysningerOmArbeidssoekerEntity.periodeId,
+            opplysningerOmArbeidssoekerEntity.sendtInnTidspunkt,
+            opplysningerOmArbeidssoekerEntity.utdanningNusKode,
+            opplysningerOmArbeidssoekerEntity.utdanningBestatt,
+            opplysningerOmArbeidssoekerEntity.utdanningGodkjent
         )
     }
 
-    private fun insertOpplysningerOmArbeidssoekerJobbsituasjon(opplysningerOmArbeidssoekerJobbsituasjon: OpplysningerOmArbeidssoekerJobbsituasjon) {
+    private fun insertOpplysningerOmArbeidssoekerJobbsituasjon(opplysningerOmArbeidssoekerJobbsituasjonEntity: OpplysningerOmArbeidssoekerJobbsituasjonEntity) {
         val sqlString = """INSERT INTO ${OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.TABLE_NAME} ( 
                     ${OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.OPPLYSNINGER_OM_ARBEIDSSOEKER_ID}, 
                     ${OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.JOBBSITUASJON}
@@ -52,12 +52,12 @@ class OpplysningerOmArbeidssoekerRepository(
         db.batchUpdate(sqlString, object : BatchPreparedStatementSetter {
             @Throws(SQLException::class)
             override fun setValues(ps: PreparedStatement, i: Int) {
-                ps.setObject(1, opplysningerOmArbeidssoekerJobbsituasjon.opplysningerOmArbeidssoekerId, Types.OTHER)
-                ps.setString(2, opplysningerOmArbeidssoekerJobbsituasjon.jobbsituasjon[i].name)
+                ps.setObject(1, opplysningerOmArbeidssoekerJobbsituasjonEntity.opplysningerOmArbeidssoekerId, Types.OTHER)
+                ps.setString(2, opplysningerOmArbeidssoekerJobbsituasjonEntity.jobbsituasjon[i])
             }
 
             override fun getBatchSize(): Int {
-                return opplysningerOmArbeidssoekerJobbsituasjon.jobbsituasjon.size
+                return opplysningerOmArbeidssoekerJobbsituasjonEntity.jobbsituasjon.size
             }
         })
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OppslagArbeidssoekerregisteretClient.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OppslagArbeidssoekerregisteretClient.kt
@@ -141,6 +141,16 @@ data class UtdanningResponse(
 // Profilering typer
 data class ProfileringRequest(val identitetsnummer: String, val periodeId: UUID)
 
+data class ProfileringResponse(
+    val profileringId: UUID,
+    val periodeId: UUID,
+    val opplysningerOmArbeidssoekerId: UUID,
+    val sendtInnAv: MetadataResponse,
+    val profilertTil: ProfilertTil,
+    val jobbetSammenhengendeSeksAvTolvSisteManeder: Boolean?,
+    val alder: Int?
+)
+
 enum class ProfilertTil {
     UKJENT_VERDI,
     UDEFINERT,

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ProfileringRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ProfileringRepository.kt
@@ -1,13 +1,12 @@
 package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
 
 import no.nav.pto.veilarbportefolje.database.PostgresTable.PROFILERING
-import no.nav.pto.veilarbportefolje.util.DateUtils
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
 
 @Repository
 class ProfileringRepository(private val db: JdbcTemplate) {
-    fun insertProfilering(sisteProfilering: Profilering) {
+    fun insertProfilering(sisteProfileringEntity: ProfileringEntity) {
         db.update(
             """INSERT INTO ${PROFILERING.TABLE_NAME} (
                     ${PROFILERING.PERIODE_ID}, 
@@ -17,9 +16,9 @@ class ProfileringRepository(private val db: JdbcTemplate) {
                  ON CONFLICT (${PROFILERING.PERIODE_ID}) DO UPDATE SET
                  (${PROFILERING.PROFILERING_RESULTAT}, ${PROFILERING.SENDT_INN_TIDSPUNKT}) = (excluded.${PROFILERING.PROFILERING_RESULTAT}, excluded.${PROFILERING.SENDT_INN_TIDSPUNKT})
                 """,
-            sisteProfilering.periodeId,
-            sisteProfilering.profileringsresultat.name,
-            DateUtils.toTimestamp(sisteProfilering.sendtInnTidspunkt)
+            sisteProfileringEntity.periodeId,
+            sisteProfileringEntity.profileringsresultat,
+            sisteProfileringEntity.sendtInnTidspunkt
         )
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/SisteArbeidssoekerPeriodeRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/SisteArbeidssoekerPeriodeRepository.kt
@@ -11,22 +11,22 @@ import java.util.*
 class SisteArbeidssoekerPeriodeRepository(
     private val db: JdbcTemplate
 ) {
-    fun insertSisteArbeidssoekerPeriode(fnr: Fnr, periodeId: UUID) {
+    fun insertSisteArbeidssoekerPeriode(sisteArbeidssoekerPeriode: ArbeidssoekerPeriodeEntity) {
         db.update(
             """INSERT INTO $TABLE_NAME values (?,?)""",
-            periodeId,
-            fnr.get()
+            sisteArbeidssoekerPeriode.arbeidssoekerperiodeId,
+            sisteArbeidssoekerPeriode.fnr
         )
     }
 
-    fun hentSisteArbeidssoekerPeriode(periodeId: UUID): ArbeidssoekerPeriode? {
+    fun hentSisteArbeidssoekerPeriode(periodeId: UUID): ArbeidssoekerPeriodeEntity? {
         return queryForObjectOrNull {
             db.queryForObject(
                 """SELECT * FROM $TABLE_NAME WHERE $ARBEIDSSOKER_PERIODE_ID = ?""",
                 { rs, _ ->
-                    ArbeidssoekerPeriode(
+                    ArbeidssoekerPeriodeEntity(
                         rs.getObject(ARBEIDSSOKER_PERIODE_ID, UUID::class.java),
-                        Fnr.of(rs.getString(FNR))
+                        rs.getString(FNR)
                     )
                 },
                 periodeId

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Bruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Bruker.java
@@ -106,6 +106,7 @@ public class Bruker {
     EnsligeForsorgereOvergangsstonad ensligeForsorgereOvergangsstonad;
 
     LocalDate brukersSituasjonSistEndret;
+    LocalDate utdanningOgSituasjonSistEndret;
 
     HuskelappForBruker huskelapp;
     String fargekategori;
@@ -203,6 +204,7 @@ public class Bruker {
                 .setBarnUnder18AarData(bruker.getBarn_under_18_aar())
                 .setEnsligeForsorgereOvergangsstonad(bruker.getEnslige_forsorgere_overgangsstonad())
                 .setBrukersSituasjonSistEndret(bruker.getBrukers_situasjon_sist_endret())
+                .setUtdanningOgSituasjonSistEndret(bruker.getUtdanning_og_situasjon_sist_endret())
                 .setHuskelapp(bruker.getHuskelapp())
                 .setFargekategori(bruker.getFargekategori());
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Filtervalg.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Filtervalg.java
@@ -2,6 +2,7 @@ package no.nav.pto.veilarbportefolje.domene;
 
 import lombok.Data;
 import lombok.experimental.Accessors;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.JobbSituasjonBeskrivelse;
 import no.nav.pto.veilarbportefolje.domene.filtervalg.DinSituasjonSvar;
 import no.nav.pto.veilarbportefolje.domene.filtervalg.UtdanningBestattSvar;
 import no.nav.pto.veilarbportefolje.domene.filtervalg.UtdanningGodkjentSvar;
@@ -34,7 +35,7 @@ public class Filtervalg {
     public List<String> tiltakstyper = new ArrayList<>();
     public List<ManuellBrukerStatus> manuellBrukerStatus = new ArrayList<>();
     public String navnEllerFnrQuery;
-    public List<DinSituasjonSvar> registreringstype = new ArrayList<>();
+    public List<JobbSituasjonBeskrivelse> registreringstype = new ArrayList<>();
     public List<UtdanningSvar> utdanning = new ArrayList<>();
     public List<UtdanningBestattSvar> utdanningBestatt = new ArrayList<>();
     public List<UtdanningGodkjentSvar> utdanningGodkjent = new ArrayList<>();

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexer.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexer.java
@@ -1,9 +1,11 @@
 package no.nav.pto.veilarbportefolje.opensearch;
 
+import io.getunleash.DefaultUnleash;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
+import no.nav.pto.veilarbportefolje.config.FeatureToggle;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OppfolgingsBruker;
 import no.nav.pto.veilarbportefolje.postgres.BrukerRepositoryV2;
 import no.nav.pto.veilarbportefolje.postgres.PostgresOpensearchMapper;
@@ -36,6 +38,7 @@ public class OpensearchIndexer {
     private final IndexName alias;
     private final PostgresOpensearchMapper postgresOpensearchMapper;
     private final OpensearchIndexerV2 opensearchIndexerV2;
+    private final DefaultUnleash defaultUnleash;
 
     public void indekser(AktorId aktoerId) {
         Optional<OppfolgingsBruker> bruker;
@@ -121,6 +124,9 @@ public class OpensearchIndexer {
         postgresOpensearchMapper.flettInnStatsborgerskapData(brukere);
         postgresOpensearchMapper.flettInnEnsligeForsorgereData(brukere);
         postgresOpensearchMapper.flettInnBarnUnder18Aar(brukere);
+        if (FeatureToggle.brukNyttArbeidssoekerregister(defaultUnleash)) {
+            postgresOpensearchMapper.flettInnOpplysningerOmArbeidssoekerData(brukere);
+        }
 
         if (brukere.isEmpty()) {
             log.warn("Skriver ikke til index da alle brukere i batchen er ugyldige");

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
@@ -49,7 +49,7 @@ public class OpensearchIndexerV2 {
     public void updateRegistering(AktorId aktoerId, ArbeidssokerRegistrertEvent arbeidssokerRegistrertEvent) {
         final XContentBuilder content = jsonBuilder()
                 .startObject()
-                .field("brukers_situasjon", arbeidssokerRegistrertEvent.getBrukersSituasjon())
+                .field("brukers_situasjoner", List.of(arbeidssokerRegistrertEvent.getBrukersSituasjon()))
                 .field("utdanning", arbeidssokerRegistrertEvent.getUtdanning())
                 .field("utdanning_bestatt", arbeidssokerRegistrertEvent.getUtdanningBestatt())
                 .field("utdanning_godkjent", arbeidssokerRegistrertEvent.getUtdanningGodkjent())
@@ -63,7 +63,7 @@ public class OpensearchIndexerV2 {
     public void updateEndringerIRegistering(AktorId aktoerId, ArbeidssokerBesvarelseEvent endringIRegistreringsdataEvent) {
         final XContentBuilder content = jsonBuilder()
                 .startObject()
-                .field("brukers_situasjon", endringIRegistreringsdataEvent.getBesvarelse().getDinSituasjon().getVerdi())
+                .field("brukers_situasjoner", List.of(endringIRegistreringsdataEvent.getBesvarelse().getDinSituasjon().getVerdi()))
                 .field("brukers_situasjon_sist_endret", endringIRegistreringsdataEvent.getBesvarelse().getDinSituasjon().getEndretTidspunkt())
                 .endObject();
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
@@ -7,6 +7,9 @@ import no.nav.arbeid.soker.registrering.ArbeidssokerRegistrertEvent;
 import no.nav.common.types.identer.AktorId;
 import no.nav.paw.besvarelse.ArbeidssokerBesvarelseEvent;
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteDTO;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.OpplysningerOmArbeidssoeker;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.OpplysningerOmArbeidssoekerEntity;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ProfileringEntity;
 import no.nav.pto.veilarbportefolje.dialog.Dialogdata;
 import no.nav.pto.veilarbportefolje.domene.HuskelappForBruker;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
@@ -32,6 +35,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerMapperKt.mapTilUtdanning;
 import static no.nav.pto.veilarbportefolje.util.DateUtils.*;
 import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
@@ -68,6 +72,30 @@ public class OpensearchIndexerV2 {
                 .endObject();
 
         update(aktoerId, content, "Oppdater endring i registrering");
+    }
+
+    @SneakyThrows
+    public void updateOpplysningerOmArbeidssoeker(AktorId aktoerId, OpplysningerOmArbeidssoekerEntity opplysningerOmArbeidssoeker) {
+        final XContentBuilder content = jsonBuilder()
+                .startObject()
+                .field("brukers_situasjoner", opplysningerOmArbeidssoeker.getOpplysningerOmJobbsituasjon().getJobbsituasjon())
+                .field("utdanning", mapTilUtdanning(opplysningerOmArbeidssoeker.getUtdanningNusKode()))
+                .field("utdanning_bestatt", opplysningerOmArbeidssoeker.getUtdanningBestatt())
+                .field("utdanning_godkjent", opplysningerOmArbeidssoeker.getUtdanningGodkjent())
+                .field("utdanning_og_situasjon_sist_endret", toLocalDate(opplysningerOmArbeidssoeker.getSendtInnTidspunkt()))
+                .endObject();
+
+        update(aktoerId, content, "Oppdater opplysninger om arbeidssøker");
+    }
+
+    @SneakyThrows
+    public void updateProfilering(AktorId aktoerId, ProfileringEntity profileringEntity) {
+        final XContentBuilder content = jsonBuilder()
+                .startObject()
+                .field("profilering_resultat", profileringEntity.getProfileringsresultat())
+                .endObject();
+
+        update(aktoerId, content, "Oppdater profileringsresultat");
     }
 
     @SneakyThrows

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -2,6 +2,7 @@ package no.nav.pto.veilarbportefolje.opensearch;
 
 import lombok.extern.slf4j.Slf4j;
 import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.JobbSituasjonBeskrivelse;
 import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.domene.*;
 import no.nav.pto.veilarbportefolje.domene.filtervalg.DinSituasjonSvar;
@@ -33,6 +34,7 @@ import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+import static no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerMapperKt.mapJobbsituasjonTilSituasjonFraGammelRegistrering;
 import static no.nav.pto.veilarbportefolje.domene.AktivitetFiltervalg.JA;
 import static no.nav.pto.veilarbportefolje.domene.AktivitetFiltervalg.NEI;
 import static no.nav.pto.veilarbportefolje.util.DateUtils.toIsoUTC;
@@ -349,10 +351,12 @@ public class OpensearchQueryBuilder {
         if (filtervalg.harDinSituasjonSvar()) {
             BoolQueryBuilder brukerensSituasjonSubQuery = boolQuery();
             filtervalg.registreringstype.forEach(dinSituasjonSvar -> {
-                if (dinSituasjonSvar == DinSituasjonSvar.INGEN_DATA) {
+                if (dinSituasjonSvar == JobbSituasjonBeskrivelse.INGEN_DATA) {
                     brukerensSituasjonSubQuery.should(boolQuery().mustNot(existsQuery("brukers_situasjoner")));
                 } else {
-                    brukerensSituasjonSubQuery.should(matchQuery("brukers_situasjoner", dinSituasjonSvar));
+                    mapJobbsituasjonTilSituasjonFraGammelRegistrering(dinSituasjonSvar.name()).forEach(sokerOrd ->
+                            brukerensSituasjonSubQuery.should(matchQuery("brukers_situasjoner", sokerOrd))
+                    );
                 }
 
             });
@@ -465,7 +469,8 @@ public class OpensearchQueryBuilder {
             case "barn_under_18_aar" ->
                     sorterBarnUnder18(searchSourceBuilder, order, brukerinnsynTilganger, filtervalg);
             case "brukersSituasjonSistEndret" -> searchSourceBuilder.sort("brukers_situasjon_sist_endret", order);
-            case "utdanningOgSituasjonSistEndret" -> searchSourceBuilder.sort("utdanning_og_situasjon_sist_endret", order);
+            case "utdanningOgSituasjonSistEndret" ->
+                    searchSourceBuilder.sort("utdanning_og_situasjon_sist_endret", order);
             case "huskelapp_frist" -> sorterHuskelappFrist(searchSourceBuilder, order);
             case "huskelapp" -> sorterHuskelappEksistere(searchSourceBuilder, order);
             case "huskelapp_kommentar" -> searchSourceBuilder.sort("huskelapp.kommentar", order);

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -465,6 +465,7 @@ public class OpensearchQueryBuilder {
             case "barn_under_18_aar" ->
                     sorterBarnUnder18(searchSourceBuilder, order, brukerinnsynTilganger, filtervalg);
             case "brukersSituasjonSistEndret" -> searchSourceBuilder.sort("brukers_situasjon_sist_endret", order);
+            case "utdanningOgSituasjonSistEndret" -> searchSourceBuilder.sort("utdanning_og_situasjon_sist_endret", order);
             case "huskelapp_frist" -> sorterHuskelappFrist(searchSourceBuilder, order);
             case "huskelapp" -> sorterHuskelappEksistere(searchSourceBuilder, order);
             case "huskelapp_kommentar" -> searchSourceBuilder.sort("huskelapp.kommentar", order);

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -5,7 +5,6 @@ import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.JobbSituasjonBeskrivelse;
 import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.domene.*;
-import no.nav.pto.veilarbportefolje.domene.filtervalg.DinSituasjonSvar;
 import no.nav.pto.veilarbportefolje.domene.filtervalg.UtdanningBestattSvar;
 import no.nav.pto.veilarbportefolje.domene.filtervalg.UtdanningGodkjentSvar;
 import no.nav.pto.veilarbportefolje.domene.filtervalg.UtdanningSvar;
@@ -34,7 +33,7 @@ import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
-import static no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerMapperKt.mapJobbsituasjonTilSituasjonFraGammelRegistrering;
+import static no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerMapperKt.inkludereSituasjonerFraBadeVeilarbregistreringOgArbeidssoekerregistrering;
 import static no.nav.pto.veilarbportefolje.domene.AktivitetFiltervalg.JA;
 import static no.nav.pto.veilarbportefolje.domene.AktivitetFiltervalg.NEI;
 import static no.nav.pto.veilarbportefolje.util.DateUtils.toIsoUTC;
@@ -350,11 +349,11 @@ public class OpensearchQueryBuilder {
 
         if (filtervalg.harDinSituasjonSvar()) {
             BoolQueryBuilder brukerensSituasjonSubQuery = boolQuery();
-            filtervalg.registreringstype.forEach(dinSituasjonSvar -> {
-                if (dinSituasjonSvar == JobbSituasjonBeskrivelse.INGEN_DATA) {
+            filtervalg.registreringstype.forEach(jobbSituasjonBeskrivelse -> {
+                if (jobbSituasjonBeskrivelse == JobbSituasjonBeskrivelse.INGEN_DATA) {
                     brukerensSituasjonSubQuery.should(boolQuery().mustNot(existsQuery("brukers_situasjoner")));
                 } else {
-                    mapJobbsituasjonTilSituasjonFraGammelRegistrering(dinSituasjonSvar.name()).forEach(sokerOrd ->
+                    inkludereSituasjonerFraBadeVeilarbregistreringOgArbeidssoekerregistrering(jobbSituasjonBeskrivelse).forEach(sokerOrd ->
                             brukerensSituasjonSubQuery.should(matchQuery("brukers_situasjoner", sokerOrd))
                     );
                 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -350,9 +350,9 @@ public class OpensearchQueryBuilder {
             BoolQueryBuilder brukerensSituasjonSubQuery = boolQuery();
             filtervalg.registreringstype.forEach(dinSituasjonSvar -> {
                 if (dinSituasjonSvar == DinSituasjonSvar.INGEN_DATA) {
-                    brukerensSituasjonSubQuery.should(boolQuery().mustNot(existsQuery("brukers_situasjon")));
+                    brukerensSituasjonSubQuery.should(boolQuery().mustNot(existsQuery("brukers_situasjoner")));
                 } else {
-                    brukerensSituasjonSubQuery.should(matchQuery("brukers_situasjon", dinSituasjonSvar));
+                    brukerensSituasjonSubQuery.should(matchQuery("brukers_situasjoner", dinSituasjonSvar));
                 }
 
             });

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/OppfolgingsBruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/OppfolgingsBruker.java
@@ -103,6 +103,7 @@ public class OppfolgingsBruker {
     boolean er_sykmeldt_med_arbeidsgiver;
     List<String> brukers_situasjoner;
     LocalDate brukers_situasjon_sist_endret;
+    LocalDate utdanning_og_situasjon_sist_endret;
     String profilering_resultat;
     String utdanning;
     String utdanning_bestatt;

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/OppfolgingsBruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/OppfolgingsBruker.java
@@ -101,7 +101,7 @@ public class OppfolgingsBruker {
     String utkast_14a_ansvarlig_veileder;
     boolean trenger_revurdering;
     boolean er_sykmeldt_med_arbeidsgiver;
-    String brukers_situasjon;
+    List<String> brukers_situasjoner;
     LocalDate brukers_situasjon_sist_endret;
     String profilering_resultat;
     String utdanning;

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingAvsluttetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingAvsluttetService.java
@@ -1,6 +1,5 @@
 package no.nav.pto.veilarbportefolje.oppfolging;
 
-import io.getunleash.DefaultUnleash;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
@@ -9,7 +8,6 @@ import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteService;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v1.registrering.ArbeidssokerRegistreringService;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v1.registrering.endring.EndringIArbeidssokerRegistreringService;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerService;
-import no.nav.pto.veilarbportefolje.config.FeatureToggle;
 import no.nav.pto.veilarbportefolje.cv.CVRepositoryV2;
 import no.nav.pto.veilarbportefolje.ensligforsorger.EnsligeForsorgereService;
 import no.nav.pto.veilarbportefolje.fargekategori.FargekategoriService;
@@ -18,6 +16,8 @@ import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerServiceV2;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlService;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v1.registrering.ArbeidssokerRegistreringService;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v1.registrering.endring.EndringIArbeidssokerRegistreringService;
 import no.nav.pto.veilarbportefolje.siste14aVedtak.Siste14aVedtakService;
 import no.nav.pto.veilarbportefolje.sisteendring.SisteEndringService;
 import org.springframework.stereotype.Service;
@@ -46,7 +46,6 @@ public class OppfolgingAvsluttetService {
     private final PdlIdentRepository pdlIdentRepository;
     private final FargekategoriService fargekategoriService;
     private final OppfolgingsbrukerServiceV2 oppfolgingsbrukerServiceV2;
-    private final DefaultUnleash defaultUnleash;
     private final ArbeidssoekerService arbeidssoekerService;
 
     public void avsluttOppfolging(AktorId aktoerId) {
@@ -64,10 +63,7 @@ public class OppfolgingAvsluttetService {
         ensligeForsorgereService.slettEnsligeForsorgereData(aktoerId);
         fargekategoriService.slettFargekategoriPaaBruker(aktoerId, maybeFnr);
         oppfolgingsbrukerServiceV2.slettOppfolgingsbruker(aktoerId, maybeFnr);
-
-        if (FeatureToggle.brukNyttArbeidssoekerregister(defaultUnleash)) {
-            arbeidssoekerService.slettArbeidssoekerData(aktoerId, maybeFnr);
-        }
+        arbeidssoekerService.slettArbeidssoekerData(aktoerId, maybeFnr);
 
         opensearchIndexerV2.slettDokumenter(List.of(aktoerId));
         secureLog.info("Bruker: {} har avsluttet oppfølging og er slettet", aktoerId);

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingAvsluttetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingAvsluttetService.java
@@ -16,8 +16,6 @@ import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerServiceV2;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlService;
-import no.nav.pto.veilarbportefolje.arbeidssoeker.v1.registrering.ArbeidssokerRegistreringService;
-import no.nav.pto.veilarbportefolje.arbeidssoeker.v1.registrering.endring.EndringIArbeidssokerRegistreringService;
 import no.nav.pto.veilarbportefolje.siste14aVedtak.Siste14aVedtakService;
 import no.nav.pto.veilarbportefolje.sisteendring.SisteEndringService;
 import org.springframework.stereotype.Service;

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
@@ -1,11 +1,9 @@
 package no.nav.pto.veilarbportefolje.oppfolging;
 
-import io.getunleash.DefaultUnleash;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerService;
-import no.nav.pto.veilarbportefolje.config.FeatureToggle;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerServiceV2;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlService;
@@ -27,7 +25,6 @@ public class OppfolgingStartetService {
     private final Siste14aVedtakService siste14aVedtakService;
     private final OppfolgingsbrukerServiceV2 oppfolgingsbrukerServiceV2;
     private final ArbeidssoekerService arbeidssoekerService;
-    private final DefaultUnleash defaultUnleash;
 
     // TODO: Dersom en eller flere av disse operasjonene feiler og kaster exception vil
     //  kafka-meldingen bli lagret og retryet. Dette kan resultere i at vi mellomlagrer data
@@ -42,10 +39,7 @@ public class OppfolgingStartetService {
 
         siste14aVedtakService.hentOgLagreSiste14aVedtak(aktorId);
         oppfolgingsbrukerServiceV2.hentOgLagreOppfolgingsbruker(aktorId);
-
-        if (FeatureToggle.brukNyttArbeidssoekerregister(defaultUnleash)) {
-            arbeidssoekerService.hentOgLagreArbeidssoekerdataForBruker(aktorId);
-        }
+        arbeidssoekerService.hentOgLagreArbeidssoekerdataForBruker(aktorId);
 
         opensearchIndexer.indekser(aktorId);
         secureLog.info("Bruker {} har startet oppfølging: {}", aktorId, oppfolgingStartetDate);

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
@@ -153,6 +153,7 @@ public class BrukerRepositoryV2 {
                 .setUtdanning(rs.getString(UTDANNING))
                 .setUtdanning_bestatt(rs.getString(UTDANNING_BESTATT))
                 .setUtdanning_godkjent(rs.getString(UTDANNING_GODKJENT))
+                .setUtdanning_og_situasjon_sist_endret(toLocalDate(rs.getTimestamp(REGISTRERING_OPPRETTET)))
                 .setHar_delt_cv(rs.getBoolean(HAR_DELT_CV))
                 .setCv_eksistere(rs.getBoolean(CV_EKSISTERER))
                 .setOppfolging(rs.getBoolean(OPPFOLGING))

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
 import static no.nav.common.utils.EnvironmentUtils.isDevelopment;
 import static no.nav.pto.veilarbportefolje.arenapakafka.ytelser.YtelseUtils.konverterDagerTilUker;
 import static no.nav.pto.veilarbportefolje.database.PostgresTable.OpensearchData.*;
@@ -244,7 +245,7 @@ public class BrukerRepositoryV2 {
         String brukersSisteSituasjon = harEndretSituasjonEttterRegistrering ? rs.getString(ENDRET_BRUKERS_SITUASJON) : rs.getString(BRUKERS_SITUASJON);
         LocalDate brukersSituasjonSistEndretDato = harEndretSituasjonEttterRegistrering ? oppdatertBrukesSituasjonSistEndretDato : brukesSituasjonOpprettetDato;
 
-        oppfolgingsBruker.setBrukers_situasjon(brukersSisteSituasjon);
+        oppfolgingsBruker.setBrukers_situasjoner(brukersSisteSituasjon == null ? emptyList() : List.of(brukersSisteSituasjon));
         oppfolgingsBruker.setBrukers_situasjon_sist_endret(brukersSituasjonSistEndretDato);
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
@@ -190,9 +190,11 @@ public class PostgresOpensearchMapper {
                 Profilering profilering = data.getProfilering();
 
                 if (opplysningerOmArbeidssoeker != null ) {
+                    String utdanningBestatt = opplysningerOmArbeidssoeker.getUtdanningBestatt() != null ? opplysningerOmArbeidssoeker.getUtdanningBestatt().name() : null;
+                    String utdanningGodkjent = opplysningerOmArbeidssoeker.getUtdanningGodkjent() != null ? opplysningerOmArbeidssoeker.getUtdanningGodkjent().name() : null;
                     bruker.setUtdanning(opplysningerOmArbeidssoeker.getUtdanning().name());
-                    bruker.setUtdanning_godkjent(opplysningerOmArbeidssoeker.getUtdanningGodkjent().name());
-                    bruker.setUtdanning_bestatt(opplysningerOmArbeidssoeker.getUtdanningBestatt().name());
+                    bruker.setUtdanning_godkjent(utdanningGodkjent);
+                    bruker.setUtdanning_bestatt(utdanningBestatt);
                     bruker.setBrukers_situasjoner(opplysningerOmArbeidssoeker.getJobbsituasjoner().stream().map(JobbSituasjonBeskrivelse::name).toList());
                     bruker.setUtdanning_og_situasjon_sist_endret(opplysningerOmArbeidssoeker.getSendtInnTidspunkt().toLocalDate());
                 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 
 import static no.nav.pto.veilarbportefolje.postgres.PostgresAktivitetMapper.kalkulerAvtalteAktivitetInformasjon;
 import static no.nav.pto.veilarbportefolje.postgres.PostgresAktivitetMapper.kalkulerGenerellAktivitetInformasjon;
-import static no.nav.pto.veilarbportefolje.util.OppfolgingUtils.vurderingsBehov;
 
 @Slf4j
 @Service

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
@@ -4,6 +4,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerData;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerService;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.OpplysningerOmArbeidssoeker;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.Profilering;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.JobbSituasjonBeskrivelse;
 import no.nav.pto.veilarbportefolje.domene.GjeldendeIdenter;
 import no.nav.pto.veilarbportefolje.domene.Statsborgerskap;
 import no.nav.pto.veilarbportefolje.ensligforsorger.EnsligeForsorgereService;
@@ -41,6 +46,7 @@ public class PostgresOpensearchMapper {
 
     private final BarnUnder18AarService barnUnder18AarService;
     private final EnsligeForsorgereService ensligeForsorgereService;
+    private final ArbeidssoekerService arbeidssoekerService;
 
     public void flettInnAktivitetsData(List<OppfolgingsBruker> brukere) {
         List<AktorId> aktoerIder = brukere.stream().map(OppfolgingsBruker::getAktoer_id).map(AktorId::of).toList();
@@ -167,6 +173,33 @@ public class PostgresOpensearchMapper {
             if (fnrEnsligeForsorgerOvergangsstønadTiltakDtoMap.containsKey(Fnr.of(bruker.getFnr()))) {
                 bruker.setEnslige_forsorgere_overgangsstonad(fnrEnsligeForsorgerOvergangsstønadTiltakDtoMap.get(Fnr.of(bruker.getFnr())).toEnsligeForsorgereOpensearchDto());
             }
+        });
+    }
+
+    public void flettInnOpplysningerOmArbeidssoekerData(List<OppfolgingsBruker> brukere) {
+        List<Fnr> fnrs = brukere.stream().map(OppfolgingsBruker::getFnr).map(Fnr::of).toList();
+        List<ArbeidssoekerData> arbeidssoekerDataList = arbeidssoekerService.hentArbeidssoekerData(fnrs);
+
+        brukere.forEach(bruker -> {
+            Optional<ArbeidssoekerData> arbeidssoekerData = arbeidssoekerDataList.stream()
+                    .filter(data -> data.getFnr().get().equals(bruker.getFnr()))
+                    .findFirst();
+
+            arbeidssoekerData.ifPresent(data -> {
+                OpplysningerOmArbeidssoeker opplysningerOmArbeidssoeker = data.getOpplysningerOmArbeidssoeker();
+                Profilering profilering = data.getProfilering();
+
+                if (opplysningerOmArbeidssoeker != null ) {
+                    bruker.setUtdanning(opplysningerOmArbeidssoeker.getUtdanning().name());
+                    bruker.setUtdanning_godkjent(opplysningerOmArbeidssoeker.getUtdanningGodkjent().name());
+                    bruker.setUtdanning_bestatt(opplysningerOmArbeidssoeker.getUtdanningBestatt().name());
+                    bruker.setBrukers_situasjoner(opplysningerOmArbeidssoeker.getJobbsituasjoner().stream().map(JobbSituasjonBeskrivelse::name).toList());
+                    bruker.setUtdanning_og_situasjon_sist_endret(opplysningerOmArbeidssoeker.getSendtInnTidspunkt().toLocalDate());
+                }
+                if (profilering != null) {
+                    bruker.setProfilering_resultat(profilering.getProfileringsresultat().name());
+                }
+            });
         });
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 
 import static no.nav.pto.veilarbportefolje.postgres.PostgresAktivitetMapper.kalkulerAvtalteAktivitetInformasjon;
 import static no.nav.pto.veilarbportefolje.postgres.PostgresAktivitetMapper.kalkulerGenerellAktivitetInformasjon;
+import static no.nav.pto.veilarbportefolje.util.OppfolgingUtils.vurderingsBehov;
 
 @Slf4j
 @Service

--- a/src/main/java/no/nav/pto/veilarbportefolje/util/ValideringsRegler.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/util/ValideringsRegler.java
@@ -75,7 +75,8 @@ public class ValideringsRegler {
             "huskelapp_frist",
             "huskelapp_kommentar",
             "huskelapp",
-            "fargekategori"
+            "fargekategori",
+            "utdanningOgSituasjonSistEndret"
     );
 
     public static void sjekkEnhet(String enhet) {

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v1/registrering/ArbeidssokerRegistreringServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v1/registrering/ArbeidssokerRegistreringServiceTest.java
@@ -62,12 +62,12 @@ class ArbeidssokerRegistreringServiceTest extends EndToEndTest {
         assertThat(getResponse.isExists()).isTrue();
 
         String utdanning = (String) getResponse.getSourceAsMap().get("utdanning");
-        String situasjon = (String) getResponse.getSourceAsMap().get("brukers_situasjon");
+        List<String> situasjon = (List<String>) getResponse.getSourceAsMap().get("brukers_situasjoner");
         String utdanningBestatt = (String) getResponse.getSourceAsMap().get("utdanning_bestatt");
         String utdanningGodkjent = (String) getResponse.getSourceAsMap().get("utdanning_godkjent");
 
         assertThat(utdanning).isEqualTo(no.nav.arbeid.soker.registrering.UtdanningSvar.GRUNNSKOLE.toString());
-        assertThat(situasjon).isEqualTo("Permittert");
+        assertThat(situasjon).isEqualTo(List.of("Permittert"));
         assertThat(utdanningBestatt).isEqualTo(UtdanningBestattSvar.INGEN_SVAR.toString());
         assertThat(utdanningGodkjent).isEqualTo(UtdanningGodkjentSvar.JA.toString());
     }
@@ -312,7 +312,7 @@ class ArbeidssokerRegistreringServiceTest extends EndToEndTest {
                         .setEnhet_id(enhet)
                         .setUtdanning_bestatt("NEI")
                         .setUtdanning_godkjent("NEI")
-                        .setBrukers_situasjon("MISTET_JOBBEN"),
+                        .setBrukers_situasjoner(List.of("MISTET_JOBBEN")),
 
                 new OppfolgingsBruker()
                         .setAktoer_id(aktoerId2.get())
@@ -321,7 +321,7 @@ class ArbeidssokerRegistreringServiceTest extends EndToEndTest {
                         .setUtdanning_bestatt("NEI")
                         .setUtdanning_godkjent("JA")
                         .setUtdanning("GRUNNSKOLE")
-                        .setBrukers_situasjon("ALDRI_HATT_JOBB"),
+                        .setBrukers_situasjoner(List.of("ALDRI_HATT_JOBB")),
 
                 new OppfolgingsBruker()
                         .setAktoer_id(aktoerId3.get())
@@ -330,7 +330,7 @@ class ArbeidssokerRegistreringServiceTest extends EndToEndTest {
                         .setUtdanning_bestatt("NEI")
                         .setUtdanning_godkjent("JA")
                         .setUtdanning("VIDEREGAENDE_GRUNNUTDANNING")
-                        .setBrukers_situasjon("MISTET_JOBBEN"),
+                        .setBrukers_situasjoner(List.of("MISTET_JOBBEN")),
 
                 new OppfolgingsBruker()
                         .setAktoer_id(aktoerId4.get())
@@ -362,7 +362,7 @@ class ArbeidssokerRegistreringServiceTest extends EndToEndTest {
                         .setUtdanning("INGEN_SVAR")
                         .setUtdanning_bestatt("NEI")
                         .setUtdanning_godkjent("JA")
-                        .setBrukers_situasjon("ALDRI_HATT_JOBB")
+                        .setBrukers_situasjoner(List.of("ALDRI_HATT_JOBB"))
         );
 
         brukere.forEach(bruker -> {

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v1/registrering/ArbeidssokerRegistreringServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v1/registrering/ArbeidssokerRegistreringServiceTest.java
@@ -3,6 +3,7 @@ package no.nav.pto.veilarbportefolje.arbeidssoeker.v1.registrering;
 import no.nav.arbeid.soker.registrering.ArbeidssokerRegistrertEvent;
 import no.nav.common.types.identer.AktorId;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v1.registrering.ArbeidssokerRegistreringService;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.JobbSituasjonBeskrivelse;
 import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.filtervalg.DinSituasjonSvar;
@@ -274,15 +275,15 @@ class ArbeidssokerRegistreringServiceTest extends EndToEndTest {
     private static Filtervalg getFiltervalgIngenSituasjonsData() {
         Filtervalg filtervalg = new Filtervalg();
         filtervalg.setFerdigfilterListe(new ArrayList<>());
-        filtervalg.registreringstype.add(DinSituasjonSvar.INGEN_DATA);
+        filtervalg.registreringstype.add(JobbSituasjonBeskrivelse.INGEN_DATA);
         return filtervalg;
     }
 
     private static Filtervalg getFiltervalgSituasjonsDataMix() {
         Filtervalg filtervalg = new Filtervalg();
         filtervalg.setFerdigfilterListe(new ArrayList<>());
-        filtervalg.registreringstype.add(DinSituasjonSvar.MISTET_JOBBEN);
-        filtervalg.registreringstype.add(DinSituasjonSvar.INGEN_DATA);
+        filtervalg.registreringstype.add(JobbSituasjonBeskrivelse.ALDRI_HATT_JOBB);
+        filtervalg.registreringstype.add(JobbSituasjonBeskrivelse.INGEN_DATA);
         return filtervalg;
     }
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v1/registrering/endring/EndringIArbeidssokerRegistreringServiceTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v1/registrering/endring/EndringIArbeidssokerRegistreringServiceTest.kt
@@ -25,12 +25,12 @@ class EndringIArbeidssokerRegistreringServiceTest : EndToEndTest() {
         val getResponse = opensearchTestClient.fetchDocument(aktorId)
         AssertionsForClassTypes.assertThat(getResponse.isExists).isTrue
 
-        val endretSituasjon: String = getResponse.sourceAsMap["brukers_situasjon"] as String
+        val endretSituasjon = getResponse.sourceAsMap["brukers_situasjoner"] as List<*>
         val endretSituasjonSistEndret: LocalDateTime =
             DateUtils.toLocalDateTimeOrNull(getResponse.sourceAsMap["brukers_situasjon_sist_endret"] as String);
 
         AssertionsForClassTypes.assertThat(endretSituasjon)
-            .isEqualTo(kafkaRegistreringMelding.besvarelse.dinSituasjon.verdi.toString())
+            .isEqualTo(listOf(kafkaRegistreringMelding.besvarelse.dinSituasjon.verdi.toString()))
         AssertionsForClassTypes.assertThat(endretSituasjonSistEndret)
             .isEqualTo(DateUtils.toLocalDateTimeOrNull(kafkaRegistreringMelding.besvarelse.dinSituasjon.endretTidspunkt.toString()))
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDataRepositoryTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerDataRepositoryTest.kt
@@ -1,0 +1,166 @@
+package no.nav.pto.veilarbportefolje.arbeidssoeker.v2
+
+import no.nav.common.types.identer.Fnr
+import no.nav.pto.veilarbportefolje.database.PostgresTable.*
+import no.nav.pto.veilarbportefolje.util.SingletonPostgresContainer
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.jdbc.core.JdbcTemplate
+import java.sql.Timestamp
+import java.util.UUID
+
+class ArbeidssoekerDataRepositoryTest {
+    private val db: JdbcTemplate = SingletonPostgresContainer.init().createJdbcTemplate()
+    private val arbeidssoekerDataRepository: ArbeidssoekerDataRepository = ArbeidssoekerDataRepository(db)
+    private val opplysningerOmArbeidssoekerRepository: OpplysningerOmArbeidssoekerRepository = OpplysningerOmArbeidssoekerRepository(db)
+
+    private val fnr1 = Fnr.of("12345671231")
+    private val fnr2 = Fnr.of("12345671232")
+    private val fnr3 = Fnr.of("12345671233")
+
+    private val periodeId1 = UUID.fromString("ea0ad984-8b99-4fff-afd6-07737ab19d16")
+    private val periodeId2 = UUID.fromString("ea0ad984-8b99-4fff-afd6-07737ab19d17")
+    private val periodeId3 = UUID.fromString("ea0ad984-8b99-4fff-afd6-07737ab19d18")
+
+    private val opplysningerId1 = UUID.fromString("ea0ad984-8b99-4fff-afd6-07737ab19d19")
+    private val opplysningerId2 = UUID.fromString("ea0ad984-8b99-4fff-afd6-07737ab19d20")
+    private val opplysningerId3 = UUID.fromString("ea0ad984-8b99-4fff-afd6-07737ab19d21")
+
+    @BeforeEach
+    fun reset() {
+        db.update("""TRUNCATE ${SISTE_ARBEIDSSOEKER_PERIODE.TABLE_NAME} CASCADE""")
+    }
+
+    @Test
+    fun hentAlleOpplysningerOmArbeidssoekerListe() {
+        // Arrange
+        setUpPeriodeTestData()
+        setUpOpplysningerOmArbeidssoekerTestData()
+
+        // Act
+        val arbeidssoekerDataForBrukere =
+            arbeidssoekerDataRepository.hentOpplysningerOmArbeidssoeker(listOf(fnr1, fnr2, fnr3))
+
+        // Assert
+        assertEquals(3, arbeidssoekerDataForBrukere.size)
+        assertEquals(2, arbeidssoekerDataForBrukere[fnr1.get()]?.jobbsituasjoner?.size)
+        assertEquals(1, arbeidssoekerDataForBrukere[fnr2.get()]?.jobbsituasjoner?.size)
+
+    }
+
+    @Test
+    fun hentProfileringPaaAlleBrukerne() {
+        // Arrange
+        setUpPeriodeTestData()
+        setUpProfileringTestData()
+
+        //Act
+        val profileringPaaBruker = arbeidssoekerDataRepository.hentProfileringsresultatListe(listOf(fnr1, fnr2, fnr3))
+
+        //Assert
+        assertEquals(3, profileringPaaBruker.size)
+        assertEquals(Profileringsresultat.ANTATT_BEHOV_FOR_VEILEDNING, profileringPaaBruker[fnr1.get()]?.profileringsresultat)
+        assertEquals(Profileringsresultat.ANTATT_GODE_MULIGHETER, profileringPaaBruker[fnr2.get()]?.profileringsresultat)
+        assertEquals(Profileringsresultat.OPPGITT_HINDRINGER, profileringPaaBruker[fnr3.get()]?.profileringsresultat)
+    }
+
+    private fun setUpPeriodeTestData() {
+        db.update(
+            """INSERT INTO ${SISTE_ARBEIDSSOEKER_PERIODE.TABLE_NAME} VALUES (?,?)""",
+            periodeId1,
+            fnr1.get()
+        )
+        db.update(
+            """INSERT INTO ${SISTE_ARBEIDSSOEKER_PERIODE.TABLE_NAME} VALUES (?,?)""",
+            periodeId2,
+            fnr2.get()
+        )
+        db.update(
+            """INSERT INTO ${SISTE_ARBEIDSSOEKER_PERIODE.TABLE_NAME} VALUES (?,?)""",
+            periodeId3,
+            fnr3.get()
+        )
+    }
+
+    private fun setUpOpplysningerOmArbeidssoekerTestData() {
+        val opplysninger1 = OpplysningerOmArbeidssoekerEntity(
+            opplysningerOmArbeidssoekerId = opplysningerId1,
+            periodeId = periodeId1,
+            sendtInnTidspunkt = Timestamp.valueOf("2024-04-23 13:22:58.089"),
+            utdanningNusKode = "3",
+            utdanningBestatt = "JA",
+            utdanningGodkjent = "JA",
+            opplysningerOmJobbsituasjon = OpplysningerOmArbeidssoekerJobbsituasjonEntity(
+                opplysningerOmArbeidssoekerId = opplysningerId1,
+                jobbsituasjon = listOf("ER_PERMITTERT", "MIDLERTIDIG_JOBB")
+            )
+        )
+
+        val opplysninger2 = OpplysningerOmArbeidssoekerEntity(
+            opplysningerOmArbeidssoekerId = opplysningerId2,
+            periodeId = periodeId2,
+            sendtInnTidspunkt = Timestamp.valueOf("2024-04-23 23:22:58.089"),
+            utdanningNusKode = "3",
+            utdanningBestatt = "JA",
+            utdanningGodkjent = "JA",
+            opplysningerOmJobbsituasjon = OpplysningerOmArbeidssoekerJobbsituasjonEntity(
+                opplysningerOmArbeidssoekerId = opplysningerId2,
+                jobbsituasjon = listOf("HAR_SAGT_OPP")
+            )
+        )
+
+        val opplysninger3 = OpplysningerOmArbeidssoekerEntity(
+            opplysningerOmArbeidssoekerId = opplysningerId3,
+            periodeId = periodeId3,
+            sendtInnTidspunkt = Timestamp.valueOf("2024-04-23 23:22:58.089"),
+            utdanningNusKode = "3",
+            utdanningBestatt = "JA",
+            utdanningGodkjent = "JA",
+            opplysningerOmJobbsituasjon = OpplysningerOmArbeidssoekerJobbsituasjonEntity(
+                opplysningerOmArbeidssoekerId = opplysningerId3,
+                jobbsituasjon = listOf("ALDRI_HATT_JOBB", "NY_JOBB")
+            )
+        )
+
+        opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(opplysninger1)
+        opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(opplysninger2)
+        opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(opplysninger3)
+    }
+
+    private fun setUpProfileringTestData() {
+        db.update(
+            """INSERT INTO ${PROFILERING.TABLE_NAME} (
+                    ${PROFILERING.PERIODE_ID}, 
+                    ${PROFILERING.PROFILERING_RESULTAT}, 
+                    ${PROFILERING.SENDT_INN_TIDSPUNKT}
+                ) VALUES (?,?,?)""",
+            periodeId1,
+            Profileringsresultat.ANTATT_BEHOV_FOR_VEILEDNING.name,
+            Timestamp.valueOf("2024-04-23 23:22:58.089")
+        )
+
+        db.update(
+            """INSERT INTO ${PROFILERING.TABLE_NAME} (
+                    ${PROFILERING.PERIODE_ID}, 
+                    ${PROFILERING.PROFILERING_RESULTAT}, 
+                    ${PROFILERING.SENDT_INN_TIDSPUNKT}
+                ) VALUES (?,?,?)""",
+            periodeId2,
+            Profileringsresultat.ANTATT_GODE_MULIGHETER.name,
+            Timestamp.valueOf("2024-04-23 23:22:58.089")
+        )
+
+        db.update(
+            """INSERT INTO ${PROFILERING.TABLE_NAME} (
+                    ${PROFILERING.PERIODE_ID}, 
+                    ${PROFILERING.PROFILERING_RESULTAT}, 
+                    ${PROFILERING.SENDT_INN_TIDSPUNKT}
+                ) VALUES (?,?,?)""",
+            periodeId3,
+            Profileringsresultat.OPPGITT_HINDRINGER.name,
+            Timestamp.valueOf("2024-04-23 23:22:58.089")
+        )
+    }
+}

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerServiceTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerServiceTest.kt
@@ -23,6 +23,7 @@ import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLIdent
 import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLPerson
 import no.nav.pto.veilarbportefolje.persononinfo.domene.PDLPersonBarn
 import no.nav.pto.veilarbportefolje.postgres.PostgresUtils
+import no.nav.pto.veilarbportefolje.util.DateUtils
 import no.nav.pto.veilarbportefolje.util.EndToEndTest
 import no.nav.pto.veilarbportefolje.util.TestDataClient.Companion.getArbeidssoekerPeriodeFraDb
 import no.nav.pto.veilarbportefolje.util.TestDataClient.Companion.getOpplysningerOmArbeidssoekerFraDb
@@ -88,26 +89,26 @@ class ArbeidssoekerServiceTest(
                 PDLIdent(aktorId.get(), false, PDLIdent.Gruppe.AKTORID)
             )
         )
-        sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(fnr1, periodeId1)
-        sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(fnr2, periodeId2)
+        sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(ArbeidssoekerPeriodeEntity(periodeId1, fnr1.get()))
+        sisteArbeidssoekerPeriodeRepository.insertSisteArbeidssoekerPeriode(ArbeidssoekerPeriodeEntity(periodeId2, fnr2.get()))
         opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(
-            genererRandomOpplysningerOmArbeidssoeker(periodeId1, opplysningerOmArbeidssoekerId1)
+            genererRandomOpplysningerOmArbeidssoekerEntity(periodeId1, opplysningerOmArbeidssoekerId1)
         )
         opplysningerOmArbeidssoekerRepository.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(
-            genererRandomOpplysningerOmArbeidssoeker(periodeId2, opplysningerOmArbeidssoekerId2)
+            genererRandomOpplysningerOmArbeidssoekerEntity(periodeId2, opplysningerOmArbeidssoekerId2)
         )
         profileringRepository.insertProfilering(
-            Profilering(
+            ProfileringEntity(
                 periodeId1,
-                Profileringsresultat.ANTATT_GODE_MULIGHETER,
-                ZonedDateTime.now()
+                Profileringsresultat.ANTATT_GODE_MULIGHETER.name,
+                DateUtils.toTimestamp(ZonedDateTime.now())
             )
         )
         profileringRepository.insertProfilering(
-            Profilering(
+            ProfileringEntity(
                 periodeId2,
-                Profileringsresultat.OPPGITT_HINDRINGER,
-                ZonedDateTime.now()
+                Profileringsresultat.OPPGITT_HINDRINGER.name,
+                DateUtils.toTimestamp(ZonedDateTime.now())
             )
         )
 
@@ -160,7 +161,7 @@ class ArbeidssoekerServiceTest(
             Metadata(
                 Instant.now(),
                 Bruker(
-                    no.nav.paw.arbeidssokerregisteret.api.v1.BrukerType.SYSTEM,
+                    BrukerType.SYSTEM,
                     "APP_NAVN:VERSJON"
                 ),
                 "APP_NAVN:VERSJON",
@@ -187,7 +188,7 @@ class ArbeidssoekerServiceTest(
             Metadata(
                 Instant.now(),
                 Bruker(
-                    no.nav.paw.arbeidssokerregisteret.api.v1.BrukerType.SYSTEM,
+                    BrukerType.SYSTEM,
                     "APP_NAVN:VERSJON"
                 ),
                 "APP_NAVN:VERSJON",
@@ -211,7 +212,7 @@ class ArbeidssoekerServiceTest(
             Metadata(
                 Instant.now(),
                 Bruker(
-                    no.nav.paw.arbeidssokerregisteret.api.v1.BrukerType.SYSTEM,
+                    BrukerType.SYSTEM,
                     "APP_NAVN:VERSJON"
                 ),
                 "APP_NAVN:VERSJON",
@@ -240,7 +241,7 @@ class ArbeidssoekerServiceTest(
             opplysningerOmArbeidssoeker!!.opplysningerOmArbeidssoekerId
         )
 
-        assertThat(opplysningerOmArbeidssoekerJobbsituasjon!!.jobbsituasjon[1]).isEqualTo(JobbSituasjonBeskrivelse.ER_PERMITTERT)
+        assertThat(opplysningerOmArbeidssoekerJobbsituasjon!!.jobbsituasjon[1]).isEqualTo(JobbSituasjonBeskrivelse.ER_PERMITTERT.name)
 
         val profilering = getProfileringFraDb(db, periodeId)
         assertNotNull(profilering)
@@ -353,7 +354,7 @@ class ArbeidssoekerServiceTest(
             Metadata(
                 Instant.now(),
                 Bruker(
-                    no.nav.paw.arbeidssokerregisteret.api.v1.BrukerType.SYSTEM,
+                    BrukerType.SYSTEM,
                     "APP_NAVN:VERSJON"
                 ),
                 "APP_NAVN:VERSJON",
@@ -410,7 +411,7 @@ class ArbeidssoekerServiceTest(
             Metadata(
                 Instant.now(),
                 Bruker(
-                    no.nav.paw.arbeidssokerregisteret.api.v1.BrukerType.SYSTEM,
+                    BrukerType.SYSTEM,
                     "APP_NAVN:VERSJON"
                 ),
                 "APP_NAVN:VERSJON",
@@ -445,7 +446,7 @@ class ArbeidssoekerServiceTest(
         assertThat(lagredeOpplysningerOmArbeidssoekerJobbsituasjon!!.opplysningerOmArbeidssoekerId).isEqualTo(
             nyOpplysningerOmArbeidssoekerId
         )
-        assertThat(lagredeOpplysningerOmArbeidssoekerJobbsituasjon.jobbsituasjon[0]).isEqualTo(JobbSituasjonBeskrivelse.DELTIDSJOBB_VIL_MER)
+        assertThat(lagredeOpplysningerOmArbeidssoekerJobbsituasjon.jobbsituasjon[0]).isEqualTo(JobbSituasjonBeskrivelse.DELTIDSJOBB_VIL_MER.name)
     }
 
     @Test
@@ -467,7 +468,7 @@ class ArbeidssoekerServiceTest(
 
         oppfolgingPeriodeService.behandleKafkaMeldingLogikk(genererStartetOppfolgingsperiode(aktorId))
         val lagretProfileringForKafkaMelding = getProfileringFraDb(db, periodeIdVedOppfolgingStartet)
-        assertThat(lagretProfileringForKafkaMelding!!.profileringsresultat).isEqualTo(Profileringsresultat.OPPGITT_HINDRINGER)
+        assertThat(lagretProfileringForKafkaMelding!!.profileringsresultat).isEqualTo(Profileringsresultat.OPPGITT_HINDRINGER.name)
 
         val profileringKafkamelding = ProfileringKafkamelding(
             UUID.randomUUID(),
@@ -492,7 +493,7 @@ class ArbeidssoekerServiceTest(
 
         // Assert
         val lagretProfileringEtterMelding = getProfileringFraDb(db, periodeIdVedOppfolgingStartet)
-        assertThat(lagretProfileringEtterMelding!!.profileringsresultat).isEqualTo(Profileringsresultat.ANTATT_BEHOV_FOR_VEILEDNING)
+        assertThat(lagretProfileringEtterMelding!!.profileringsresultat).isEqualTo(Profileringsresultat.ANTATT_BEHOV_FOR_VEILEDNING.name)
     }
 
     @Test
@@ -515,7 +516,7 @@ class ArbeidssoekerServiceTest(
 
         oppfolgingPeriodeService.behandleKafkaMeldingLogikk(genererStartetOppfolgingsperiode(aktorId))
         val lagretProfileringForKafkaMelding = getProfileringFraDb(db, periodeIdVedOppfolgingStartet)
-        assertThat(lagretProfileringForKafkaMelding!!.profileringsresultat).isEqualTo(Profileringsresultat.OPPGITT_HINDRINGER)
+        assertThat(lagretProfileringForKafkaMelding!!.profileringsresultat).isEqualTo(Profileringsresultat.OPPGITT_HINDRINGER.name)
         assertThat(lagretProfileringForKafkaMelding.periodeId).isEqualTo(periodeIdVedOppfolgingStartet)
 
         val profileringKafkamelding = ProfileringKafkamelding(
@@ -540,9 +541,9 @@ class ArbeidssoekerServiceTest(
         arbeidssoekerService.behandleKafkaMeldingLogikk(profileringKafkamelding)
 
         // Assert
-        val lagretProfileringEtterMeldingSkalVæreSamme = getProfileringFraDb(db, periodeIdVedOppfolgingStartet)
-        assertThat(lagretProfileringEtterMeldingSkalVæreSamme!!.profileringsresultat).isEqualTo(Profileringsresultat.OPPGITT_HINDRINGER)
-        assertThat(lagretProfileringEtterMeldingSkalVæreSamme.periodeId).isEqualTo(periodeIdVedOppfolgingStartet)
+        val lagretProfileringEtterMeldingSkalVereSamme = getProfileringFraDb(db, periodeIdVedOppfolgingStartet)
+        assertThat(lagretProfileringEtterMeldingSkalVereSamme!!.profileringsresultat).isEqualTo(Profileringsresultat.OPPGITT_HINDRINGER.name)
+        assertThat(lagretProfileringEtterMeldingSkalVereSamme.periodeId).isEqualTo(periodeIdVedOppfolgingStartet)
 
     }
 
@@ -643,10 +644,10 @@ class ArbeidssoekerServiceTest(
     }
 }
 
-fun genererRandomOpplysningerOmArbeidssoeker(
+fun genererRandomOpplysningerOmArbeidssoekerEntity(
     periodeId: UUID,
     opplysningerOmArbeidssoekerId: UUID
-): OpplysningerOmArbeidssoeker {
+): OpplysningerOmArbeidssoekerEntity {
     return OpplysningerOmArbeidssoekerResponse(
         periodeId = periodeId,
         opplysningerOmArbeidssoekerId = opplysningerOmArbeidssoekerId,
@@ -679,6 +680,6 @@ fun genererRandomOpplysningerOmArbeidssoeker(
         helse = HelseResponse(
             helsetilstandHindrerArbeid = JaNeiVetIkke.NEI
         )
-    ).toOpplysningerOmArbeidssoeker()
+    ).toOpplysningerOmArbeidssoekerEntity()
 }
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OpplysningerOmArbeidssoekerRepositoryTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/OpplysningerOmArbeidssoekerRepositoryTest.kt
@@ -59,14 +59,14 @@ class OpplysningerOmArbeidssoekerRepositoryTest {
             annet = AnnetResponse(
                 andreForholdHindrerArbeid = JaNeiVetIkke.NEI
             )
-        ).toOpplysningerOmArbeidssoeker()
+        ).toOpplysningerOmArbeidssoekerEntity()
         opplysningerOmArbeidssoeker.insertOpplysningerOmArbeidssoekerOgJobbsituasjon(opplysningerOmArbeidssoekerObjekt)
 
 
-        val resultatOpplysninger: OpplysningerOmArbeidssoeker? =
+        val resultatOpplysninger: OpplysningerOmArbeidssoekerEntity? =
             TestDataClient.getOpplysningerOmArbeidssoekerFraDb(db, opplysningerOmArbeidssoekerObjekt.periodeId)
 
-        val resultatJobbsituasjon: OpplysningerOmArbeidssoekerJobbsituasjon? =
+        val resultatJobbsituasjon: OpplysningerOmArbeidssoekerJobbsituasjonEntity? =
             TestDataClient.getOpplysningerOmArbeidssoekerJobbsituasjonFraDb(
                 db,
                 resultatOpplysninger!!.opplysningerOmArbeidssoekerId

--- a/src/test/java/no/nav/pto/veilarbportefolje/config/ApplicationConfigTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/config/ApplicationConfigTest.java
@@ -176,7 +176,8 @@ import static org.mockito.Mockito.when;
         ArbeidssoekerService.class,
         OpplysningerOmArbeidssoekerRepository.class,
         SisteArbeidssoekerPeriodeRepository.class,
-        ProfileringRepository.class
+        ProfileringRepository.class,
+        ArbeidssoekerDataRepository.class
 })
 public class ApplicationConfigTest {
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetOgAvsluttetServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetOgAvsluttetServiceTest.java
@@ -241,18 +241,18 @@ class OppfolgingStartetOgAvsluttetServiceTest extends EndToEndTest {
 
         oppfolgingPeriodeService.behandleKafkaMeldingLogikk(genererStartetOppfolgingsperiode(aktorId));
 
-        ArbeidssoekerPeriode arbeidssoekerPeriode = TestDataClient.getArbeidssoekerPeriodeFraDb(jdbcTemplate, periodeId);
+        ArbeidssoekerPeriodeEntity arbeidssoekerPeriode = TestDataClient.getArbeidssoekerPeriodeFraDb(jdbcTemplate, periodeId);
 
         assertNotNull(arbeidssoekerPeriode);
-        OpplysningerOmArbeidssoeker opplysningerOmArbeidssoeker = TestDataClient.getOpplysningerOmArbeidssoekerFraDb(jdbcTemplate, arbeidssoekerPeriode.getArbeidssoekerperiodeId());
+        OpplysningerOmArbeidssoekerEntity opplysningerOmArbeidssoeker = TestDataClient.getOpplysningerOmArbeidssoekerFraDb(jdbcTemplate, arbeidssoekerPeriode.getArbeidssoekerperiodeId());
 
         assertNotNull(opplysningerOmArbeidssoeker);
-        OpplysningerOmArbeidssoekerJobbsituasjon opplysningerOmArbeidssoekerJobbsituasjon = TestDataClient.getOpplysningerOmArbeidssoekerJobbsituasjonFraDb(jdbcTemplate, opplysningerOmArbeidssoeker.getOpplysningerOmArbeidssoekerId());
+        OpplysningerOmArbeidssoekerJobbsituasjonEntity opplysningerOmArbeidssoekerJobbsituasjon = TestDataClient.getOpplysningerOmArbeidssoekerJobbsituasjonFraDb(jdbcTemplate, opplysningerOmArbeidssoeker.getOpplysningerOmArbeidssoekerId());
 
         assertNotNull(opplysningerOmArbeidssoekerJobbsituasjon);
-        assertThat(opplysningerOmArbeidssoekerJobbsituasjon.getJobbsituasjon().get(1)).isEqualTo(JobbSituasjonBeskrivelse.ER_PERMITTERT);
+        assertThat(opplysningerOmArbeidssoekerJobbsituasjon.getJobbsituasjon().get(1)).isEqualTo(JobbSituasjonBeskrivelse.ER_PERMITTERT.name());
 
-        Profilering profilering = TestDataClient.getProfileringFraDb(jdbcTemplate, periodeId);
+        ProfileringEntity profilering = TestDataClient.getProfileringFraDb(jdbcTemplate, periodeId);
         assertNotNull(profilering);
     }
 
@@ -340,20 +340,20 @@ class OppfolgingStartetOgAvsluttetServiceTest extends EndToEndTest {
 
         arbeidssoekerService.hentOgLagreArbeidssoekerdataForBruker(aktorId);
 
-        ArbeidssoekerPeriode sisteArbeidssoekerPeriodeFørAvsluttet = TestDataClient.getArbeidssoekerPeriodeFraDb(jdbcTemplate, UUID.fromString("ea0ad984-8b99-4fff-afd6-07737ab19d16"));
+        ArbeidssoekerPeriodeEntity sisteArbeidssoekerPeriodeFørAvsluttet = TestDataClient.getArbeidssoekerPeriodeFraDb(jdbcTemplate, UUID.fromString("ea0ad984-8b99-4fff-afd6-07737ab19d16"));
         assertThat(sisteArbeidssoekerPeriodeFørAvsluttet).isNotNull();
-        OpplysningerOmArbeidssoeker opplysningerOmArbeidssoekerFørAvsluttet = TestDataClient.getOpplysningerOmArbeidssoekerFraDb(jdbcTemplate, sisteArbeidssoekerPeriodeFørAvsluttet.getArbeidssoekerperiodeId());
+        OpplysningerOmArbeidssoekerEntity opplysningerOmArbeidssoekerFørAvsluttet = TestDataClient.getOpplysningerOmArbeidssoekerFraDb(jdbcTemplate, sisteArbeidssoekerPeriodeFørAvsluttet.getArbeidssoekerperiodeId());
         assertThat(opplysningerOmArbeidssoekerFørAvsluttet).isNotNull();
-        OpplysningerOmArbeidssoekerJobbsituasjon opplysningerOmArbeidssoekerJobbsituasjonFørAvsluttet = TestDataClient.getOpplysningerOmArbeidssoekerJobbsituasjonFraDb(jdbcTemplate, opplysningerOmArbeidssoekerFørAvsluttet.getOpplysningerOmArbeidssoekerId());
+        OpplysningerOmArbeidssoekerJobbsituasjonEntity opplysningerOmArbeidssoekerJobbsituasjonFørAvsluttet = TestDataClient.getOpplysningerOmArbeidssoekerJobbsituasjonFraDb(jdbcTemplate, opplysningerOmArbeidssoekerFørAvsluttet.getOpplysningerOmArbeidssoekerId());
         assertThat(opplysningerOmArbeidssoekerJobbsituasjonFørAvsluttet).isNotNull();
 
         oppfolgingPeriodeService.behandleKafkaMeldingLogikk(genererAvsluttetOppfolgingsperiode(aktorId));
 
-        ArbeidssoekerPeriode sisteArbeidssoekerPeriodeEtterAvsluttet = TestDataClient.getArbeidssoekerPeriodeFraDb(jdbcTemplate, UUID.fromString("ea0ad984-8b99-4fff-afd6-07737ab19d16"));
+        ArbeidssoekerPeriodeEntity sisteArbeidssoekerPeriodeEtterAvsluttet = TestDataClient.getArbeidssoekerPeriodeFraDb(jdbcTemplate, UUID.fromString("ea0ad984-8b99-4fff-afd6-07737ab19d16"));
         assertThat(sisteArbeidssoekerPeriodeEtterAvsluttet).isNull();
-        OpplysningerOmArbeidssoeker opplysningerOmArbeidssoekerEtterAvsluttet = TestDataClient.getOpplysningerOmArbeidssoekerFraDb(jdbcTemplate, sisteArbeidssoekerPeriodeFørAvsluttet.getArbeidssoekerperiodeId());
+        OpplysningerOmArbeidssoekerEntity opplysningerOmArbeidssoekerEtterAvsluttet = TestDataClient.getOpplysningerOmArbeidssoekerFraDb(jdbcTemplate, sisteArbeidssoekerPeriodeFørAvsluttet.getArbeidssoekerperiodeId());
         assertThat(opplysningerOmArbeidssoekerEtterAvsluttet).isNull();
-        OpplysningerOmArbeidssoekerJobbsituasjon opplysningerOmArbeidssoekerJobbsituasjonEtterAvsluttet = TestDataClient.getOpplysningerOmArbeidssoekerJobbsituasjonFraDb(jdbcTemplate, opplysningerOmArbeidssoekerFørAvsluttet.getOpplysningerOmArbeidssoekerId());
+        OpplysningerOmArbeidssoekerJobbsituasjonEntity opplysningerOmArbeidssoekerJobbsituasjonEtterAvsluttet = TestDataClient.getOpplysningerOmArbeidssoekerJobbsituasjonFraDb(jdbcTemplate, opplysningerOmArbeidssoekerFørAvsluttet.getOpplysningerOmArbeidssoekerId());
         assertThat(opplysningerOmArbeidssoekerJobbsituasjonEtterAvsluttet).isNull();
     }
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepositoryTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepositoryTest.java
@@ -2,6 +2,7 @@ package no.nav.pto.veilarbportefolje.persononinfo;
 
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerService;
 import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest;
 import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingPeriodeService;
 import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingRepositoryV2;
@@ -11,6 +12,7 @@ import no.nav.pto_schema.kafka.json.topic.SisteOppfolgingsperiodeV1;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -34,6 +36,9 @@ public class PdlIdentRepositoryTest {
 
     @Autowired
     private OppfolgingRepositoryV2 oppfolgingRepositoryV2;
+
+    @MockBean
+    private ArbeidssoekerService arbeidssoekerService;
 
     @Test
     public void identSplitt_allePersonerMedTidligereIdenterSkalSlettes() {

--- a/src/test/java/no/nav/pto/veilarbportefolje/util/EndToEndTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/util/EndToEndTest.java
@@ -5,6 +5,7 @@ import lombok.SneakyThrows;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
 import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest;
+import no.nav.pto.veilarbportefolje.config.FeatureToggle;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.opensearch.IndexName;
@@ -27,6 +28,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.when;
 
 @SpringBootTest(classes = ApplicationConfigTest.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
@@ -64,6 +67,7 @@ public abstract class EndToEndTest {
         try {
             TimeZone.setDefault(TimeZone.getTimeZone(Optional.ofNullable(System.getenv("TZ")).orElse("Europe/Oslo")));
             opensearchAdminService.opprettNyIndeks(indexName.getValue());
+            when(FeatureToggle.brukNyttArbeidssoekerregister(defaultUnleash)).thenReturn(true);
         } catch (Exception e) {
             opensearchAdminService.slettIndex(indexName.getValue());
             opensearchAdminService.opprettNyIndeks(indexName.getValue());

--- a/src/test/java/no/nav/pto/veilarbportefolje/util/TestDataClient.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/util/TestDataClient.kt
@@ -191,17 +191,17 @@ class TestDataClient(
         fun getArbeidssoekerPeriodeFraDb(
             jdbcTemplate: JdbcTemplate,
             arbeidssoekerPeriodeId: UUID
-        ): ArbeidssoekerPeriode? {
+        ): ArbeidssoekerPeriodeEntity? {
             return try {
                 jdbcTemplate.queryForObject(
                     """SELECT * FROM ${PostgresTable.SISTE_ARBEIDSSOEKER_PERIODE.TABLE_NAME} WHERE ${PostgresTable.SISTE_ARBEIDSSOEKER_PERIODE.ARBEIDSSOKER_PERIODE_ID} =?""",
                     { rs: ResultSet, _ ->
-                        ArbeidssoekerPeriode(
+                        ArbeidssoekerPeriodeEntity(
                             rs.getObject(
                                 PostgresTable.SISTE_ARBEIDSSOEKER_PERIODE.ARBEIDSSOKER_PERIODE_ID,
                                 UUID::class.java
                             ),
-                            Fnr.of(rs.getString(PostgresTable.SISTE_ARBEIDSSOEKER_PERIODE.FNR))
+                            rs.getString(PostgresTable.SISTE_ARBEIDSSOEKER_PERIODE.FNR)
                         )
                     },
                     arbeidssoekerPeriodeId
@@ -215,7 +215,7 @@ class TestDataClient(
         fun getOpplysningerOmArbeidssoekerFraDb(
             jdbcTemplate: JdbcTemplate,
             arbeidssoekerPeriode: UUID
-        ): OpplysningerOmArbeidssoeker? {
+        ): OpplysningerOmArbeidssoekerEntity? {
             return try {
                 jdbcTemplate.queryForObject(
                     """SELECT * FROM ${PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER.TABLE_NAME} WHERE ${PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER.PERIODE_ID} =?""",
@@ -225,14 +225,14 @@ class TestDataClient(
                                 PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER.OPPLYSNINGER_OM_ARBEIDSSOEKER_ID,
                                 UUID::class.java
                             )
-                        OpplysningerOmArbeidssoeker(
+                        OpplysningerOmArbeidssoekerEntity(
                             opplysningerOmArbeidssoekerId,
                             rs.getObject(PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER.PERIODE_ID, UUID::class.java),
-                            DateUtils.toZonedDateTime(rs.getTimestamp(PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER.SENDT_INN_TIDSPUNKT)),
+                            rs.getTimestamp(PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER.SENDT_INN_TIDSPUNKT),
                             rs.getString(PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER.UTDANNING_NUS_KODE),
                             rs.getString(PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER.UTDANNING_BESTATT),
                             rs.getString(PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER.UTDANNING_GODKJENT),
-                            OpplysningerOmArbeidssoekerJobbsituasjon(opplysningerOmArbeidssoekerId, emptyList())
+                            OpplysningerOmArbeidssoekerJobbsituasjonEntity(opplysningerOmArbeidssoekerId, emptyList())
                         )
                     },
                     arbeidssoekerPeriode
@@ -246,7 +246,7 @@ class TestDataClient(
         fun getOpplysningerOmArbeidssoekerJobbsituasjonFraDb(
             jdbcTemplate: JdbcTemplate,
             opplysningerOmArbeidssoekerId: UUID
-        ): OpplysningerOmArbeidssoekerJobbsituasjon? {
+        ): OpplysningerOmArbeidssoekerJobbsituasjonEntity? {
             val jobbSituasjoner: List<String> = try {
                 jdbcTemplate.queryForList(
                     """SELECT * FROM ${PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.TABLE_NAME} WHERE ${PostgresTable.OPPLYSNINGER_OM_ARBEIDSSOEKER_JOBBSITUASJON.OPPLYSNINGER_OM_ARBEIDSSOEKER_ID} =?""",
@@ -261,23 +261,23 @@ class TestDataClient(
             return if (jobbSituasjoner.isEmpty())
                 null
             else
-                OpplysningerOmArbeidssoekerJobbsituasjon(
+                OpplysningerOmArbeidssoekerJobbsituasjonEntity(
                     opplysningerOmArbeidssoekerId,
-                    jobbSituasjoner.map { JobbSituasjonBeskrivelse.valueOf(it) }
+                    jobbSituasjoner.map { (it) }
                 )
 
         }
 
         @JvmStatic
-        fun getProfileringFraDb(jdbcTemplate: JdbcTemplate, periodeId: UUID): Profilering? {
+        fun getProfileringFraDb(jdbcTemplate: JdbcTemplate, periodeId: UUID): ProfileringEntity? {
             return try {
                 jdbcTemplate.queryForObject(
                     """SELECT * FROM ${PostgresTable.PROFILERING.TABLE_NAME} WHERE ${PostgresTable.PROFILERING.PERIODE_ID} =?""",
                     { rs: ResultSet, _ ->
-                        Profilering(
+                        ProfileringEntity(
                             rs.getObject(PostgresTable.PROFILERING.PERIODE_ID, UUID::class.java),
-                            Profileringsresultat.valueOf(rs.getString(PostgresTable.PROFILERING.PROFILERING_RESULTAT)),
-                            DateUtils.toZonedDateTime(rs.getTimestamp(PostgresTable.PROFILERING.SENDT_INN_TIDSPUNKT))
+                            rs.getString(PostgresTable.PROFILERING.PROFILERING_RESULTAT),
+                            rs.getTimestamp(PostgresTable.PROFILERING.SENDT_INN_TIDSPUNKT)
                         )
                     },
                     periodeId


### PR DESCRIPTION
## Describe your changes
Populere filter for registrering med også nye data fra det nye arbeidssøkerregisteret

* Refaktorere  eksisterende kode for arbeidssøkerregister

* Utvide brukers situasjon i opensearch til å være et array av situasjoner siden det nå kanskje skje (ikke i frontend og i praksis enda, men basert på kode kan det se ut som at det skal kunne være tilfelle i fremtiden)

* Flette inn data fra nytt arbeidssøkerregister ved indeksering

* Fjerne toggle ved start og avslutt oppfolging for nytt arbeidssøkerregistrering (har ligget en stund i prod og ser ut til å fungere)

* Oppdaterer opensearch med arbeidssoekerregistreringsdata ved innkommende kafkameldinger (så man ikke må vente på indeksering for at oversikten skal bli oppdatert)

* Sørge for at vi får med alle brukere, også de med eventuelle gamle situasjoner, når man filtrerer. Tror de skal være migrert over på nye alle sammen, men greit å være på den sikre siden så ingen brukere faller igjennom,

## Trello ticket number and link
[#587](https://trello.com/c/N46wEHKr/587-veilarbregistrering-blir-skrudd-av-vi-m%C3%A5-koble-oss-p%C3%A5-nye-kafkastr%C3%B8mmer-og-endepunkt-for-besvarelse-fra-registrering-profilering)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- OBS: bør kjøre hovedindexsering tror jeg
