### PR TITLE
Legg til sortering for Utgatt varsel-dato

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Sorteringsfelt.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Sorteringsfelt.java
@@ -91,6 +91,7 @@ public enum Sorteringsfelt {
 
     TILTAKSHENDELSE_TEKST("tiltakshendelse_tekst"),
     TILTAKSHENDELSE_DATO_OPPRETTET("tiltakshendelse_dato_opprettet"),
+
     UTGATT_VARSEL_DATO("filterhendelse_dato_opprettet");
 
     /** Filterverdien som vert sendt mellom frontend og backend */

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Sorteringsfelt.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Sorteringsfelt.java
@@ -90,7 +90,8 @@ public enum Sorteringsfelt {
     FARGEKATEGORI("fargekategori"),
 
     TILTAKSHENDELSE_TEKST("tiltakshendelse_tekst"),
-    TILTAKSHENDELSE_DATO_OPPRETTET("tiltakshendelse_dato_opprettet");
+    TILTAKSHENDELSE_DATO_OPPRETTET("tiltakshendelse_dato_opprettet"),
+    UTGATT_VARSEL_DATO("filterhendelse_dato_opprettet");
 
     /** Filterverdien som vert sendt mellom frontend og backend */
     public final String sorteringsverdi;

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -495,6 +495,7 @@ public class OpensearchQueryBuilder {
             case FARGEKATEGORI -> searchSourceBuilder.sort("fargekategori", order);
             case TILTAKSHENDELSE_DATO_OPPRETTET -> sorterTiltakshendelseOpprettetDato(searchSourceBuilder, order);
             case TILTAKSHENDELSE_TEKST -> searchSourceBuilder.sort("tiltakshendelse.tekst", order);
+            case UTGATT_VARSEL_DATO -> sorterUtgattVarselHendelseDato(searchSourceBuilder, order);
             default -> defaultSort(sorteringsfelt, searchSourceBuilder, order);
         }
         addSecondarySort(searchSourceBuilder);

--- a/src/main/java/no/nav/pto/veilarbportefolje/util/ValideringsRegler.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/util/ValideringsRegler.java
@@ -82,7 +82,8 @@ public class ValideringsRegler {
            FARGEKATEGORI.sorteringsverdi,
            UTDANNING_OG_SITUASJON_SIST_ENDRET.sorteringsverdi,
            TILTAKSHENDELSE_DATO_OPPRETTET.sorteringsverdi,
-           TILTAKSHENDELSE_TEKST.sorteringsverdi
+           TILTAKSHENDELSE_TEKST.sorteringsverdi,
+           UTGATT_VARSEL_DATO.sorteringsverdi
     );
 
     public static void sjekkEnhet(String enhet) {

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -332,7 +332,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 new Filtervalg(),
                 null,
@@ -370,7 +370,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 filtervalg,
                 null,
@@ -429,7 +429,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 filtervalg,
                 null,
@@ -474,7 +474,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 filtervalg,
                 null,
@@ -1113,15 +1113,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var liste = List.of(nyForEnhet, ikkeNyForEnhet);
         skrivBrukereTilTestindeks(liste);
 
-        pollOpensearchUntil(() -> opensearchService.hentBrukere(
-                TEST_ENHET,
-                Optional.empty(),
-                "asc",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
-                new Filtervalg().setFerdigfilterListe(List.of(Brukerstatus.TRENGER_VURDERING)),
-                null,
-                null
-        ).getAntall() == liste.size());
+        pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == liste.size());
 
         List<Brukerstatus> ferdigFiltere = List.of(
                 Brukerstatus.UFORDELTE_BRUKERE,
@@ -1131,7 +1123,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.empty(),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 new Filtervalg().setFerdigfilterListe(ferdigFiltere),
                 null,
@@ -1162,21 +1154,12 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var liste = List.of(brukerVeilederHarTilgangTil, brukerVeilederIkkeHarTilgangTil);
         skrivBrukereTilTestindeks(liste);
 
-        pollOpensearchUntil(() -> opensearchService.hentBrukere(
-                TEST_ENHET,
-                Optional.empty(),
-                "asc",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
-                new Filtervalg(),
-                null,
-                null
-        ).getAntall() == 1);
-
+        pollOpensearchUntil(() -> opensearchTestClient.countDocuments() == liste.size());
 
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(TEST_VEILEDER_0),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 new Filtervalg(),
                 null,
@@ -1215,7 +1198,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(LITE_PRIVILEGERT_VEILEDER),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 new Filtervalg().setFerdigfilterListe(List.of(Brukerstatus.UFORDELTE_BRUKERE)),
                 null,
@@ -1260,7 +1243,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(TEST_VEILEDER_0),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 filterValg,
                 null,
@@ -1302,7 +1285,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(TEST_VEILEDER_0),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 filterValg,
                 null,
@@ -1344,7 +1327,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(TEST_VEILEDER_0),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 filterValg,
                 null,
@@ -1409,7 +1392,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(TEST_VEILEDER_0),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 filterValg,
                 null,
@@ -1460,7 +1443,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 filterValg,
                 null,
@@ -1509,7 +1492,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 filterValg,
                 null,
@@ -1560,7 +1543,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 filterValg,
                 null,
@@ -1612,7 +1595,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 filterValg,
                 null,
@@ -5136,7 +5119,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         return osService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "asc",
+                "ikke_satt",
                 Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                 new Filtervalg().setFerdigfilterListe(emptyList()),
                 null,
@@ -5172,7 +5155,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 () -> opensearchService.hentBrukere(
                         TEST_ENHET,
                         empty(),
-                        "asc",
+                        "ikke_satt",
                         Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                         new Filtervalg(),
                         null,
@@ -5187,7 +5170,7 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 () -> opensearchService.hentBrukere(
                         TEST_ENHET,
                         Optional.of(veilederId),
-                        "asc",
+                        "ikke_satt",
                         Sorteringsfelt.IKKE_SATT.sorteringsverdi,
                         new Filtervalg(),
                         null,


### PR DESCRIPTION
## Describe your changes
- Legg til sortering på dato i utgåtte varsel-hendelsar.
- Bruker ein gyldig sorteringsverdi ("ikke_satt") i staden for ein ugyldig verdi ("asc") i testar der rekkefølgja ikkje speler nokon rolle.

Syster-PR: https://github.com/navikt/veilarbportefoljeflatefs/pull/1164


## Trello ticket number and link
https://trello.com/c/gK85yMHJ/835-sortering-p%C3%A5-kolonner-for-filterhendelse


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

