### PR TITLE
Sortere tiltakshendelser på opprettet-dato som default

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -430,7 +430,8 @@ public class OpensearchQueryBuilder {
             sortField, SearchSourceBuilder searchSourceBuilder, Filtervalg filtervalg, BrukerinnsynTilganger brukerinnsynTilganger) {
         SortOrder order = "ascending".equals(sortOrder) ? SortOrder.ASC : SortOrder.DESC;
 
-        if ("ikke_satt".equals(sortField) && filtervalg.ferdigfilterListe.contains(TILTAKSHENDELSER)) {
+        /* Null-sjekken er fordi testane kan ha ferdigfilterliste = null */
+        if ("ikke_satt".equals(sortField) && filtervalg.ferdigfilterListe != null && filtervalg.ferdigfilterListe.contains(TILTAKSHENDELSER)) {
             sorterTiltakshendelseOpprettetDato(searchSourceBuilder, order);
             return searchSourceBuilder;
         }

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -36,6 +36,7 @@ import static java.util.stream.Collectors.toList;
 import static no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerMapperKt.inkludereSituasjonerFraBadeVeilarbregistreringOgArbeidssoekerregistrering;
 import static no.nav.pto.veilarbportefolje.domene.AktivitetFiltervalg.JA;
 import static no.nav.pto.veilarbportefolje.domene.AktivitetFiltervalg.NEI;
+import static no.nav.pto.veilarbportefolje.domene.Brukerstatus.TILTAKSHENDELSER;
 import static no.nav.pto.veilarbportefolje.util.DateUtils.toIsoUTC;
 import static org.apache.commons.lang3.StringUtils.isNumeric;
 import static org.opensearch.index.query.QueryBuilders.*;
@@ -429,7 +430,11 @@ public class OpensearchQueryBuilder {
             sortField, SearchSourceBuilder searchSourceBuilder, Filtervalg filtervalg, BrukerinnsynTilganger brukerinnsynTilganger) {
         SortOrder order = "ascending".equals(sortOrder) ? SortOrder.ASC : SortOrder.DESC;
 
-        if ("ikke_satt".equals(sortField)) {
+        if ("ikke_satt".equals(sortField) && filtervalg.ferdigfilterListe.contains(TILTAKSHENDELSER)) {
+            sorterTiltakshendelseOpprettetDato(searchSourceBuilder, order);
+            return searchSourceBuilder;
+        }
+        if ("ikke_satt".equals(sortField) ) {
             searchSourceBuilder.sort("aktoer_id", SortOrder.ASC);
             return searchSourceBuilder;
         }
@@ -474,7 +479,7 @@ public class OpensearchQueryBuilder {
             case "huskelapp" -> sorterHuskelappEksistere(searchSourceBuilder, order);
             case "huskelapp_kommentar" -> searchSourceBuilder.sort("huskelapp.kommentar", order);
             case "fargekategori" -> searchSourceBuilder.sort("fargekategori", order);
-            case "tiltakshendelse_dato_opprettet" -> searchSourceBuilder.sort("tiltakshendelse.opprettet", order);
+            case "tiltakshendelse_dato_opprettet" -> sorterTiltakshendelseOpprettetDato(searchSourceBuilder, order);
             default -> defaultSort(sortField, searchSourceBuilder, order);
         }
         addSecondarySort(searchSourceBuilder);
@@ -512,6 +517,10 @@ public class OpensearchQueryBuilder {
 
     static void sorterStatsborgerskapGyldigFra(SearchSourceBuilder searchSourceBuilder, SortOrder order) {
         searchSourceBuilder.sort("hovedStatsborgerskap.gyldigFra", order);
+    }
+
+    static void sorterTiltakshendelseOpprettetDato(SearchSourceBuilder searchSourceBuilder, SortOrder order) {
+        searchSourceBuilder.sort("tiltakshendelse.opprettet", order);
     }
 
     static void sorterTolkeSpraak(Filtervalg filtervalg, SearchSourceBuilder searchSourceBuilder, SortOrder order) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -434,7 +434,7 @@ public class OpensearchQueryBuilder {
             sorterTiltakshendelseOpprettetDato(searchSourceBuilder, order);
             return searchSourceBuilder;
         }
-        if ("ikke_satt".equals(sortField) ) {
+        if ("ikke_satt".equals(sortField)) {
             searchSourceBuilder.sort("aktoer_id", SortOrder.ASC);
             return searchSourceBuilder;
         }
@@ -480,6 +480,7 @@ public class OpensearchQueryBuilder {
             case "huskelapp_kommentar" -> searchSourceBuilder.sort("huskelapp.kommentar", order);
             case "fargekategori" -> searchSourceBuilder.sort("fargekategori", order);
             case "tiltakshendelse_dato_opprettet" -> sorterTiltakshendelseOpprettetDato(searchSourceBuilder, order);
+            case "tiltakshendelse_tekst" -> searchSourceBuilder.sort("tiltakshendelse.tekst", order);
             default -> defaultSort(sortField, searchSourceBuilder, order);
         }
         addSecondarySort(searchSourceBuilder);

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -474,6 +474,7 @@ public class OpensearchQueryBuilder {
             case "huskelapp" -> sorterHuskelappEksistere(searchSourceBuilder, order);
             case "huskelapp_kommentar" -> searchSourceBuilder.sort("huskelapp.kommentar", order);
             case "fargekategori" -> searchSourceBuilder.sort("fargekategori", order);
+            case "tiltakshendelse_dato_opprettet" -> searchSourceBuilder.sort("tiltakshendelse.opprettet", order);
             default -> defaultSort(sortField, searchSourceBuilder, order);
         }
         addSecondarySort(searchSourceBuilder);

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -432,7 +432,7 @@ public class OpensearchQueryBuilder {
 
         /* Null-sjekken er fordi testane kan ha ferdigfilterliste = null */
         if ("ikke_satt".equals(sortField) && filtervalg.ferdigfilterListe != null && filtervalg.ferdigfilterListe.contains(TILTAKSHENDELSER)) {
-            sorterTiltakshendelseOpprettetDato(searchSourceBuilder, order);
+            sorterTiltakshendelseOpprettetDato(searchSourceBuilder, SortOrder.ASC);
             return searchSourceBuilder;
         }
         if ("ikke_satt".equals(sortField)) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/util/ValideringsRegler.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/util/ValideringsRegler.java
@@ -77,7 +77,8 @@ public class ValideringsRegler {
             "huskelapp",
             "fargekategori",
             "utdanningOgSituasjonSistEndret",
-            "tiltakshendelse_dato_opprettet"
+            "tiltakshendelse_dato_opprettet",
+            "tiltakshendelse_tekst"
     );
 
     public static void sjekkEnhet(String enhet) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/util/ValideringsRegler.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/util/ValideringsRegler.java
@@ -76,7 +76,8 @@ public class ValideringsRegler {
             "huskelapp_kommentar",
             "huskelapp",
             "fargekategori",
-            "utdanningOgSituasjonSistEndret"
+            "utdanningOgSituasjonSistEndret",
+            "tiltakshendelse_dato_opprettet"
     );
 
     public static void sjekkEnhet(String enhet) {

--- a/src/main/resources/opensearch_settings.json
+++ b/src/main/resources/opensearch_settings.json
@@ -259,6 +259,16 @@
             "type": "keyword"
           }
         }
+      },
+      "tiltakshendelse": {
+        "properties": {
+          "opprettet": {
+            "type": "date"
+          },
+          "tekst": {
+            "type": "keyword"
+          }
+        }
       }
     }
   }

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -3295,6 +3295,78 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
     }
 
     @Test
+    public void test_sortering_tiltakshendelser() {
+        Fnr bruker1Fnr = Fnr.of("01010111111");
+        UUID bruker1UUID = UUID.randomUUID();
+        LocalDateTime bruker1Opprettet = LocalDateTime.of(2024, 06, 01, 0, 0);
+        String tekst = "Forslag: Endre alt";
+        String lenke = "http.cat/200";
+        Tiltakstype tiltakstype = Tiltakstype.ARBFORB;
+
+        OppfolgingsBruker bruker1 = new OppfolgingsBruker()
+                .setFnr(bruker1Fnr.toString())
+                .setAktoer_id(randomAktorId().toString())
+                .setOppfolging(true)
+                .setVeileder_id(TEST_VEILEDER_0)
+                .setNy_for_veileder(false)
+                .setEnhet_id(TEST_ENHET)
+                .setTiltakshendelse(new Tiltakshendelse(bruker1UUID, bruker1Opprettet, tekst, lenke, tiltakstype, bruker1Fnr));
+
+        Fnr bruker2Fnr = Fnr.of("02020222222");
+        UUID bruker2UUID = UUID.randomUUID();
+        LocalDateTime bruker2Opprettet = LocalDateTime.of(2023, 06, 01, 0, 0);
+
+
+        OppfolgingsBruker bruker2 = new OppfolgingsBruker()
+                .setFnr(bruker2Fnr.toString())
+                .setAktoer_id(randomAktorId().toString())
+                .setOppfolging(true)
+                .setVeileder_id(TEST_VEILEDER_0)
+                .setNy_for_veileder(false)
+                .setEnhet_id(TEST_ENHET)
+                .setTiltakshendelse(new Tiltakshendelse(bruker2UUID, bruker2Opprettet, tekst, lenke, tiltakstype, bruker2Fnr));
+
+        Fnr bruker3Fnr = Fnr.of("03030333333");
+        UUID bruker3UUID = UUID.randomUUID();
+        LocalDateTime bruker3Opprettet = LocalDateTime.of(2022, 06, 01, 0, 0);
+
+        OppfolgingsBruker bruker3 = new OppfolgingsBruker()
+                .setFnr(bruker3Fnr.toString())
+                .setAktoer_id(randomAktorId().toString())
+                .setOppfolging(true)
+                .setVeileder_id(TEST_VEILEDER_0)
+                .setNy_for_veileder(false)
+                .setEnhet_id(TEST_ENHET)
+                .setTiltakshendelse(new Tiltakshendelse(bruker3UUID, bruker3Opprettet, tekst, lenke, tiltakstype, bruker3Fnr));
+
+        List<OppfolgingsBruker> brukere = List.of(bruker1, bruker2, bruker3);
+
+        skrivBrukereTilTestindeks(brukere);
+
+        pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == brukere.size());
+
+
+        Filtervalg filterValg = new Filtervalg()
+                .setFerdigfilterListe(List.of(TILTAKSHENDELSER));
+
+        BrukereMedAntall response = opensearchService.hentBrukere(
+                TEST_ENHET,
+                empty(),
+                "ascending",
+                "tiltakshendelse_dato_opprettet",
+                filterValg,
+                null,
+                null
+        );
+        List<Bruker> sorterteBrukere = response.getBrukere();
+
+        assertThat(response.getAntall()).isEqualTo(3);
+        assertThat(sorterteBrukere.get(0).getFnr()).isEqualTo(bruker3Fnr.toString());
+        assertThat(sorterteBrukere.get(1).getFnr()).isEqualTo(bruker2Fnr.toString());
+        assertThat(sorterteBrukere.get(2).getFnr()).isEqualTo(bruker1Fnr.toString());
+    }
+
+    @Test
     public void test_sorting_barn_under_18_veileder_tilgang_6_7() {
 
         var bruker1B = new OppfolgingsBruker()

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -3233,6 +3233,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setEnhet_id(TEST_ENHET)
                 .setTiltakshendelse(null);
 
+
         Fnr bruker2Fnr = Fnr.of("02020222222");
         UUID bruker2UUID = UUID.randomUUID();
         LocalDateTime bruker2Opprettet = LocalDateTime.now();
@@ -3248,6 +3249,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setNy_for_veileder(false)
                 .setEnhet_id(TEST_ENHET)
                 .setTiltakshendelse(new Tiltakshendelse(bruker2UUID, bruker2Opprettet, bruker2Tekst, bruker2Lenke, bruker2Tiltakstype, bruker2Fnr));
+
 
         Fnr bruker3Fnr = Fnr.of("03030333333");
         UUID bruker3UUID = UUID.randomUUID();
@@ -3265,12 +3267,11 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setEnhet_id(TEST_ENHET)
                 .setTiltakshendelse(new Tiltakshendelse(bruker3UUID, bruker3Opprettet, bruker3Tekst, bruker3Lenke, bruker3Tiltakstype, bruker3Fnr));
 
+
         List<OppfolgingsBruker> brukere = List.of(bruker1, bruker2, bruker3);
 
         skrivBrukereTilTestindeks(brukere);
-
         pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == brukere.size());
-
 
         Filtervalg filterValg = new Filtervalg()
                 .setFerdigfilterListe(List.of(TILTAKSHENDELSER));
@@ -3295,11 +3296,11 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
     }
 
     @Test
