### PR TITLE
Stotte kafka consumer med key

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetService.java
@@ -9,7 +9,7 @@ import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.domene.Motedeltaker;
 import no.nav.pto.veilarbportefolje.domene.Moteplan;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerRepositoryV3;
 import no.nav.pto.veilarbportefolje.sisteendring.SisteEndringService;
@@ -25,7 +25,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class AktivitetService extends KafkaCommonConsumerService<KafkaAktivitetMelding> {
+public class AktivitetService extends KafkaCommonNonKeyedConsumerService<KafkaAktivitetMelding> {
     private final AktiviteterRepositoryV2 aktiviteterRepositoryV2;
     private final OppfolgingsbrukerRepositoryV3 oppfolgingsbrukerRepository;
     private final SisteEndringService sisteEndringService;

--- a/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/arbeidssoeker/v2/ArbeidssoekerService.kt
@@ -5,7 +5,7 @@ import no.nav.common.types.identer.AktorId
 import no.nav.common.types.identer.Fnr
 import no.nav.paw.arbeidssokerregisteret.api.v1.Periode
 import no.nav.pto.veilarbportefolje.config.FeatureToggle
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository
 import no.nav.pto.veilarbportefolje.util.SecureLog.secureLog
@@ -19,7 +19,7 @@ import no.nav.paw.arbeidssokerregisteret.api.v4.OpplysningerOmArbeidssoeker as O
 @Service
 class ArbeidssoekerPeriodeKafkaMeldingService(
     private val arbeidssoekerService: ArbeidssoekerService
-) : KafkaCommonConsumerService<Periode>() {
+) : KafkaCommonNonKeyedConsumerService<Periode>() {
     override fun behandleKafkaMeldingLogikk(kafkaMelding: Periode) {
         arbeidssoekerService.behandleKafkaMeldingLogikk(kafkaMelding)
     }
@@ -28,7 +28,7 @@ class ArbeidssoekerPeriodeKafkaMeldingService(
 @Service
 class ArbeidssoekerOpplysningerOmArbeidssoekerKafkaMeldingService(
     private val arbeidssoekerService: ArbeidssoekerService
-) : KafkaCommonConsumerService<OpplysningerOmArbeidssoekerKafkaMelding>() {
+) : KafkaCommonNonKeyedConsumerService<OpplysningerOmArbeidssoekerKafkaMelding>() {
     override fun behandleKafkaMeldingLogikk(kafkaMelding: OpplysningerOmArbeidssoekerKafkaMelding) {
         arbeidssoekerService.behandleKafkaMeldingLogikk(kafkaMelding)
     }
@@ -37,7 +37,7 @@ class ArbeidssoekerOpplysningerOmArbeidssoekerKafkaMeldingService(
 @Service
 class ArbeidssoekerProfileringKafkaMeldingService(
     private val arbeidssoekerService: ArbeidssoekerService
-) : KafkaCommonConsumerService<ProfileringKafkaMelding>() {
+) : KafkaCommonNonKeyedConsumerService<ProfileringKafkaMelding>() {
     override fun behandleKafkaMeldingLogikk(kafkaMelding: ProfileringKafkaMelding) {
         arbeidssoekerService.behandleKafkaMeldingLogikk(kafkaMelding)
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/cv/CVService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/cv/CVService.java
@@ -6,7 +6,7 @@ import no.nav.arbeid.cv.avro.Melding;
 import no.nav.arbeid.cv.avro.Meldingstype;
 import no.nav.common.types.identer.AktorId;
 import no.nav.pto.veilarbportefolje.cv.dto.CVMelding;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.stereotype.Service;
@@ -18,7 +18,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @RequiredArgsConstructor
 @Service
 @Slf4j
-public class CVService extends KafkaCommonConsumerService<Melding> {
+public class CVService extends KafkaCommonNonKeyedConsumerService<Melding> {
     private final OpensearchIndexerV2 opensearchIndexerV2;
     private final CVRepositoryV2 cvRepositoryV2;
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/dialog/DialogService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/dialog/DialogService.java
@@ -2,7 +2,7 @@ package no.nav.pto.veilarbportefolje.dialog;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +12,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class DialogService extends KafkaCommonConsumerService<Dialogdata> {
+public class DialogService extends KafkaCommonNonKeyedConsumerService<Dialogdata> {
     private final OpensearchIndexerV2 opensearchIndexerV2;
     private final DialogRepositoryV2 dialogRepositoryV2;
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereService.java
@@ -10,7 +10,7 @@ import no.nav.pto.veilarbportefolje.ensligforsorger.domain.Stønadstype;
 import no.nav.pto.veilarbportefolje.ensligforsorger.dto.input.VedtakOvergangsstønadArbeidsoppfølging;
 import no.nav.pto.veilarbportefolje.ensligforsorger.dto.output.EnsligeForsorgerOvergangsstønadTiltakDto;
 import no.nav.pto.veilarbportefolje.ensligforsorger.mapping.AktivitetsTypeTilAktivitetsplikt;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import org.springframework.stereotype.Service;
 
@@ -26,7 +26,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class EnsligeForsorgereService extends KafkaCommonConsumerService<VedtakOvergangsstønadArbeidsoppfølging> {
+public class EnsligeForsorgereService extends KafkaCommonNonKeyedConsumerService<VedtakOvergangsstønadArbeidsoppfølging> {
     private final OpensearchIndexerV2 opensearchIndexerV2;
     private final EnsligeForsorgereRepository ensligeForsorgereRepository;
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/IKafkaCommonConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/IKafkaCommonConsumerService.java
@@ -1,7 +1,0 @@
-package no.nav.pto.veilarbportefolje.kafka;
-
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-
-public interface IKafkaCommonConsumerService<T> {
-    void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding);
-}

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/IKafkaCommonConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/IKafkaCommonConsumerService.java
@@ -1,0 +1,7 @@
+package no.nav.pto.veilarbportefolje.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public interface IKafkaCommonConsumerService<T> {
+    void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding);
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonConsumerService.java
@@ -5,15 +5,15 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 
 public abstract class KafkaCommonConsumerService<T> {
-    abstract void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding);
+    abstract void behandleKafkaRecord(ConsumerRecord<String, T> kafkaRecord);
 
-    void loggKafkaMeldingInformasjon(ConsumerRecord<String, T> kafkaMelding) {
+    void loggKafkaRecordInformasjon(ConsumerRecord<String, T> kafkaRecord) {
         secureLog.info(
                 "Behandler kafka-melding med key: {} og offset: {}, og partition: {} på topic {}",
-                kafkaMelding.key(),
-                kafkaMelding.offset(),
-                kafkaMelding.partition(),
-                kafkaMelding.topic()
+                kafkaRecord.key(),
+                kafkaRecord.offset(),
+                kafkaRecord.partition(),
+                kafkaRecord.topic()
         );
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonConsumerService.java
@@ -1,0 +1,19 @@
+package no.nav.pto.veilarbportefolje.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
+
+public abstract class KafkaCommonConsumerService<T> {
+    abstract void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding);
+
+    void loggKafkaMeldingInformasjon(ConsumerRecord<String, T> kafkaMelding) {
+        secureLog.info(
+                "Behandler kafka-melding med key: {} og offset: {}, og partition: {} på topic {}",
+                kafkaMelding.key(),
+                kafkaMelding.offset(),
+                kafkaMelding.partition(),
+                kafkaMelding.topic()
+        );
+    }
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonConsumerService.java
@@ -6,7 +6,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 
 @Slf4j
-public abstract class KafkaCommonConsumerService<T> {
+public abstract class KafkaCommonConsumerService<T> implements IKafkaCommonConsumerService<T> {
     public void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding) {
         secureLog.info(
                 "Behandler kafka-melding med key: {} og offset: {}, og partition: {} på topic {}",

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonKeyedConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonKeyedConsumerService.java
@@ -1,0 +1,22 @@
+package no.nav.pto.veilarbportefolje.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
+
+public abstract class KafkaCommonKeyedConsumerService<T> implements IKafkaCommonConsumerService<T> {
+
+    @Override
+    public void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding) {
+        secureLog.info(
+                "Behandler kafka-melding med key: {} og offset: {}, og partition: {} på topic {}",
+                kafkaMelding.key(),
+                kafkaMelding.offset(),
+                kafkaMelding.partition(),
+                kafkaMelding.topic()
+        );
+        behandleKafkaMeldingLogikk(kafkaMelding.value(), kafkaMelding.key());
+    }
+
+    protected abstract void behandleKafkaMeldingLogikk(T kafkaMelding, String nokkel);
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonKeyedConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonKeyedConsumerService.java
@@ -2,8 +2,6 @@ package no.nav.pto.veilarbportefolje.kafka;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
-
 public abstract class KafkaCommonKeyedConsumerService<T> extends KafkaCommonConsumerService<T> {
 
     @Override

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonKeyedConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonKeyedConsumerService.java
@@ -5,10 +5,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 public abstract class KafkaCommonKeyedConsumerService<T> extends KafkaCommonConsumerService<T> {
 
     @Override
-    public void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding) {
-        loggKafkaMeldingInformasjon(kafkaMelding);
-        behandleKafkaMeldingLogikk(kafkaMelding.value(), kafkaMelding.key());
+    public void behandleKafkaRecord(ConsumerRecord<String, T> kafkaRecord) {
+        loggKafkaRecordInformasjon(kafkaRecord);
+        behandleKafkaRecordLogikk(kafkaRecord.value(), kafkaRecord.key());
     }
 
-    protected abstract void behandleKafkaMeldingLogikk(T kafkaMelding, String nokkel);
+    protected abstract void behandleKafkaRecordLogikk(T kafkaRecordValue, String kafkaKey);
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonKeyedConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonKeyedConsumerService.java
@@ -4,17 +4,11 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 
-public abstract class KafkaCommonKeyedConsumerService<T> implements IKafkaCommonConsumerService<T> {
+public abstract class KafkaCommonKeyedConsumerService<T> extends KafkaCommonConsumerService<T> {
 
     @Override
     public void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding) {
-        secureLog.info(
-                "Behandler kafka-melding med key: {} og offset: {}, og partition: {} på topic {}",
-                kafkaMelding.key(),
-                kafkaMelding.offset(),
-                kafkaMelding.partition(),
-                kafkaMelding.topic()
-        );
+        loggKafkaMeldingInformasjon(kafkaMelding);
         behandleKafkaMeldingLogikk(kafkaMelding.value(), kafkaMelding.key());
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonNonKeyedConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonNonKeyedConsumerService.java
@@ -5,6 +5,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 @Slf4j
 public abstract class KafkaCommonNonKeyedConsumerService<T> extends KafkaCommonConsumerService<T> {
+
+    @Override
     public void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding) {
         loggKafkaMeldingInformasjon(kafkaMelding);
         behandleKafkaMeldingLogikk(kafkaMelding.value());

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonNonKeyedConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonNonKeyedConsumerService.java
@@ -3,18 +3,10 @@ package no.nav.pto.veilarbportefolje.kafka;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
-
 @Slf4j
-public abstract class KafkaCommonNonKeyedConsumerService<T> implements IKafkaCommonConsumerService<T> {
+public abstract class KafkaCommonNonKeyedConsumerService<T> extends KafkaCommonConsumerService<T> {
     public void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding) {
-        secureLog.info(
-                "Behandler kafka-melding med key: {} og offset: {}, og partition: {} på topic {}",
-                kafkaMelding.key(),
-                kafkaMelding.offset(),
-                kafkaMelding.partition(),
-                kafkaMelding.topic()
-        );
+        loggKafkaMeldingInformasjon(kafkaMelding);
         behandleKafkaMeldingLogikk(kafkaMelding.value());
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonNonKeyedConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonNonKeyedConsumerService.java
@@ -7,10 +7,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 public abstract class KafkaCommonNonKeyedConsumerService<T> extends KafkaCommonConsumerService<T> {
 
     @Override
-    public void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding) {
-        loggKafkaMeldingInformasjon(kafkaMelding);
-        behandleKafkaMeldingLogikk(kafkaMelding.value());
+    public void behandleKafkaRecord(ConsumerRecord<String, T> kafkaRecord) {
+        loggKafkaRecordInformasjon(kafkaRecord);
+        behandleKafkaMeldingLogikk(kafkaRecord.value());
     }
 
-    protected abstract void behandleKafkaMeldingLogikk(T kafkaMelding);
+    protected abstract void behandleKafkaMeldingLogikk(T kafkaRecordValue);
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonNonKeyedConsumerService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaCommonNonKeyedConsumerService.java
@@ -6,7 +6,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 
 @Slf4j
-public abstract class KafkaCommonConsumerService<T> implements IKafkaCommonConsumerService<T> {
+public abstract class KafkaCommonNonKeyedConsumerService<T> implements IKafkaCommonConsumerService<T> {
     public void behandleKafkaRecord(ConsumerRecord<String, T> kafkaMelding) {
         secureLog.info(
                 "Behandler kafka-melding med key: {} og offset: {}, og partition: {} på topic {}",

--- a/src/main/java/no/nav/pto/veilarbportefolje/mal/MalService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/mal/MalService.java
@@ -2,14 +2,14 @@ package no.nav.pto.veilarbportefolje.mal;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.sisteendring.SisteEndringService;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class MalService extends KafkaCommonConsumerService<MalEndringKafkaDTO> {
+public class MalService extends KafkaCommonNonKeyedConsumerService<MalEndringKafkaDTO> {
 
     private final SisteEndringService sisteEndringService;
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/ManuellStatusService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/ManuellStatusService.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
 import no.nav.pto.veilarbportefolje.domene.BrukerOppdatertInformasjon;
 import no.nav.pto.veilarbportefolje.domene.ManuellBrukerStatus;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +15,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ManuellStatusService extends KafkaCommonConsumerService<ManuellStatusDTO> {
+public class ManuellStatusService extends KafkaCommonNonKeyedConsumerService<ManuellStatusDTO> {
     private final OppfolgingService oppfolgingService;
     private final OppfolgingRepositoryV2 oppfolgingRepositoryV2;
     private final OpensearchIndexerV2 opensearchIndexerV2;

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/NyForVeilederService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/NyForVeilederService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
 import no.nav.pto.veilarbportefolje.domene.BrukerOppdatertInformasjon;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +14,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class NyForVeilederService extends KafkaCommonConsumerService<NyForVeilederDTO> {
+public class NyForVeilederService extends KafkaCommonNonKeyedConsumerService<NyForVeilederDTO> {
     private final OppfolgingService oppfolgingService;
     private final OppfolgingRepositoryV2 oppfolgingRepositoryV2;
     private final OpensearchIndexerV2 opensearchIndexerV2;

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingPeriodeService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingPeriodeService.java
@@ -3,7 +3,7 @@ package no.nav.pto.veilarbportefolje.oppfolging;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto_schema.kafka.json.topic.SisteOppfolgingsperiodeV1;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +12,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class OppfolgingPeriodeService extends KafkaCommonConsumerService<SisteOppfolgingsperiodeV1> {
+public class OppfolgingPeriodeService extends KafkaCommonNonKeyedConsumerService<SisteOppfolgingsperiodeV1> {
     private final OppfolgingStartetService oppfolgingStartetService;
     private final OppfolgingAvsluttetService oppfolgingAvsluttetService;
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetService.java
@@ -10,7 +10,7 @@ import no.nav.pto.veilarbportefolje.config.FeatureToggle;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.fargekategori.FargekategoriService;
 import no.nav.pto.veilarbportefolje.huskelapp.HuskelappService;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository;
 import org.springframework.stereotype.Service;
@@ -23,7 +23,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class VeilederTilordnetService extends KafkaCommonConsumerService<VeilederTilordnetDTO> {
+public class VeilederTilordnetService extends KafkaCommonNonKeyedConsumerService<VeilederTilordnetDTO> {
     private final OppfolgingService oppfolgingService;
     private final OppfolgingRepositoryV2 oppfolgingRepositoryV2;
     private final ArbeidslisteService arbeidslisteService;

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerServiceV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolgingsbruker/OppfolgingsbrukerServiceV2.java
@@ -9,10 +9,9 @@ import no.nav.common.types.identer.Fnr;
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteService;
 import no.nav.pto.veilarbportefolje.client.VeilarbVeilederClient;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
-import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.fargekategori.FargekategoriService;
 import no.nav.pto.veilarbportefolje.huskelapp.HuskelappService;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository;
@@ -37,7 +36,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class OppfolgingsbrukerServiceV2 extends KafkaCommonConsumerService<EndringPaaOppfoelgingsBrukerV2> {
+public class OppfolgingsbrukerServiceV2 extends KafkaCommonNonKeyedConsumerService<EndringPaaOppfoelgingsBrukerV2> {
     private final OppfolgingsbrukerRepositoryV3 oppfolgingsbrukerRepositoryV3;
     private final BrukerServiceV2 brukerServiceV2;
     private final OpensearchIndexerV2 opensearchIndexerV2;

--- a/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlBrukerdataKafkaService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlBrukerdataKafkaService.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
 import no.nav.pto.veilarbportefolje.config.FeatureToggle;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlResponses.PdlDokument;
@@ -31,7 +31,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class PdlBrukerdataKafkaService extends KafkaCommonConsumerService<PdlDokument> {
+public class PdlBrukerdataKafkaService extends KafkaCommonNonKeyedConsumerService<PdlDokument> {
     private final PdlService pdlService;
 
     private final PdlIdentRepository pdlIdentRepository;

--- a/src/main/java/no/nav/pto/veilarbportefolje/siste14aVedtak/Siste14aVedtakService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/siste14aVedtak/Siste14aVedtakService.java
@@ -3,7 +3,7 @@ package no.nav.pto.veilarbportefolje.siste14aVedtak;
 import lombok.RequiredArgsConstructor;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository;
 import no.nav.pto.veilarbportefolje.persononinfo.domene.IdenterForBruker;
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class Siste14aVedtakService extends KafkaCommonConsumerService<Siste14aVedtakKafkaDto> {
+public class Siste14aVedtakService extends KafkaCommonNonKeyedConsumerService<Siste14aVedtakKafkaDto> {
 
     private final PdlIdentRepository pdlIdentRepository;
     private final Siste14aVedtakRepository siste14aVedtakRepository;

--- a/src/main/java/no/nav/pto/veilarbportefolje/sistelest/SistLestService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/sistelest/SistLestService.java
@@ -3,7 +3,7 @@ package no.nav.pto.veilarbportefolje.sistelest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.service.BrukerServiceV2;
 import no.nav.pto.veilarbportefolje.sisteendring.SisteEndringService;
 import org.springframework.stereotype.Service;
@@ -15,7 +15,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class SistLestService extends KafkaCommonConsumerService<SistLestKafkaMelding> {
+public class SistLestService extends KafkaCommonNonKeyedConsumerService<SistLestKafkaMelding> {
     private final BrukerServiceV2 brukerService;
     private final SisteEndringService sisteEndringService;
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/tiltakshendelse/TiltakshendelseService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/tiltakshendelse/TiltakshendelseService.java
@@ -3,7 +3,7 @@ package no.nav.pto.veilarbportefolje.tiltakshendelse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2;
 import no.nav.pto.veilarbportefolje.service.BrukerServiceV2;
 import no.nav.pto.veilarbportefolje.tiltakshendelse.domain.Tiltakshendelse;
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class TiltakshendelseService extends KafkaCommonConsumerService<KafkaTiltakshendelse> {
+public class TiltakshendelseService extends KafkaCommonNonKeyedConsumerService<KafkaTiltakshendelse> {
     private final TiltakshendelseRepository repository;
     private final BrukerServiceV2 brukerServiceV2;
     private final OpensearchIndexerV2 opensearchIndexerV2;

--- a/src/main/java/no/nav/pto/veilarbportefolje/vedtakstotte/Utkast14aStatusendringService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/vedtakstotte/Utkast14aStatusendringService.java
@@ -3,7 +3,7 @@ package no.nav.pto.veilarbportefolje.vedtakstotte;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
-import no.nav.pto.veilarbportefolje.kafka.KafkaCommonConsumerService;
+import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +12,7 @@ import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class Utkast14aStatusendringService extends KafkaCommonConsumerService<Kafka14aStatusendring> {
+public class Utkast14aStatusendringService extends KafkaCommonNonKeyedConsumerService<Kafka14aStatusendring> {
     private final Utkast14aStatusRepository utkast14aStatusRepository;
     private final OpensearchIndexer opensearchIndexer;
 


### PR DESCRIPTION
## Describe your changes

Legger til støtte for å kunne behandle Kafka-meldingar med eit ekstra parameter/argument; nemlig sjølve Kafka-keyen. 

Denne endringen skal brukast i ein separat branch (ifm. hendelsesfilter), men tenkte det var like greit å skilje ut ein eigen PR.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
