### PR TITLE
Unngå å fylle DB med masse aktorId="-1" i dev dersom "fnr" ikkje er eit gyldig fødselsnummer

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/arenapakafka/ytelser/YtelsesService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arenapakafka/ytelser/YtelsesService.java
@@ -57,14 +57,14 @@ public class YtelsesService {
 
         AktorId aktorId = getAktorId(aktorClient, innhold.getFnr());
 
-        if(isDevelopment().orElse(false) && "-1".equals(aktorId.get())) {
+        if(isDevelopment().orElse(false) && Objects.equals(aktorId.get(), "-1")) {
             // TODO: Dette er en midlertidig fiks siden vi har et tilfelle der vi fyller YTELSESVEDTAK DB-tabellen med
             // masse "-1" verdier i AKTORID-kolonna. Grunnen til at dette skjer er fordi `getAktorId(...)`-metoden
             // returnerer "-1" dersom den får inn en verdi som ikke kvalifiserer som et gyldig fødselsnummer OG
             // vi er i dev-miljøet (i prod kastes exception).
             // Inntil videre ignorerer vi disse meldingene i dette scenariet til vi vet hva vi ønsker å gjøre med
             // disse fnr-ene som ikke er gyldige fødselsnummer.
-            // 07.11.2024 Sondre
+            // 2024-11-07, Sondre
 
             secureLog.warn("(Hendelse i dev-miljø) Fikk verdi \"-1\" når vi forsøkte å hente AktørID for fnr {}. Ignorerer melding.", innhold.getFnr());
             return;


### PR DESCRIPTION
## Describe your changes

Vi brukar ein metode `getAktorId(...)` for å mappe eit fødselsnummer til AktørID. I dev er logikken slik at denne metoden returnerer verdien `"-1"` dersom verdien den får inn ikkje er eit gyldig føselsnummer (`Fnr.ofValidFnr(...)`). 

Dette har ikkje vore eit problem før no, fordi vi plutseleg har begynt å få mange Kafka-meldingar med eit `fnr` som _ikkje_ er eit gyldig fødselsnummer. TL;DR: så har dette fylt opp `YTELSESVEDTAK`-tabellen i DB-en med masse `"-1"`-verdiar i `AKTORID`-kolonna. Dette blir progressivt verre etterkvart som vi får fleire og fleire rader med `"-1"`, sidan spørjinga får fleire og fleire rader å leite gjennom.

Vi løyser dette midlartidig ved å ignorere meldinga i dev dersom vi får AktørID = `"-1"`, inntil vi finn ut kva som er forventa oppførsel frå Arena i dev.

## Trello ticket number and link

n/a

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code