-    public void test_sortering_tiltakshendelser() {
+    public void test_sortering_tiltakshendelser_opprettet() {
         Fnr bruker1Fnr = Fnr.of("01010111111");
         UUID bruker1UUID = UUID.randomUUID();
         LocalDateTime bruker1Opprettet = LocalDateTime.of(2024, 06, 01, 0, 0);
-        String tekst = "Forslag: Endre alt";
+        String bruker1tekst = "Dette er noko tekst som startar på D.";
         String lenke = "http.cat/200";
         Tiltakstype tiltakstype = Tiltakstype.ARBFORB;
 
@@ -3310,12 +3311,13 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setVeileder_id(TEST_VEILEDER_0)
                 .setNy_for_veileder(false)
                 .setEnhet_id(TEST_ENHET)
-                .setTiltakshendelse(new Tiltakshendelse(bruker1UUID, bruker1Opprettet, tekst, lenke, tiltakstype, bruker1Fnr));
+                .setTiltakshendelse(new Tiltakshendelse(bruker1UUID, bruker1Opprettet, bruker1tekst, lenke, tiltakstype, bruker1Fnr));
+
 
         Fnr bruker2Fnr = Fnr.of("02020222222");
         UUID bruker2UUID = UUID.randomUUID();
         LocalDateTime bruker2Opprettet = LocalDateTime.of(2023, 06, 01, 0, 0);
-
+        String bruker2Tekst = "Akkurat slik startar du ein setning med bokstaven A.";
 
         OppfolgingsBruker bruker2 = new OppfolgingsBruker()
                 .setFnr(bruker2Fnr.toString())
@@ -3324,11 +3326,13 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setVeileder_id(TEST_VEILEDER_0)
                 .setNy_for_veileder(false)
                 .setEnhet_id(TEST_ENHET)
-                .setTiltakshendelse(new Tiltakshendelse(bruker2UUID, bruker2Opprettet, tekst, lenke, tiltakstype, bruker2Fnr));
+                .setTiltakshendelse(new Tiltakshendelse(bruker2UUID, bruker2Opprettet, bruker2Tekst, lenke, tiltakstype, bruker2Fnr));
+
 
         Fnr bruker3Fnr = Fnr.of("03030333333");
         UUID bruker3UUID = UUID.randomUUID();
         LocalDateTime bruker3Opprettet = LocalDateTime.of(2022, 06, 01, 0, 0);
+        String bruker3Tekst = "Byrjinga av denne teksten er bokstaven B.";
 
         OppfolgingsBruker bruker3 = new OppfolgingsBruker()
                 .setFnr(bruker3Fnr.toString())
@@ -3337,14 +3341,13 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setVeileder_id(TEST_VEILEDER_0)
                 .setNy_for_veileder(false)
                 .setEnhet_id(TEST_ENHET)
-                .setTiltakshendelse(new Tiltakshendelse(bruker3UUID, bruker3Opprettet, tekst, lenke, tiltakstype, bruker3Fnr));
+                .setTiltakshendelse(new Tiltakshendelse(bruker3UUID, bruker3Opprettet, bruker3Tekst, lenke, tiltakstype, bruker3Fnr));
+
 
         List<OppfolgingsBruker> brukere = List.of(bruker1, bruker2, bruker3);
 
         skrivBrukereTilTestindeks(brukere);
-
         pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == brukere.size());
-
 
         Filtervalg filterValg = new Filtervalg()
                 .setFerdigfilterListe(List.of(TILTAKSHENDELSER));
@@ -3366,7 +3369,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         assertThat(brukereDefaultRekkefolge.get(2).getFnr()).isEqualTo(bruker1Fnr.toString());
 
 
-        BrukereMedAntall responseEksplisittSortering = opensearchService.hentBrukere(
+        BrukereMedAntall responseSortertNyesteDato = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
                 "descending",
@@ -3375,12 +3378,28 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 null,
                 null
         );
-        List<Bruker> brukereEksplisittSortert = responseEksplisittSortering.getBrukere();
+        List<Bruker> brukereOpprettetSortertPaNyeste = responseSortertNyesteDato.getBrukere();
 
-        assertThat(responseEksplisittSortering.getAntall()).isEqualTo(3);
-        assertThat(brukereEksplisittSortert.get(0).getFnr()).isEqualTo(bruker1Fnr.toString());
-        assertThat(brukereEksplisittSortert.get(1).getFnr()).isEqualTo(bruker2Fnr.toString());
-        assertThat(brukereEksplisittSortert.get(2).getFnr()).isEqualTo(bruker3Fnr.toString());
+        assertThat(responseSortertNyesteDato.getAntall()).isEqualTo(3);
+        assertThat(brukereOpprettetSortertPaNyeste.get(0).getFnr()).isEqualTo(bruker1Fnr.toString());
+        assertThat(brukereOpprettetSortertPaNyeste.get(1).getFnr()).isEqualTo(bruker2Fnr.toString());
+        assertThat(brukereOpprettetSortertPaNyeste.get(2).getFnr()).isEqualTo(bruker3Fnr.toString());
+
+        BrukereMedAntall responseSortertAlfabetisk = opensearchService.hentBrukere(
+                TEST_ENHET,
+                empty(),
+                "ascending",
+                "tiltakshendelse_tekst",
+                filterValg,
+                null,
+                null
+        );
+        List<Bruker> brukereTekstSortertAlfabetisk = responseSortertAlfabetisk.getBrukere();
+
+        assertThat(responseSortertAlfabetisk.getAntall()).isEqualTo(3);
+        assertThat(brukereTekstSortertAlfabetisk.get(0).getFnr()).isEqualTo(bruker2Fnr.toString());
+        assertThat(brukereTekstSortertAlfabetisk.get(1).getFnr()).isEqualTo(bruker3Fnr.toString());
+        assertThat(brukereTekstSortertAlfabetisk.get(2).getFnr()).isEqualTo(bruker1Fnr.toString());
     }
 
     @Test

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -3349,21 +3349,38 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         Filtervalg filterValg = new Filtervalg()
                 .setFerdigfilterListe(List.of(TILTAKSHENDELSER));
 
