### PR TITLE
Hendelse filter backend opensearch

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Bruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Bruker.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
+import no.nav.pto.veilarbportefolje.hendelsesfilter.Hendelse;
 import no.nav.pto.veilarbportefolje.opensearch.domene.Endring;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OppfolgingsBruker;
 import no.nav.pto.veilarbportefolje.persononinfo.barnUnder18Aar.BarnUnder18AarData;
@@ -115,6 +116,7 @@ public class Bruker {
 
     TiltakshendelseForBruker tiltakshendelse;
     GjeldendeVedtak14a gjeldendeVedtak14a;
+    Hendelse utgattVarsel;
 
     public static Bruker of(OppfolgingsBruker bruker, boolean ufordelt, boolean erVedtakstottePilotPa) {
 
@@ -213,7 +215,8 @@ public class Bruker {
                 .setFargekategori(bruker.getFargekategori())
                 .setFargekategoriEnhetId(bruker.getFargekategori_enhetId())
                 .setTiltakshendelse(TiltakshendelseForBruker.of(bruker.getTiltakshendelse()))
-                .setGjeldendeVedtak14a(bruker.getGjeldendeVedtak14a());
+                .setGjeldendeVedtak14a(bruker.getGjeldendeVedtak14a())
+                .setUtgattVarsel(bruker.getUtgatt_varsel());
     }
 
     public void kalkulerNesteUtlopsdatoAvValgtAktivitetFornklet(List<String> aktiviteterForenklet) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Bruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Bruker.java
@@ -116,7 +116,7 @@ public class Bruker {
 
     TiltakshendelseForBruker tiltakshendelse;
     GjeldendeVedtak14a gjeldendeVedtak14a;
-    Hendelse utgattVarsel;
+    Hendelse.HendelseInnhold utgattVarsel;
 
     public static Bruker of(OppfolgingsBruker bruker, boolean ufordelt, boolean erVedtakstottePilotPa) {
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseModell.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseModell.kt
@@ -50,17 +50,26 @@ enum class Operasjon {
     OPPDATER
 }
 
-data class Hendelse(
+data class Hendelse @JsonCreator constructor(
+    @JsonProperty("id")
     val id: UUID,
+    @JsonProperty("personIdent")
     val personIdent: NorskIdent,
+    @JsonProperty("avsender")
     val avsender: String,
+    @JsonProperty("kategori")
     val kategori: Kategori,
+    @JsonProperty("hendelse")
     val hendelse: HendelseInnhold
 ) {
-    data class HendelseInnhold(
+    data class HendelseInnhold @JsonCreator constructor(
+        @JsonProperty("beskrivelse")
         val beskrivelse: String,
+        @JsonProperty("dato")
         val dato: ZonedDateTime,
+        @JsonProperty("lenke")
         val lenke: URL,
+        @JsonProperty("detaljer")
         val detaljer: String?
     )
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseService.kt
@@ -1,7 +1,9 @@
 package no.nav.pto.veilarbportefolje.hendelsesfilter
 
+import no.nav.common.types.identer.Fnr
 import no.nav.pto.veilarbportefolje.kafka.KafkaCommonKeyedConsumerService
 import no.nav.pto.veilarbportefolje.kafka.KafkaConfigCommon.Topic
+import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexerV2
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository
 import org.jetbrains.annotations.TestOnly
 import org.slf4j.Logger
@@ -23,7 +25,8 @@ import java.util.*
 @Service
 class HendelseService(
     @Autowired private val hendelseRepository: HendelseRepository,
-    @Autowired private val pdlIdentRepository: PdlIdentRepository
+    @Autowired private val pdlIdentRepository: PdlIdentRepository,
+    @Autowired private val opensearchIndexerV2: OpensearchIndexerV2
 ) : KafkaCommonKeyedConsumerService<HendelseRecordValue>() {
     private val logger: Logger = LoggerFactory.getLogger(HendelseService::class.java)
 
@@ -66,9 +69,17 @@ class HendelseService(
         try {
             hendelseRepository.insert(hendelse)
 
+            val eldsteHendelse = hendelseRepository.getEldste(hendelse.personIdent)
+            if (eldsteHendelse.id == hendelse.id) {
+                oppdaterUgattVarselForBrukerIOpenSearch(hendelse)
+            }
+
             logger.info("Hendelse med id ${hendelse.id} ble startet")
         } catch (ex: HendelseIdEksistererAlleredeException) {
             logger.info("Hendelse med ID ${hendelse.id} allerede startet. Ignorerer melding.")
+        } catch (ex: IngenHendelseForPersonException) {
+            // Not good - vi opprettet en hendelse men klarte ikke hente den igjen
+            // Kan ha vært en race-condition (eks. en annen pod slettet hendelsen vi nettopp opprettet 🤷‍♂️)
         }
     }
 
@@ -76,13 +87,21 @@ class HendelseService(
         try {
             hendelseRepository.update(hendelse)
 
+            val eldsteHendelse = hendelseRepository.getEldste(hendelse.personIdent)
+            if (eldsteHendelse.id == hendelse.id) {
+                oppdaterUgattVarselForBrukerIOpenSearch(hendelse)
+            }
+
             logger.info("Hendelse med id ${hendelse.id} ble oppdatert")
         } catch (ex: IngenHendelseMedIdException) {
             // 2024-12-02, Sondre:
             // Per no ignorer vi melding, då vi forventar å alltid få ei "START"-melding før ei eventuell "OPPDATER"- eller "STOPP"-melding.
-            // Dette går fint så lenge vi ikkje har skrudd på "compaction" på topicet. Dersom vi har "compaction" på er det ikkje gitt
+            // Dette går fint så lenge vi ikkje har skrudd på "compaction" på topic-et. Dersom vi har "compaction" på er det ikkje gitt
             // at vi berre kan ignorere, sidan vi då potensielt går glipp av hendelsar ved ein eventuell rewind på topic-et.
             logger.warn("Fikk hendelse med operasjon ${Operasjon.OPPDATER} og ID ${hendelse.id}, men ingen hendelse med denne ID-en finnes. Ignorerer melding.")
+        } catch (ex: IngenHendelseForPersonException) {
+            // Not good - vi oppdaterte en persistert hendelse men klarte ikke hente den igjen
+            // Kan ha vært en race-condition (dvs. en annen pod slettet hendelsen vi nettopp oppdaterte 🤷‍♂️)
         }
     }
 
@@ -90,13 +109,45 @@ class HendelseService(
         try {
             hendelseRepository.delete(hendelse.id)
 
+            val eldsteHendelse = hendelseRepository.getEldste(hendelse.personIdent)
+            oppdaterUgattVarselForBrukerIOpenSearch(eldsteHendelse)
+
             logger.info("Hendelse med id ${hendelse.id} ble stoppet")
         } catch (ex: IngenHendelseMedIdException) {
             // 2024-12-02, Sondre:
             // Per no ignorer vi melding, då vi forventar å alltid få ei "START"-melding før ei eventuell "OPPDATER"- eller "STOPP"-melding.
-            // Dette går fint så lenge vi ikkje har skrudd på "compaction" på topicet. Dersom vi har "compaction" på er det ikkje gitt
+            // Dette går fint så lenge vi ikkje har skrudd på "compaction" på topic-et. Dersom vi har "compaction" på er det ikkje gitt
             // at vi berre kan ignorere, sidan vi då potensielt går glipp av hendelsar ved ein eventuell rewind på topic-et.
             logger.warn("Fikk hendelse med operasjon ${Operasjon.STOPP} og ID ${hendelse.id}, men ingen hendelse med denne ID-en finnes. Ignorerer melding.")
+        } catch (ex: IngenHendelseForPersonException) {
+            // All good - det var ingen flere hendelser for personen etter at vi slettet den som kom inn som argument
+            slettUgattVarselForBrukerIOpenSearch(hendelse)
+        }
+    }
+
+    private fun oppdaterUgattVarselForBrukerIOpenSearch(hendelse: Hendelse) {
+        // 2024-11-29, Sondre
+        // Egentlig unødvendig if-sjekk så lenge kun Team DAB er på med "utgåtte varsel"
+        // Men har den med likevel for å tydeliggjøre at det er "utgått varsel"-feltet i OpenSearch
+        // som oppdateres her. Vi må huske å oppdatere håndtering etterhvert som denne tjenesten
+        // blir mer generalisert/får flere produsenter
+        if (Kategori.UTGATT_VARSEL == hendelse.kategori) {
+            // TODO: 2024-11-29, Sondre - Her konverterer vi bare ukritisk til Fnr, selv om NorskIdent også kan være f.eks. D-nummer
+            val aktorId = pdlIdentRepository.hentAktorIdForAktivBruker(Fnr.of(hendelse.personIdent.get()))
+            opensearchIndexerV2.oppdaterUtgattVarsel(hendelse, aktorId)
+        }
+    }
+
+    private fun slettUgattVarselForBrukerIOpenSearch(hendelse: Hendelse) {
+        // 2024-11-29, Sondre
+        // Egentlig unødvendig if-sjekk så lenge kun Team DAB er på med "utgåtte varsel"
+        // Men har den med likevel for å tydeliggjøre at det er "utgått varsel"-feltet i OpenSearch
+        // som oppdateres her. Vi må huske å oppdatere håndtering etterhvert som denne tjenesten
+        // blir mer generalisert/får flere produsenter
+        if (Kategori.UTGATT_VARSEL == hendelse.kategori) {
+            // TODO: 2024-11-29, Sondre - Her konverterer vi bare ukritisk til Fnr, selv om NorskIdent også kan være f.eks. D-nummer
+            val aktorId = pdlIdentRepository.hentAktorIdForAktivBruker(Fnr.of(hendelse.personIdent.get()))
+            opensearchIndexerV2.slettUtgattVarsel(aktorId)
         }
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseService.kt
@@ -84,7 +84,7 @@ class HendelseService(
         if (eldsteHendelse.id == hendelse.id) {
             oppdaterUgattVarselForBrukerIOpenSearch(hendelse)
 
-            logger.info("Hendelse med id ${hendelse.id} ble lagret i DB og OpenSearch ble oppdatert med ny eldste utgåtte varsel for person, med samme id.")
+            logger.info("Hendelse med id ${hendelse.id} ble lagret i DB og OpenSearch ble oppdatert med ny eldste utgåtte varsel for person.")
         } else {
             logger.info("Hendelse med id ${hendelse.id} ble lagret i DB")
         }
@@ -109,7 +109,7 @@ class HendelseService(
         val eldsteHendelse = hendelseRepository.getEldste(hendelse.personIdent)
         if (eldsteHendelse.id == hendelse.id) {
             oppdaterUgattVarselForBrukerIOpenSearch(hendelse)
-            logger.info("Hendelse med id ${hendelse.id} ble oppdatert i DB og OpenSearch ble oppdatert med ny eldste utgåtte varsel for person, med samme id.")
+            logger.info("Hendelse med id ${hendelse.id} ble oppdatert i DB og OpenSearch ble oppdatert med ny eldste utgåtte varsel for person.")
         } else {
             logger.info("Hendelse med id ${hendelse.id} ble oppdatert i DB")
         }

--- a/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseService.kt
@@ -128,6 +128,7 @@ class HendelseService(
             // Dette går fint så lenge vi ikkje har skrudd på "compaction" på topic-et. Dersom vi har "compaction" på er det ikkje gitt
             // at vi berre kan ignorere, sidan vi då potensielt går glipp av hendelsar ved ein eventuell rewind på topic-et.
             logger.warn("Fikk hendelse med operasjon ${Operasjon.STOPP} og ID ${hendelse.id}, men ingen hendelse med denne ID-en finnes. Ignorerer melding.")
+            return
         }
 
         val resultatAvGetEldsteHendelse = try {

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexer.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexer.java
@@ -126,6 +126,7 @@ public class OpensearchIndexer {
         postgresOpensearchMapper.flettInnBarnUnder18Aar(brukere);
         postgresOpensearchMapper.flettInnTiltakshendelser(brukere);
         postgresOpensearchMapper.flettInnSiste14aVedtak(brukere);
+        postgresOpensearchMapper.flettInnEldsteUtgattVarsel(brukere);
         if (FeatureToggle.brukNyttArbeidssoekerregister(defaultUnleash)) {
             postgresOpensearchMapper.flettInnOpplysningerOmArbeidssoekerData(brukere);
         }

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
@@ -396,16 +396,10 @@ public class OpensearchIndexerV2 {
         final XContentBuilder content = jsonBuilder()
                 .startObject()
                 .startObject("utgatt_varsel")
-                .field("id", hendelse.getId().toString())
-                .field("personIdent", hendelse.getPersonIdent().get())
-                .field("avsender", hendelse.getAvsender())
-                .field("kategori", hendelse.getKategori().name())
-                .startObject("hendelse")
                 .field("beskrivelse", hendelse.getHendelse().getBeskrivelse())
                 .field("dato", hendelse.getHendelse().getDato())
                 .field("lenke", hendelse.getHendelse().getLenke().toString())
                 .field("detaljer", hendelse.getHendelse().getDetaljer())
-                .endObject()
                 .endObject()
                 .endObject();
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
@@ -11,6 +11,7 @@ import no.nav.pto.veilarbportefolje.dialog.Dialogdata;
 import no.nav.pto.veilarbportefolje.domene.HuskelappForBruker;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.ensligforsorger.dto.output.EnsligeForsorgerOvergangsstønadTiltakDto;
+import no.nav.pto.veilarbportefolje.hendelsesfilter.Hendelse;
 import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingRepositoryV2;
 import no.nav.pto.veilarbportefolje.oppfolgingsbruker.OppfolgingsbrukerEntity;
 import no.nav.pto.veilarbportefolje.siste14aVedtak.GjeldendeVedtak14a;
@@ -388,6 +389,37 @@ public class OpensearchIndexerV2 {
                 .endObject();
 
         update(aktorId, content, format("Oppdaterte gjeldendeVedtak14a for aktorId: %s", aktorId.get()));
+    }
+
+    @SneakyThrows
+    public void oppdaterUtgattVarsel(Hendelse hendelse, AktorId aktorId) {
+        final XContentBuilder content = jsonBuilder()
+                .startObject()
+                .startObject("utgatt_varsel")
+                .field("id", hendelse.getId().toString())
+                .field("personIdent", hendelse.getPersonIdent().get())
+                .field("avsender", hendelse.getAvsender())
+                .field("kategori", hendelse.getKategori().name())
+                .startObject("hendelse")
+                .field("beskrivelse", hendelse.getHendelse().getBeskrivelse())
+                .field("dato", hendelse.getHendelse().getDato())
+                .field("lenke", hendelse.getHendelse().getLenke().toString())
+                .field("detaljer", hendelse.getHendelse().getDetaljer())
+                .endObject()
+                .endObject()
+                .endObject();
+
+        update(aktorId, content, format("Oppdaterte utgått varsel for aktorId: %s", aktorId.get()));
+    }
+
+    @SneakyThrows
+    public void slettUtgattVarsel(AktorId aktorId) {
+        final XContentBuilder content = jsonBuilder()
+                .startObject()
+                .nullField("utgatt_varsel")
+                .endObject();
+
+        update(aktorId, content, format("Slettet utgått varsel for aktorId: %s", aktorId.get()));
     }
 
     private void update(AktorId aktoerId, XContentBuilder content, String logInfo) throws IOException {

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/OppfolgingsBruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/OppfolgingsBruker.java
@@ -5,6 +5,7 @@ import lombok.experimental.Accessors;
 import no.nav.pto.veilarbportefolje.domene.EnsligeForsorgereOvergangsstonad;
 import no.nav.pto.veilarbportefolje.domene.HuskelappForBruker;
 import no.nav.pto.veilarbportefolje.domene.Statsborgerskap;
+import no.nav.pto.veilarbportefolje.hendelsesfilter.Hendelse;
 import no.nav.pto.veilarbportefolje.persononinfo.barnUnder18Aar.BarnUnder18AarData;
 import no.nav.pto.veilarbportefolje.siste14aVedtak.Avvik14aVedtak;
 import no.nav.pto.veilarbportefolje.siste14aVedtak.GjeldendeVedtak14a;
@@ -134,4 +135,5 @@ public class OppfolgingsBruker {
     Tiltakshendelse tiltakshendelse;
 
     GjeldendeVedtak14a gjeldendeVedtak14a;
+    Hendelse utgatt_varsel;
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/OppfolgingsBruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/domene/OppfolgingsBruker.java
@@ -135,5 +135,5 @@ public class OppfolgingsBruker {
     Tiltakshendelse tiltakshendelse;
 
     GjeldendeVedtak14a gjeldendeVedtak14a;
-    Hendelse utgatt_varsel;
+    Hendelse.HendelseInnhold utgatt_varsel;
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
@@ -250,7 +250,7 @@ public class PostgresOpensearchMapper {
         brukere.forEach(bruker -> {
             try {
                 Hendelse eldsteHendelsePaPerson = hendelseRepository.getEldste(NorskIdent.of(bruker.getFnr()));
-                bruker.setUtgatt_varsel(eldsteHendelsePaPerson);
+                bruker.setUtgatt_varsel(eldsteHendelsePaPerson.getHendelse());
             } catch (IngenHendelseForPersonException ex) {
                 log.info("Fant ingen hendelse/utgått varsel for person, så ingen data å flette inn.");
             }

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
@@ -4,11 +4,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.common.types.identer.NorskIdent;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.*;
 import no.nav.pto.veilarbportefolje.domene.GjeldendeIdenter;
 import no.nav.pto.veilarbportefolje.domene.Statsborgerskap;
 import no.nav.pto.veilarbportefolje.ensligforsorger.EnsligeForsorgereService;
 import no.nav.pto.veilarbportefolje.ensligforsorger.dto.output.EnsligeForsorgerOvergangsstønadTiltakDto;
+import no.nav.pto.veilarbportefolje.hendelsesfilter.Hendelse;
+import no.nav.pto.veilarbportefolje.hendelsesfilter.HendelseRepository;
+import no.nav.pto.veilarbportefolje.hendelsesfilter.IngenHendelseForPersonException;
 import no.nav.pto.veilarbportefolje.kodeverk.KodeverkService;
 import no.nav.pto.veilarbportefolje.opensearch.domene.Endring;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OppfolgingsBruker;
@@ -47,6 +51,7 @@ public class PostgresOpensearchMapper {
     private final ArbeidssoekerService arbeidssoekerService;
     private final TiltakshendelseRepository tiltakshendelseRepository;
     private final Siste14aVedtakRepository siste14aVedtakRepository;
+    private final HendelseRepository hendelseRepository;
 
     public void flettInnAktivitetsData(List<OppfolgingsBruker> brukere) {
         List<AktorId> aktoerIder = brukere.stream().map(OppfolgingsBruker::getAktoer_id).map(AktorId::of).toList();
@@ -238,6 +243,18 @@ public class PostgresOpensearchMapper {
                     siste14aVedtakForBruker.getHovedmal(),
                     siste14aVedtakForBruker.getFattetDato()
             )).orElse(null));
+        });
+    }
+
+    public void flettInnEldsteUtgattVarsel(List<OppfolgingsBruker> brukere) {
+        brukere.forEach(bruker -> {
+            try {
+                Hendelse eldsteHendelsePaPerson = hendelseRepository.getEldste(NorskIdent.of(bruker.getFnr()));
+                bruker.setUtgatt_varsel(eldsteHendelsePaPerson);
+            } catch (IngenHendelseForPersonException ex) {
+                log.info("Fant ingen hendelse/utgått varsel for person, så ingen data å flette inn.");
+                // Ingen hendelse for bruker = ingenting å flette inn
+            }
         });
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/PostgresOpensearchMapper.java
@@ -253,7 +253,6 @@ public class PostgresOpensearchMapper {
                 bruker.setUtgatt_varsel(eldsteHendelsePaPerson);
             } catch (IngenHendelseForPersonException ex) {
                 log.info("Fant ingen hendelse/utgått varsel for person, så ingen data å flette inn.");
-                // Ingen hendelse for bruker = ingenting å flette inn
             }
         });
     }

--- a/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseIntegrationTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseIntegrationTest.kt
@@ -1,6 +1,7 @@
 package no.nav.pto.veilarbportefolje.hendelsesfilter
 
 import no.nav.common.types.identer.NorskIdent
+import no.nav.pto.veilarbportefolje.database.PostgresTable.HENDELSE
 import no.nav.pto.veilarbportefolje.domene.Bruker
 import no.nav.pto.veilarbportefolje.domene.Filtervalg
 import no.nav.pto.veilarbportefolje.domene.Sorteringsfelt
@@ -11,15 +12,28 @@ import no.nav.pto.veilarbportefolje.util.TestDataUtils.randomAktorId
 import no.nav.pto.veilarbportefolje.util.TestDataUtils.randomFnr
 import no.nav.pto.veilarbportefolje.util.TestDataUtils.randomNavKontor
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
 import java.util.*
 
 class HendelseIntegrationTest(
     @Autowired private val opensearchService: OpensearchService,
     @Autowired private val hendelseService: HendelseService,
-    @Autowired private val hendelseRepository: HendelseRepository
+    @Autowired private val hendelseRepository: HendelseRepository,
+    @Autowired private val jdbcTemplate: JdbcTemplate
 ) : EndToEndTest() {
+
+    @BeforeEach
+    fun reset() {
+        jdbcTemplate.update("TRUNCATE aktiviteter")
+        jdbcTemplate.update("TRUNCATE oppfolgingsbruker_arena_v2")
+        jdbcTemplate.update("TRUNCATE bruker_identer")
+        jdbcTemplate.update("TRUNCATE oppfolging_data")
+        jdbcTemplate.update("TRUNCATE nom_skjerming")
+        jdbcTemplate.update("TRUNCATE TABLE ${HENDELSE.TABLE_NAME}")
+    }
 
     @Test
     fun `skal oppdatere data om utgått varsel på bruker i OpenSearch ved indeksering når vi har hendelse-data for bruker`() {

--- a/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseIntegrationTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseIntegrationTest.kt
@@ -1,0 +1,84 @@
+package no.nav.pto.veilarbportefolje.hendelsesfilter
+
+import no.nav.common.types.identer.NorskIdent
+import no.nav.pto.veilarbportefolje.domene.Bruker
+import no.nav.pto.veilarbportefolje.domene.Filtervalg
+import no.nav.pto.veilarbportefolje.domene.Sorteringsfelt
+import no.nav.pto.veilarbportefolje.opensearch.OpensearchService
+import no.nav.pto.veilarbportefolje.util.EndToEndTest
+import no.nav.pto.veilarbportefolje.util.OpensearchTestClient.pollOpensearchUntil
+import no.nav.pto.veilarbportefolje.util.TestDataUtils.randomAktorId
+import no.nav.pto.veilarbportefolje.util.TestDataUtils.randomFnr
+import no.nav.pto.veilarbportefolje.util.TestDataUtils.randomNavKontor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.*
+
+class HendelseIntegrationTest(
+    @Autowired private val opensearchService: OpensearchService,
+    @Autowired private val hendelseService: HendelseService,
+    @Autowired private val hendelseRepository: HendelseRepository
+) : EndToEndTest() {
+
+    @Test
+    fun `skal oppdatere data om utgått varsel på bruker i OpenSearch ved indeksering når vi har hendelse-data for bruker`() {
+        // Given
+        val brukerAktorId = randomAktorId()
+        val brukerFnr = randomFnr()
+        val brukerNorskIdent = NorskIdent.of(brukerFnr.get())
+        val brukerOppfolgingsEnhet = randomNavKontor()
+        val hendelse = genererRandomHendelse(personIdent = brukerNorskIdent)
+        testDataClient.lagreBrukerUnderOppfolging(brukerAktorId, brukerFnr, brukerOppfolgingsEnhet.value, null)
+        hendelseRepository.insert(hendelse)
+
+        // When
+        opensearchIndexer.indekser(brukerAktorId)
+
+        // Then
+        pollOpensearchUntil { opensearchTestClient.countDocuments() == 1 }
+        val brukerFraRespons: Bruker = opensearchService.hentBrukere(
+            brukerOppfolgingsEnhet.value,
+            Optional.empty(),
+            "asc",
+            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Filtervalg().setFerdigfilterListe(emptyList()),
+            null,
+            null
+        ).brukere.first()
+        assertThat(brukerFraRespons).isNotNull
+        assertThat(brukerFraRespons.utgattVarsel).isNotNull
+        assertThat(brukerFraRespons.utgattVarsel.avsender).isEqualTo(hendelse.avsender)
+        assertThat(brukerFraRespons.utgattVarsel.kategori).isEqualTo(hendelse.kategori)
+        assertThat(brukerFraRespons.utgattVarsel.personIdent).isEqualTo(hendelse.personIdent)
+        assertThat(brukerFraRespons.utgattVarsel.hendelse.beskrivelse).isEqualTo(hendelse.hendelse.beskrivelse)
+        assertThat(brukerFraRespons.utgattVarsel.hendelse.detaljer).isEqualTo(hendelse.hendelse.detaljer)
+        assertThat(brukerFraRespons.utgattVarsel.hendelse.lenke).isEqualTo(hendelse.hendelse.lenke)
+    }
+
+    @Test
+    fun `skal oppdatere data om utgått varsel på bruker i OpenSearch ved indeksering når vi ikke har hendelse-data for bruker`() {
+        // Given
+        val brukerAktorId = randomAktorId()
+        val brukerFnr = randomFnr()
+        val brukerOppfolgingsEnhet = randomNavKontor()
+        testDataClient.lagreBrukerUnderOppfolging(brukerAktorId, brukerFnr, brukerOppfolgingsEnhet.value, null)
+
+        // When
+        opensearchIndexer.indekser(brukerAktorId)
+
+        // Then
+        pollOpensearchUntil { opensearchTestClient.countDocuments() == 1 }
+        val brukerFraRespons: Bruker = opensearchService.hentBrukere(
+            brukerOppfolgingsEnhet.value,
+            Optional.empty(),
+            "asc",
+            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Filtervalg().setFerdigfilterListe(emptyList()),
+            null,
+            null
+        ).brukere.first()
+        assertThat(brukerFraRespons).isNotNull
+        assertThat(brukerFraRespons.utgattVarsel).isNull()
+    }
+}

--- a/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseIntegrationTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseIntegrationTest.kt
@@ -228,7 +228,7 @@ class HendelseIntegrationTest(
     }
 
     @Test
-    fun `dersom ny hendelse med operasjon=START er eldre enn allerede lagret hendelse, skal ny hendelse overskrive utgått varsel i OpenSearch for bruker`() {
+    fun `dersom ny hendelse med operasjon=START har eldst hendelse-dato, skal ny hendelse overskrive utgått varsel i OpenSearch for bruker`() {
         // Given
         val brukerAktorId = randomAktorId()
         val brukerFnr = randomFnr()
@@ -279,7 +279,7 @@ class HendelseIntegrationTest(
     }
 
     @Test
-    fun `dersom ny hendelse med operasjon=STOPP var den eldste lagrede hendelsen, skal utgått varsel i OpenSearch for bruker oppdateres med det som nå er ny eldste hendelse`() {
+    fun `dersom ny hendelse med operasjon=STOPP har eldst hendelse-dato, skal utgått varsel i OpenSearch for bruker oppdateres hendelsen som har nest eldst hendelse-dato`() {
         // Given
         val brukerAktorId = randomAktorId()
         val brukerFnr = randomFnr()

--- a/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseIntegrationTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseIntegrationTest.kt
@@ -62,13 +62,9 @@ class HendelseIntegrationTest(
         ).brukere.first()
         assertThat(brukerFraRespons).isNotNull
         assertThat(brukerFraRespons.utgattVarsel).isNotNull
-        assertThat(brukerFraRespons.utgattVarsel.id).isEqualTo(hendelse.id)
-        assertThat(brukerFraRespons.utgattVarsel.avsender).isEqualTo(hendelse.avsender)
-        assertThat(brukerFraRespons.utgattVarsel.kategori).isEqualTo(hendelse.kategori)
-        assertThat(brukerFraRespons.utgattVarsel.personIdent).isEqualTo(hendelse.personIdent)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.beskrivelse).isEqualTo(hendelse.hendelse.beskrivelse)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.detaljer).isEqualTo(hendelse.hendelse.detaljer)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.lenke).isEqualTo(hendelse.hendelse.lenke)
+        assertThat(brukerFraRespons.utgattVarsel.beskrivelse).isEqualTo(hendelse.hendelse.beskrivelse)
+        assertThat(brukerFraRespons.utgattVarsel.detaljer).isEqualTo(hendelse.hendelse.detaljer)
+        assertThat(brukerFraRespons.utgattVarsel.lenke).isEqualTo(hendelse.hendelse.lenke)
     }
 
     @Test
@@ -128,14 +124,10 @@ class HendelseIntegrationTest(
         ).brukere.first()
         assertThat(brukerFraRespons).isNotNull
         assertThat(brukerFraRespons.utgattVarsel).isNotNull
-        val forventetHendelse = toHendelse(hendelseRecordValue, hendelseId)
-        assertThat(brukerFraRespons.utgattVarsel.id).isEqualTo(forventetHendelse.id)
-        assertThat(brukerFraRespons.utgattVarsel.avsender).isEqualTo(forventetHendelse.avsender)
-        assertThat(brukerFraRespons.utgattVarsel.kategori).isEqualTo(forventetHendelse.kategori)
-        assertThat(brukerFraRespons.utgattVarsel.personIdent).isEqualTo(forventetHendelse.personIdent)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.beskrivelse).isEqualTo(forventetHendelse.hendelse.beskrivelse)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.detaljer).isEqualTo(forventetHendelse.hendelse.detaljer)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.lenke).isEqualTo(forventetHendelse.hendelse.lenke)
+        val forventetHendelseInnhold = toHendelse(hendelseRecordValue, hendelseId).hendelse
+        assertThat(brukerFraRespons.utgattVarsel.beskrivelse).isEqualTo(forventetHendelseInnhold.beskrivelse)
+        assertThat(brukerFraRespons.utgattVarsel.detaljer).isEqualTo(forventetHendelseInnhold.detaljer)
+        assertThat(brukerFraRespons.utgattVarsel.lenke).isEqualTo(forventetHendelseInnhold.lenke)
     }
 
     @Test
@@ -178,14 +170,10 @@ class HendelseIntegrationTest(
         ).brukere.first()
         assertThat(brukerFraRespons).isNotNull
         assertThat(brukerFraRespons.utgattVarsel).isNotNull
-        val forventetHendelse = toHendelse(oppdatertHendelseRecordValue, hendelseId)
-        assertThat(brukerFraRespons.utgattVarsel.id).isEqualTo(forventetHendelse.id)
-        assertThat(brukerFraRespons.utgattVarsel.avsender).isEqualTo(forventetHendelse.avsender)
-        assertThat(brukerFraRespons.utgattVarsel.kategori).isEqualTo(forventetHendelse.kategori)
-        assertThat(brukerFraRespons.utgattVarsel.personIdent).isEqualTo(forventetHendelse.personIdent)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.beskrivelse).isEqualTo(forventetHendelse.hendelse.beskrivelse)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.detaljer).isEqualTo(forventetHendelse.hendelse.detaljer)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.lenke).isEqualTo(forventetHendelse.hendelse.lenke)
+        val forventetHendelseInnhold = toHendelse(oppdatertHendelseRecordValue, hendelseId).hendelse
+        assertThat(brukerFraRespons.utgattVarsel.beskrivelse).isEqualTo(forventetHendelseInnhold.beskrivelse)
+        assertThat(brukerFraRespons.utgattVarsel.detaljer).isEqualTo(forventetHendelseInnhold.detaljer)
+        assertThat(brukerFraRespons.utgattVarsel.lenke).isEqualTo(forventetHendelseInnhold.lenke)
     }
 
     @Test
@@ -268,14 +256,10 @@ class HendelseIntegrationTest(
         ).brukere.first()
         assertThat(brukerFraRespons).isNotNull
         assertThat(brukerFraRespons.utgattVarsel).isNotNull
-        val forventetHendelse = toHendelse(eldreHendelseRecordValue, eldreHendelseId)
-        assertThat(brukerFraRespons.utgattVarsel.id).isEqualTo(forventetHendelse.id)
-        assertThat(brukerFraRespons.utgattVarsel.avsender).isEqualTo(forventetHendelse.avsender)
-        assertThat(brukerFraRespons.utgattVarsel.kategori).isEqualTo(forventetHendelse.kategori)
-        assertThat(brukerFraRespons.utgattVarsel.personIdent).isEqualTo(forventetHendelse.personIdent)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.beskrivelse).isEqualTo(forventetHendelse.hendelse.beskrivelse)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.detaljer).isEqualTo(forventetHendelse.hendelse.detaljer)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.lenke).isEqualTo(forventetHendelse.hendelse.lenke)
+        val forventetHendelseInnhold = toHendelse(eldreHendelseRecordValue, eldreHendelseId).hendelse
+        assertThat(brukerFraRespons.utgattVarsel.beskrivelse).isEqualTo(forventetHendelseInnhold.beskrivelse)
+        assertThat(brukerFraRespons.utgattVarsel.detaljer).isEqualTo(forventetHendelseInnhold.detaljer)
+        assertThat(brukerFraRespons.utgattVarsel.lenke).isEqualTo(forventetHendelseInnhold.lenke)
     }
 
     @Test
@@ -323,13 +307,9 @@ class HendelseIntegrationTest(
         ).brukere.first()
         assertThat(brukerFraRespons).isNotNull
         assertThat(brukerFraRespons.utgattVarsel).isNotNull
-        val forventetHendelse = toHendelse(yngreHendelseRecordValue, yngreHendelseId)
-        assertThat(brukerFraRespons.utgattVarsel.id).isEqualTo(forventetHendelse.id)
-        assertThat(brukerFraRespons.utgattVarsel.avsender).isEqualTo(forventetHendelse.avsender)
-        assertThat(brukerFraRespons.utgattVarsel.kategori).isEqualTo(forventetHendelse.kategori)
-        assertThat(brukerFraRespons.utgattVarsel.personIdent).isEqualTo(forventetHendelse.personIdent)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.beskrivelse).isEqualTo(forventetHendelse.hendelse.beskrivelse)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.detaljer).isEqualTo(forventetHendelse.hendelse.detaljer)
-        assertThat(brukerFraRespons.utgattVarsel.hendelse.lenke).isEqualTo(forventetHendelse.hendelse.lenke)
+        val forventetHendelseInnhold = toHendelse(yngreHendelseRecordValue, yngreHendelseId).hendelse
+        assertThat(brukerFraRespons.utgattVarsel.beskrivelse).isEqualTo(forventetHendelseInnhold.beskrivelse)
+        assertThat(brukerFraRespons.utgattVarsel.detaljer).isEqualTo(forventetHendelseInnhold.detaljer)
+        assertThat(brukerFraRespons.utgattVarsel.lenke).isEqualTo(forventetHendelseInnhold.lenke)
     }
 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelsesfilterTestUtil.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelsesfilterTestUtil.kt
@@ -11,6 +11,20 @@ import java.time.ZonedDateTime
 import java.util.*
 import kotlin.random.Random
 
+// For å kunne kalle funksjonen fra Java uten å måtte sende inn argument
+fun genererRandomHendelse(): Hendelse {
+    return genererRandomHendelse(
+        UUID.randomUUID(),
+        randomNorskIdent(),
+        randomAvsender(),
+        randomKategori(),
+        randomBeskrivelse(),
+        randomZonedDate(),
+        randomUrl(),
+        randomDetaljer(),
+    )
+}
+
 fun genererRandomHendelse(
     id: UUID = UUID.randomUUID(),
     personIdent: NorskIdent = randomNorskIdent(),

--- a/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelsesfilterTestUtil.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelsesfilterTestUtil.kt
@@ -88,12 +88,12 @@ fun genererRandomHendelseConsumerRecord(
     )
 }
 
-private fun randomUrl(): URL =
+fun randomUrl(): URL =
     URI.create("https://veilarbpersonflate.intern.dev.nav.no/${Random.nextInt(until = 10)}").toURL()
 
-private fun randomBeskrivelse() = "Beskrivelse_${Random.nextInt(until = 10)}"
+fun randomBeskrivelse() = "Beskrivelse_${Random.nextInt(until = 10)}"
 
-private fun randomAvsender() = "Avsender_${Random.nextInt(until = 10)}"
+fun randomAvsender() = "Avsender_${Random.nextInt(until = 10)}"
 
 fun randomKategori(): Kategori {
     val kategoriValues = Kategori.entries

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -4930,7 +4930,13 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
 
         assertThat(respons.getAntall()).isEqualTo(1);
         assertThat(utgattVarsel).isNotNull();
-        assertThat(utgattVarsel).isEqualTo(oppfolgingsBruker.getUtgatt_varsel());
+        assertThat(utgattVarsel.getId()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getId());
+        assertThat(utgattVarsel.getAvsender()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getAvsender());
+        assertThat(utgattVarsel.getKategori()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getKategori());
+        assertThat(utgattVarsel.getPersonIdent()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getPersonIdent());
+        assertThat(utgattVarsel.getHendelse().getBeskrivelse()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getHendelse().getBeskrivelse());
+        assertThat(utgattVarsel.getHendelse().getDetaljer()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getHendelse().getDetaljer());
+        assertThat(utgattVarsel.getHendelse().getLenke()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getHendelse().getLenke());
     }
 
     private BrukereMedAntall sorterBrukerePaStandardsorteringenAktorid(OpensearchService osService) {

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -7,7 +7,6 @@ import no.nav.common.auth.context.UserRole;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.EnhetId;
 import no.nav.common.types.identer.Fnr;
-import no.nav.common.types.identer.NorskIdent;
 import no.nav.poao_tilgang.client.Decision;
 import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteDTO;
@@ -19,7 +18,6 @@ import no.nav.pto.veilarbportefolje.domene.*;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.fargekategori.FargekategoriVerdi;
 import no.nav.pto.veilarbportefolje.hendelsesfilter.Hendelse;
-import no.nav.pto.veilarbportefolje.hendelsesfilter.Kategori;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OpensearchResponse;
 import no.nav.pto.veilarbportefolje.opensearch.domene.OppfolgingsBruker;
 import no.nav.pto.veilarbportefolje.persononinfo.barnUnder18Aar.BarnUnder18AarData;
@@ -41,7 +39,6 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-import java.net.URI;
 import java.sql.Timestamp;
 import java.time.*;
 import java.util.*;
@@ -4911,7 +4908,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 .setOppfolging(true)
                 .setVeileder_id(TEST_VEILEDER_0)
                 .setEnhet_id(TEST_ENHET)
-                .setUtgatt_varsel(hendelse);
+                .setUtgatt_varsel(hendelse.getHendelse());
         skrivBrukereTilTestindeks(oppfolgingsBruker);
 
         pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == 1);
@@ -4926,17 +4923,13 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 null
         );
         Bruker bruker = respons.getBrukere().getFirst();
-        Hendelse utgattVarsel = bruker.getUtgattVarsel();
+        Hendelse.HendelseInnhold utgattVarsel = bruker.getUtgattVarsel();
 
         assertThat(respons.getAntall()).isEqualTo(1);
         assertThat(utgattVarsel).isNotNull();
-        assertThat(utgattVarsel.getId()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getId());
-        assertThat(utgattVarsel.getAvsender()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getAvsender());
-        assertThat(utgattVarsel.getKategori()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getKategori());
-        assertThat(utgattVarsel.getPersonIdent()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getPersonIdent());
-        assertThat(utgattVarsel.getHendelse().getBeskrivelse()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getHendelse().getBeskrivelse());
-        assertThat(utgattVarsel.getHendelse().getDetaljer()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getHendelse().getDetaljer());
-        assertThat(utgattVarsel.getHendelse().getLenke()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getHendelse().getLenke());
+        assertThat(utgattVarsel.getBeskrivelse()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getBeskrivelse());
+        assertThat(utgattVarsel.getDetaljer()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getDetaljer());
+        assertThat(utgattVarsel.getLenke()).isEqualTo(oppfolgingsBruker.getUtgatt_varsel().getLenke());
     }
 
     private BrukereMedAntall sorterBrukerePaStandardsorteringenAktorid(OpensearchService osService) {


### PR DESCRIPTION
## Describe your changes

Denne PR-en opprettar eit nytt felt i OpenSearch kalt "utgatt_varsel" og sikrar at vi oppdaterer dette med data vi har lagra ifm. nytt hendelsesfilter-topic, både ved enkelt-/hovedindeksering og ved behandling av meldingar.

Ein detalj som er verdt å merke seg er at vi kan ha lagra fleire hendelsar på brukaren, men det er berre den eldste av desse vi er interessert i ifm. indeksering.

_Støtte for filtrering og statustal kjem i eigen PR._

## Trello ticket number and link

[TC-819](https://trello.com/c/he5gyw8U/819-hendelsesfilter-for-utg%C3%A5tte-varsler)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
