### PR TITLE
For å kunne varsle i frontend om sletting av huskelapp og kategori ved kontorbytte trenger vi å vite enhetid hvor det ble opprettet

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslisteService.java
@@ -63,7 +63,7 @@ public class ArbeidslisteService {
         return arbeidslisteRepositoryV2.insertArbeidsliste(dto)
                 .onSuccess((result) -> {
                     opensearchIndexerV2.updateArbeidsliste(result);
-                    opensearchIndexerV2.updateFargekategori(result.getAktorId(), ArbeidslisteMapper.mapTilFargekategoriVerdi(result.kategori));
+                    opensearchIndexerV2.updateFargekategori(result.getAktorId(), ArbeidslisteMapper.mapTilFargekategoriVerdi(result.kategori), navKontorForBruker.toString());
                 });
     }
 
@@ -77,7 +77,7 @@ public class ArbeidslisteService {
         return arbeidslisteRepositoryV2.updateArbeidsliste(data)
                 .onSuccess((result) -> {
                     opensearchIndexerV2.updateArbeidsliste(result);
-                    opensearchIndexerV2.updateFargekategori(result.getAktorId(), ArbeidslisteMapper.mapTilFargekategoriVerdi(result.kategori));
+                    opensearchIndexerV2.updateFargekategori(result.getAktorId(), ArbeidslisteMapper.mapTilFargekategoriVerdi(result.kategori), data.getNavKontorForArbeidsliste());
                 });
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/database/PostgresTable.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/database/PostgresTable.java
@@ -31,13 +31,14 @@ public class PostgresTable {
         public static final String ARB_OVERSKRIFT = "ARB_OVERSKRIFT";
         public static final String ARB_NAV_KONTOR_FOR_ARBEIDSLISTE = "ARB_NAV_KONTOR_FOR_ARBEIDSLISTE";
         public static final String FAR_VERDI = "FAR_VERDI";
-        public static final String FAR_SIST_ENDRET = "FAR_SIST_ENDRET";
+        public static final String FAR_ENHET_ID = "FAR_ENHET_ID";
 
         public static final String HL_FRIST = "HL_FRIST";
         public static final String HL_KOMMENTAR = "HL_KOMMENTAR";
         public static final String HL_ENDRET_DATO = "HL_ENDRET_DATO";
         public static final String HL_ENDRET_AV = "HL_ENDRET_AV";
-        public static final String HL_HUSKELAPPID= "HL_HUSKELAPPID";
+        public static final String HL_HUSKELAPPID = "HL_HUSKELAPPID";
+        public static final String HL_ENHET_ID = "HL_ENHET_ID";
         public static final String BRUKERS_SITUASJON = "BRUKERS_SITUASJON";
         public static final String UTDANNING = "UTDANNING";
         public static final String UTDANNING_BESTATT = "UTDANNING_BESTATT";

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Bruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Bruker.java
@@ -110,6 +110,7 @@ public class Bruker {
 
     HuskelappForBruker huskelapp;
     String fargekategori;
+    String fargekategoriEnhetId;
 
 
     public static Bruker of(OppfolgingsBruker bruker, boolean ufordelt, boolean erVedtakstottePilotPa) {
@@ -206,7 +207,9 @@ public class Bruker {
                 .setBrukersSituasjonSistEndret(bruker.getBrukers_situasjon_sist_endret())
                 .setUtdanningOgSituasjonSistEndret(bruker.getUtdanning_og_situasjon_sist_endret())
                 .setHuskelapp(bruker.getHuskelapp())
-                .setFargekategori(bruker.getFargekategori());
+                .setFargekategori(bruker.getFargekategori())
+                .setFargekategoriEnhetId(bruker.getFargekategori_enhetId());
+
     }
 
     public void kalkulerNesteUtlopsdatoAvValgtAktivitetFornklet(List<String> aktiviteterForenklet) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/HuskelappForBruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/HuskelappForBruker.java
@@ -9,7 +9,8 @@ public record HuskelappForBruker(
     String kommentar,
     LocalDate endretDato,
     String endretAv,
-    String huskelappId
+    String huskelappId,
+    String enhetId
 ) {
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public HuskelappForBruker {

--- a/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/fargekategori/FargekategoriService.java
@@ -49,7 +49,7 @@ public class FargekategoriService {
         } else {
             FargekategoriEntity oppdatertKategori = fargekategoriRepository.upsertFargekateori(request, sistEndretAv, enhetId);
 
-            oppdaterIOpensearch(request.fnr(), request.fargekategoriVerdi());
+            oppdaterIOpensearch(request.fnr(), request.fargekategoriVerdi().name(), enhetId.get());
 
             return Optional.of(oppdatertKategori);
         }
@@ -64,7 +64,7 @@ public class FargekategoriService {
         } else {
             fargekategoriRepository.batchupsertFargekategori(fargekategoriVerdi, fnr, innloggetVeileder, enhetId);
 
-            fnr.forEach(f -> oppdaterIOpensearch(f, fargekategoriVerdi));
+            fnr.forEach(f -> oppdaterIOpensearch(f,fargekategoriVerdi.name(), enhetId.get()));
         }
     }
 
@@ -73,9 +73,9 @@ public class FargekategoriService {
         opensearchIndexerV2.slettFargekategori(aktorId);
     }
 
-    private void oppdaterIOpensearch(Fnr fnr, FargekategoriVerdi fargekategoriVerdi) {
+    private void oppdaterIOpensearch(Fnr fnr, String fargekategori, String enhetId) {
         AktorId aktorId = Optional.ofNullable(pdlIdentRepository.hentAktorIdForAktivBruker(fnr)).orElseThrow(RuntimeException::new);
-        opensearchIndexerV2.updateFargekategori(aktorId, fargekategoriVerdi.name());
+        opensearchIndexerV2.updateFargekategori(aktorId, fargekategori, enhetId);
     }
 
     public void slettFargekategoriPaaBruker(AktorId aktorId, Optional<Fnr> maybeFnr) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/huskelapp/HuskelappService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/huskelapp/HuskelappService.java
@@ -41,7 +41,7 @@ public class HuskelappService {
             UUID huskelappId = huskelappRepository.opprettHuskelapp(huskelappOpprettRequest, veilederId);
 
             AktorId aktorId = hentAktorId(huskelappOpprettRequest.brukerFnr()).orElseThrow(RuntimeException::new);
-            opensearchIndexerV2.updateHuskelapp(aktorId, new HuskelappForBruker(huskelappOpprettRequest.frist(), huskelappOpprettRequest.kommentar(), LocalDate.now(), veilederId.getValue(), huskelappId.toString()));
+            opensearchIndexerV2.updateHuskelapp(aktorId, new HuskelappForBruker(huskelappOpprettRequest.frist(), huskelappOpprettRequest.kommentar(), LocalDate.now(), veilederId.getValue(), huskelappId.toString(), huskelappOpprettRequest.enhetId().get()));
 
             return huskelappId;
         } catch (Exception e) {
@@ -55,7 +55,7 @@ public class HuskelappService {
             huskelappRepository.redigerHuskelapp(huskelappRedigerRequest, veilederId);
 
             AktorId aktorId = hentAktorId(huskelappRedigerRequest.brukerFnr()).orElseThrow(RuntimeException::new);
-            opensearchIndexerV2.updateHuskelapp(aktorId, new HuskelappForBruker(huskelappRedigerRequest.frist(), huskelappRedigerRequest.kommentar(), LocalDate.now(), veilederId.getValue(), huskelappRedigerRequest.huskelappId().toString()));
+            opensearchIndexerV2.updateHuskelapp(aktorId, new HuskelappForBruker(huskelappRedigerRequest.frist(), huskelappRedigerRequest.kommentar(), LocalDate.now(), veilederId.getValue(), huskelappRedigerRequest.huskelappId().toString(), huskelappRedigerRequest.enhetId().get()));
 
         } catch (Exception e) {
             secureLog.error("Kunne ikke redigere huskelapp for fnr: " + huskelappRedigerRequest.brukerFnr() + " HuskelappId: " + huskelappRedigerRequest.huskelappId().toString(), e);

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
@@ -7,7 +7,6 @@ import no.nav.arbeid.soker.registrering.ArbeidssokerRegistrertEvent;
 import no.nav.common.types.identer.AktorId;
 import no.nav.paw.besvarelse.ArbeidssokerBesvarelseEvent;
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteDTO;
-import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.OpplysningerOmArbeidssoeker;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.OpplysningerOmArbeidssoekerEntity;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ProfileringEntity;
 import no.nav.pto.veilarbportefolje.dialog.Dialogdata;
@@ -130,6 +129,7 @@ public class OpensearchIndexerV2 {
                 .field("endretAv", huskelapp.endretAv())
                 .field("endretDato", huskelapp.endretDato())
                 .field("huskelappId", huskelapp.huskelappId())
+                .field("enhetId", huskelapp.enhetId())
                 .endObject()
                 .endObject();
 
@@ -148,10 +148,11 @@ public class OpensearchIndexerV2 {
     }
 
     @SneakyThrows
-    public void updateFargekategori(AktorId aktoerId, String fargekategori) {
+    public void updateFargekategori(AktorId aktoerId, String fargekategori, String enhetId) {
         final XContentBuilder content = jsonBuilder()
                 .startObject()
                 .field("fargekategori", fargekategori)
+                .field("fargekategori_enhetId", enhetId)
                 .endObject();
 
         update(aktoerId, content, "Oppretter/redigerer fargekategori");
@@ -163,6 +164,7 @@ public class OpensearchIndexerV2 {
         final XContentBuilder content = jsonBuilder()
                 .startObject()
                 .nullField("fargekategori")
+                .nullField("fargekategori_enhetId")
                 .endObject();
 
         update(aktoerId, content, "Sletter fargekategori");

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/OppfolgingsBruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/OppfolgingsBruker.java
@@ -128,5 +128,5 @@ public class OppfolgingsBruker {
     EnsligeForsorgereOvergangsstonad enslige_forsorgere_overgangsstonad;
     HuskelappForBruker huskelapp;
     String fargekategori;
-
+    String fargekategori_enhetId;
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
@@ -73,11 +73,13 @@ public class BrukerRepositoryV2 {
                                ARB.KATEGORI                     as ARB_KATEGORI,
                                ARB.NAV_KONTOR_FOR_ARBEIDSLISTE  as ARB_NAV_KONTOR_FOR_ARBEIDSLISTE,
                                FAR.verdi                        as FAR_VERDI,
+                               FAR.enhet_id                     as FAR_ENHET_ID,
                                HL.frist							as HL_FRIST,
                                HL.kommentar						as HL_KOMMENTAR,
                                HL.endret_dato                   as HL_ENDRET_DATO,
                                hl.endret_av_veileder            as HL_ENDRET_AV,
-                               HL.huskelapp_id                  as HL_HUSKELAPPID
+                               HL.huskelapp_id                  as HL_HUSKELAPPID,
+                               HL.enhet_id                      as HL_ENHET_ID
                         FROM OPPFOLGING_DATA OD
                                 inner join aktive_identer ai on OD.aktoerid = ai.aktorid
                                  left join oppfolgingsbruker_arena_v2 ob on ob.fodselsnr = ai.fnr
@@ -176,7 +178,8 @@ public class BrukerRepositoryV2 {
                 .setAapmaxtiduke(rs.getObject(AAPMAXTIDUKE, Integer.class))
                 .setAapordinerutlopsdato(aapordinerutlopsdato)
                 .setAapunntakukerigjen(konverterDagerTilUker(rs.getObject(AAPUNNTAKDAGERIGJEN, Integer.class)))
-                .setFargekategori(rs.getString(FAR_VERDI));
+                .setFargekategori(rs.getString(FAR_VERDI))
+                .setFargekategori_enhetId(rs.getString(FAR_ENHET_ID));
 
         setHuskelapp(bruker, rs);
         setBrukersSituasjon(bruker, rs);
@@ -232,8 +235,9 @@ public class BrukerRepositoryV2 {
         String huskelappId = rs.getString(HL_HUSKELAPPID);
         LocalDate endretDato = toLocalDate(rs.getTimestamp(HL_ENDRET_DATO));
         VeilederId endretAv = VeilederId.veilederIdOrNull(rs.getString(HL_ENDRET_AV));
+        String enhetId = rs.getString(HL_ENHET_ID);
         if (frist != null || kommentar != null) {
-            oppfolgingsBruker.setHuskelapp(new HuskelappForBruker(frist, kommentar, endretDato, endretAv.getValue(), huskelappId));
+            oppfolgingsBruker.setHuskelapp(new HuskelappForBruker(frist, kommentar, endretDato, endretAv.getValue(), huskelappId, enhetId));
         }
     }
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -557,8 +557,9 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setOppfolging(true)
                 .setEnhet_id(TEST_ENHET)
                 .setVeileder_id(TEST_VEILEDER_0)
-                .setHuskelapp(new HuskelappForBruker(LocalDate.now(), "test huskelapp", LocalDate.now(), TEST_VEILEDER_0, UUID.randomUUID().toString()))
-                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_A.name());
+                .setHuskelapp(new HuskelappForBruker(LocalDate.now(), "test huskelapp", LocalDate.now(), TEST_VEILEDER_0, UUID.randomUUID().toString(), TEST_ENHET))
+                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_A.name())
+                .setFargekategori_enhetId(TEST_ENHET);
 
         var testBruker2 = new OppfolgingsBruker()
                 .setAktoer_id(randomAktorId().toString())
@@ -575,7 +576,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setVenterpasvarfranav("2018-05-09T22:00:00Z")
                 .setNyesteutlopteaktivitet("2018-05-09T22:00:00Z")
                 .setHuskelapp(null)
-                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_B.name());
+                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_B.name())
+                .setFargekategori_enhetId(TEST_ENHET);
 
         var inaktivBruker = new OppfolgingsBruker()
                 .setAktoer_id(randomAktorId().toString())
@@ -587,10 +589,12 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
 
         var kode6BrukerSomVeilederIkkeHarInnsynsrettPa = genererRandomBruker(true, TEST_ENHET, TEST_VEILEDER_0, Adressebeskyttelse.STRENGT_FORTROLIG.diskresjonskode, false)
                 .setVenterpasvarfranav(toIsoUTC(LocalDateTime.now()))
-                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_A.name());
+                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_A.name())
+                .setFargekategori_enhetId(TEST_ENHET);
         var kode7BrukerSomVeilederIkkeHarInnsynsrettPa = genererRandomBruker(true, TEST_ENHET, TEST_VEILEDER_0, Adressebeskyttelse.FORTROLIG.diskresjonskode, false)
                 .setVenterpasvarfranav(toIsoUTC(LocalDateTime.now()))
-                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_B.name());
+                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_B.name())
+                .setFargekategori_enhetId(TEST_ENHET);
         var egenAnsattBrukerSomVeilederIkkeHarInnsynsrettPa = genererRandomBruker(true, TEST_ENHET, TEST_VEILEDER_0, null, true)
                 .setVenterpasvarfranav(toIsoUTC(LocalDateTime.now()));
 
@@ -3793,10 +3797,10 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
 
     @Test
     public void test_sortering_huskelapp() {
-        var huskelapp1 = new HuskelappForBruker(LocalDate.now().plusDays(20), "dddd Ringe fastlege", LocalDate.now(), TEST_VEILEDER_0, UUID.randomUUID().toString());
-        var huskelapp2 = new HuskelappForBruker(LocalDate.now().plusDays(30), "bbbb Ha et møte", LocalDate.now(), TEST_VEILEDER_0, UUID.randomUUID().toString());
-        var huskelapp3 = new HuskelappForBruker(LocalDate.now().plusMonths(2), "aaaa Snakke om idrett", LocalDate.now(), TEST_VEILEDER_0, UUID.randomUUID().toString());
-        var huskelapp4 = new HuskelappForBruker(LocalDate.now().plusDays(3), "cccc Huddle med Julie", LocalDate.now(), TEST_VEILEDER_0, UUID.randomUUID().toString());
+        var huskelapp1 = new HuskelappForBruker(LocalDate.now().plusDays(20), "dddd Ringe fastlege", LocalDate.now(), TEST_VEILEDER_0, UUID.randomUUID().toString(), TEST_ENHET);
+        var huskelapp2 = new HuskelappForBruker(LocalDate.now().plusDays(30), "bbbb Ha et møte", LocalDate.now(), TEST_VEILEDER_0, UUID.randomUUID().toString(), TEST_ENHET);
+        var huskelapp3 = new HuskelappForBruker(LocalDate.now().plusMonths(2), "aaaa Snakke om idrett", LocalDate.now(), TEST_VEILEDER_0, UUID.randomUUID().toString(), TEST_ENHET);
+        var huskelapp4 = new HuskelappForBruker(LocalDate.now().plusDays(3), "cccc Huddle med Julie", LocalDate.now(), TEST_VEILEDER_0, UUID.randomUUID().toString(), TEST_ENHET);
 
         var bruker1 = new OppfolgingsBruker()
                 .setFnr(randomFnr().toString())
@@ -3899,7 +3903,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setOppfolging(true)
                 .setVeileder_id(TEST_VEILEDER_0)
                 .setEnhet_id(TEST_ENHET)
-                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_D.name());
+                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_D.name())
+                .setFargekategori_enhetId(TEST_ENHET);
 
         var bruker2 = new OppfolgingsBruker()
                 .setFnr(randomFnr().toString())
@@ -3908,7 +3913,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setVeileder_id(TEST_VEILEDER_0)
                 .setNy_for_veileder(false)
                 .setEnhet_id(TEST_ENHET)
-                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_A.name());
+                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_A.name())
+                .setFargekategori_enhetId(TEST_ENHET);
 
         var bruker3 = new OppfolgingsBruker()
                 .setFnr(randomFnr().toString())
@@ -3916,7 +3922,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setOppfolging(true)
                 .setVeileder_id(TEST_VEILEDER_0)
                 .setEnhet_id(TEST_ENHET)
-                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_A.name());
+                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_A.name())
+                .setFargekategori_enhetId(TEST_ENHET);
 
         var bruker4 = new OppfolgingsBruker()
                 .setFnr(randomFnr().toString())
@@ -3924,7 +3931,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setOppfolging(true)
                 .setVeileder_id(TEST_VEILEDER_0)
                 .setEnhet_id(TEST_ENHET)
-                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_B.name());
+                .setFargekategori(FargekategoriVerdi.FARGEKATEGORI_B.name())
+                .setFargekategori_enhetId(TEST_ENHET);
 
         var bruker5 = new OppfolgingsBruker()
                 .setFnr(randomFnr().toString())


### PR DESCRIPTION
## Describe your changes
Vi ønsker å varsle brukerne om at ved tildeling til veileder etter kontorbytte vil huskelapp og fargekategori bli slettet. For at dette skal kunne gjøres i frontend må vi sende med enhetsid på både huskelapp og fargekategorien i svar fra opensearch

## Trello ticket number and link
[#625](https://trello.com/c/hv0LjSyW/625-advarsel-om-at-huskelapp-kategori-vert-sletta-om-ein-tildeler-til-nokon-som-ikkje-har-tilgang-ved-kontorbytte)
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