-        BrukereMedAntall response = opensearchService.hentBrukere(
+        BrukereMedAntall responseDefaultSortering = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
                 "ascending",
+                "ikke_satt",
+                filterValg,
+                null,
+                null
+        );
+        List<Bruker> brukereDefaultRekkefolge = responseDefaultSortering.getBrukere();
+
+        assertThat(responseDefaultSortering.getAntall()).isEqualTo(3);
+        assertThat(brukereDefaultRekkefolge.get(0).getFnr()).isEqualTo(bruker3Fnr.toString());
+        assertThat(brukereDefaultRekkefolge.get(1).getFnr()).isEqualTo(bruker2Fnr.toString());
+        assertThat(brukereDefaultRekkefolge.get(2).getFnr()).isEqualTo(bruker1Fnr.toString());
+
+
+        BrukereMedAntall responseEksplisittSortering = opensearchService.hentBrukere(
+                TEST_ENHET,
+                empty(),
+                "descending",
                 "tiltakshendelse_dato_opprettet",
                 filterValg,
                 null,
                 null
         );
-        List<Bruker> sorterteBrukere = response.getBrukere();
+        List<Bruker> brukereEksplisittSortert = responseEksplisittSortering.getBrukere();
 
-        assertThat(response.getAntall()).isEqualTo(3);
-        assertThat(sorterteBrukere.get(0).getFnr()).isEqualTo(bruker3Fnr.toString());
-        assertThat(sorterteBrukere.get(1).getFnr()).isEqualTo(bruker2Fnr.toString());
-        assertThat(sorterteBrukere.get(2).getFnr()).isEqualTo(bruker1Fnr.toString());
+        assertThat(responseEksplisittSortering.getAntall()).isEqualTo(3);
+        assertThat(brukereEksplisittSortert.get(0).getFnr()).isEqualTo(bruker1Fnr.toString());
+        assertThat(brukereEksplisittSortert.get(1).getFnr()).isEqualTo(bruker2Fnr.toString());
+        assertThat(brukereEksplisittSortert.get(2).getFnr()).isEqualTo(bruker3Fnr.toString());
     }
 
     @Test


### PR DESCRIPTION
## Describe your changes

- Default-sortering på opprettet-dato når ein har valgt "tiltakshendelser"-filteret
- Lagt til sortering for dato + lenketekst
- Oppdatert settings slik at OpenSearch veit kva format sorteringsfelta har (vi får ikkje lov å sortere tekst utan denne).

(Eg laga generell sortering på dato ved ein feil, og sidan vi skal ha det på sikt uansett lot eg vere å slette koden og la til sortering på lenketekst.)

## Trello ticket number and link
https://trello.com/c/gYOzlaPm/690-sortere-eldste-f%C3%B8rst-backend


## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics


## OBS:
**Hugs å køyre hovedindeksering med nytt alias i prod for at sorteringa på tiltakshendelse-tekst skal fungere.**