### PR TITLE
En sjekk på at person er under oppfølging hos oss før vi lagrer tiltakshendelse på person

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <java.version>21</java.version>
         <common.version>3.2024.10.25_13.44-9db48a0dbe67</common.version>
         <jaxb.version>2.3.1</jaxb.version>
-        <testcontainers.version>1.20.1</testcontainers.version>
+        <testcontainers.version>1.20.3</testcontainers.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.release>21</maven.compiler.release>


### PR DESCRIPTION
## Describe your changes
Fiks for tilfelle av at en person bytter ident, mens man har en tiltakshendelse i statusfilter på person. (F.eks fra d-nummer til fnr)

Ved tilfelle hvor en person med en "aktiv" tiltakshendelse bytter ident vil vi få en ny kafkamelding fra Komet med nytt fnr på eksisterende tiltakshendelse. P.t så håndterer vi ikke generelt bytte av ident. Så selv om tiltakshendelse vil "bli løst" er det da en risiko for at vi ender med å ha hendelser vi ikke får vist i statusfilteret. 

Inntil vi faktisk håndterer bytte av ident blir løsningen å kaste en exception. To forskjellige tiltak:  1. sjekker om person er under oppfølging og sjekker om tiltakshendeIsen vi allerede har lagret matcher fnr vi får inn på oppdatering av hendelsen. Dersom det blir kastet exception ved en av disse tilfellene må vi inn å manuelt gjøre endringer i tiltakshendelsetabellen.

## Trello ticket number and link
[#718](https://trello.com/c/IyqMLEBj/718-tiltakshendelse-h%C3%A5ndter-endring-i-fnr)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist before requesting a review
- [x] I have performed a self-review of my code

