### PR TITLE
Opprydding/forbetring av logikk/validering/typing relatert til sorteringsfelt og -rekkefølge

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/EnhetController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/EnhetController.java
@@ -61,12 +61,12 @@ public class EnhetController {
             @RequestBody Filtervalg filtervalg) {
 
         ValideringsRegler.sjekkEnhet(enhet);
-        ValideringsRegler.sjekkSortering(sortDirection, sortField);
-        ValideringsRegler.sjekkFiltervalg(filtervalg);
+        Sorteringsrekkefolge validertSorteringsrekkefolge = ValideringsRegler.sjekkSorteringsrekkefolge(sortDirection);
+        Sorteringsfelt validertSorteringsfelt = ValideringsRegler.sjekkSorteringsfelt(sortField);
         authService.innloggetVeilederHarTilgangTilOppfolging();
         authService.innloggetVeilederHarTilgangTilEnhet(enhet);
 
-        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.empty(), sortDirection, sortField, filtervalg, fra, antall);
+        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.empty(), validertSorteringsrekkefolge, validertSorteringsfelt, filtervalg, fra, antall);
         List<Bruker> sensurerteBrukereSublist = authService.sensurerBrukere(brukereMedAntall.getBrukere());
 
         return PortefoljeUtils.buildPortefolje(brukereMedAntall.getAntall(),

--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
@@ -44,12 +44,12 @@ public class VeilederController {
 
         ValideringsRegler.sjekkVeilederIdent(veilederIdent, false);
         ValideringsRegler.sjekkEnhet(enhet);
-        ValideringsRegler.sjekkSortering(sortDirection, sortField);
-        ValideringsRegler.sjekkFiltervalg(filtervalg);
+        Sorteringsrekkefolge validertSorteringsrekkefolge = ValideringsRegler.sjekkSorteringsrekkefolge(sortDirection);
+        Sorteringsfelt validertSorteringsfelt = ValideringsRegler.sjekkSorteringsfelt(sortField);
         authService.innloggetVeilederHarTilgangTilOppfolging();
         authService.innloggetVeilederHarTilgangTilEnhet(enhet);
 
-        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.of(veilederIdent), sortDirection, sortField, filtervalg, fra, antall);
+        BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(enhet, Optional.of(veilederIdent), validertSorteringsrekkefolge, validertSorteringsfelt, filtervalg, fra, antall);
         List<Bruker> sensurerteBrukereSublist = authService.sensurerBrukere(brukereMedAntall.getBrukere());
 
         return PortefoljeUtils.buildPortefolje(brukereMedAntall.getAntall(),

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Sorteringsfelt.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Sorteringsfelt.java
@@ -101,13 +101,13 @@ public enum Sorteringsfelt {
         this.sorteringsverdi = sorteringsverdi;
     }
 
-    public static Sorteringsfelt nameFromValue(String value) {
+    public static Sorteringsfelt toSorteringsfelt(String sorteringsverdi) {
         for (Sorteringsfelt sorteringsfelt : values()) {
-            if (sorteringsfelt.sorteringsverdi.equals(value)) {
+            if (sorteringsfelt.sorteringsverdi.equals(sorteringsverdi)) {
                 return sorteringsfelt;
             }
         }
-        throw new IllegalArgumentException("Ugyldig verdi for enum: " + value );
+        throw new IllegalArgumentException("Ugyldig verdi for enum: " + sorteringsverdi);
     }
 
     @Override

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Sorteringsrekkefolge.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Sorteringsrekkefolge.java
@@ -1,0 +1,30 @@
+package no.nav.pto.veilarbportefolje.domene;
+
+public enum Sorteringsrekkefolge {
+    IKKE_SATT("ikke_satt"),
+    STIGENDE("ascending"),
+    SYNKENDE("descending");
+
+    /**
+     * Verdien som blir sendt mellom frontend og backend
+     */
+    public final String sorteringsverdi;
+
+    Sorteringsrekkefolge(String sorteringsverdi) {
+        this.sorteringsverdi = sorteringsverdi;
+    }
+
+    public static Sorteringsrekkefolge toSorteringsrekkefolge(String sorteringsverdi) {
+        for (Sorteringsrekkefolge sorteringsrekkefolge : values()) {
+            if (sorteringsrekkefolge.sorteringsverdi.equals(sorteringsverdi)) {
+                return sorteringsrekkefolge;
+            }
+        }
+        throw new IllegalArgumentException("Ugyldig verdi for enum: " + sorteringsverdi);
+    }
+
+    @Override
+    public String toString() {
+        return this.name() + " (" + this.sorteringsverdi + ")";
+    }
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -452,12 +452,14 @@ public class OpensearchQueryBuilder {
      * som er lov å sortere på i OpenSearch er det viktig at vi ikke legger til nye sorteringsfelter i {@link Sorteringsfelt}
      * uten å sørge for at disse også er tilgjengelige i {@link OppfolgingsBruker}.
      */
-    static SearchSourceBuilder sorterQueryParametere(String sortOrder, String
-            sortField, SearchSourceBuilder searchSourceBuilder, Filtervalg filtervalg, BrukerinnsynTilganger brukerinnsynTilganger) {
-        SortOrder order = "ascending".equals(sortOrder) ? SortOrder.ASC : SortOrder.DESC;
-
-        /* På sikt (tm) skal vi typesikre sortField slik at vi får Sorteringsfelt her, gjerne allereie på Controller-nivå. I denne omgangen lagar eg berre enumen for sorteringsfelta. 2024-11-28, Ingrid. */
-        Sorteringsfelt sorteringsfelt = Sorteringsfelt.nameFromValue(sortField);
+    static SearchSourceBuilder sorterQueryParametere(
+            Sorteringsrekkefolge sorteringsrekkefolge,
+            Sorteringsfelt sorteringsfelt,
+            SearchSourceBuilder searchSourceBuilder,
+            Filtervalg filtervalg,
+            BrukerinnsynTilganger brukerinnsynTilganger
+    ) {
+        SortOrder sorteringsrekkefolgeOpenSearch = Sorteringsrekkefolge.STIGENDE.equals(sorteringsrekkefolge) ? SortOrder.ASC : SortOrder.DESC;
 
         // Vi må assigne til en ny variabel for at kompilatoren sin exhaustiveness-check skal slå inn.
         // Dette er strengt tatt ikke nødvendig da vi bare kunne returnert searchSourceBuilder direkte, men da ville vi
@@ -468,150 +470,150 @@ public class OpensearchQueryBuilder {
                 yield searchSourceBuilder;
             }
             case VALGTE_AKTIVITETER -> {
-                sorterValgteAktiviteter(filtervalg, searchSourceBuilder, order);
+                sorterValgteAktiviteter(filtervalg, searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case MOTER_MED_NAV_IDAG -> {
-                searchSourceBuilder.sort("alle_aktiviteter_mote_startdato", order);
+                searchSourceBuilder.sort("alle_aktiviteter_mote_startdato", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case MOTESTATUS -> {
-                searchSourceBuilder.sort("aktivitet_mote_startdato", order);
+                searchSourceBuilder.sort("aktivitet_mote_startdato", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case I_AVTALT_AKTIVITET -> {
                 FieldSortBuilder builder = new FieldSortBuilder("aktivitet_utlopsdatoer")
-                        .order(order)
+                        .order(sorteringsrekkefolgeOpenSearch)
                         .sortMode(MIN);
                 searchSourceBuilder.sort(builder);
                 yield searchSourceBuilder;
             }
             case FODSELSNUMMER -> {
-                searchSourceBuilder.sort("fnr.raw", order);
+                searchSourceBuilder.sort("fnr.raw", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case UTLOPTE_AKTIVITETER -> {
-                searchSourceBuilder.sort("nyesteutlopteaktivitet", order);
+                searchSourceBuilder.sort("nyesteutlopteaktivitet", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case ARBEIDSLISTE_FRIST -> {
-                searchSourceBuilder.sort("arbeidsliste_frist", order);
+                searchSourceBuilder.sort("arbeidsliste_frist", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case AAP_TYPE -> {
-                searchSourceBuilder.sort("ytelse", order);
+                searchSourceBuilder.sort("ytelse", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case AAP_VURDERINGSFRIST -> {
-                sorterAapVurderingsfrist(searchSourceBuilder, order, filtervalg);
+                sorterAapVurderingsfrist(searchSourceBuilder, sorteringsrekkefolgeOpenSearch, filtervalg);
                 yield searchSourceBuilder;
             }
             case AAP_RETTIGHETSPERIODE -> {
-                sorterAapRettighetsPeriode(searchSourceBuilder, order);
+                sorterAapRettighetsPeriode(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case GJELDENDE_VEDTAK_14A_INNSATSGRUPPE -> {
-                searchSourceBuilder.sort("gjeldendeVedtak14a.innsatsgruppe", order);
+                searchSourceBuilder.sort("gjeldendeVedtak14a.innsatsgruppe", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case GJELDENDE_VEDTAK_14A_HOVEDMAL -> {
-                searchSourceBuilder.sort("gjeldendeVedtak14a.hovedmal", order);
+                searchSourceBuilder.sort("gjeldendeVedtak14a.hovedmal", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case GJELDENDE_VEDTAK_14A_VEDTAKSDATO -> {
-                sorterGjeldendeVedtak14aVedtaksdato(searchSourceBuilder, order);
+                sorterGjeldendeVedtak14aVedtaksdato(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case UTKAST_14A_STATUS -> {
-                searchSourceBuilder.sort("utkast_14a_status", order);
+                searchSourceBuilder.sort("utkast_14a_status", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case ARBEIDSLISTE_KATEGORI -> {
-                searchSourceBuilder.sort("arbeidsliste_kategori", order);
+                searchSourceBuilder.sort("arbeidsliste_kategori", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case SISTE_ENDRING_DATO -> {
-                sorterSisteEndringTidspunkt(searchSourceBuilder, order, filtervalg);
+                sorterSisteEndringTidspunkt(searchSourceBuilder, sorteringsrekkefolgeOpenSearch, filtervalg);
                 yield searchSourceBuilder;
             }
             case ARBEIDSLISTE_OVERSKRIFT -> {
-                sorterArbeidslisteOverskrift(searchSourceBuilder, order);
+                sorterArbeidslisteOverskrift(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case FODELAND -> {
-                sorterFodeland(searchSourceBuilder, order);
+                sorterFodeland(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case STATSBORGERSKAP -> {
-                sorterStatsborgerskap(searchSourceBuilder, order);
+                sorterStatsborgerskap(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case STATSBORGERSKAP_GYLDIG_FRA -> {
-                sorterStatsborgerskapGyldigFra(searchSourceBuilder, order);
+                sorterStatsborgerskapGyldigFra(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case TOLKESPRAK -> {
-                sorterTolkeSpraak(filtervalg, searchSourceBuilder, order);
+                sorterTolkeSpraak(filtervalg, searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case TOLKEBEHOV_SIST_OPPDATERT -> {
-                searchSourceBuilder.sort("tolkBehovSistOppdatert", order);
+                searchSourceBuilder.sort("tolkBehovSistOppdatert", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case ENSLIGE_FORSORGERE_UTLOP_YTELSE -> {
-                sorterEnsligeForsorgereUtlopsDato(searchSourceBuilder, order);
+                sorterEnsligeForsorgereUtlopsDato(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE -> {
-                sorterEnsligeForsorgereVedtaksPeriode(searchSourceBuilder, order);
+                sorterEnsligeForsorgereVedtaksPeriode(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case ENSLIGE_FORSORGERE_AKTIVITETSPLIKT -> {
-                sorterEnsligeForsorgereAktivitetsPlikt(searchSourceBuilder, order);
+                sorterEnsligeForsorgereAktivitetsPlikt(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case ENSLIGE_FORSORGERE_OM_BARNET -> {
-                sorterEnsligeForsorgereOmBarnet(searchSourceBuilder, order);
+                sorterEnsligeForsorgereOmBarnet(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case BARN_UNDER_18_AR -> {
-                sorterBarnUnder18(searchSourceBuilder, order, brukerinnsynTilganger, filtervalg);
+                sorterBarnUnder18(searchSourceBuilder, sorteringsrekkefolgeOpenSearch, brukerinnsynTilganger, filtervalg);
                 yield searchSourceBuilder;
             }
             case BRUKERS_SITUASJON_SIST_ENDRET -> {
-                searchSourceBuilder.sort("brukers_situasjon_sist_endret", order);
+                searchSourceBuilder.sort("brukers_situasjon_sist_endret", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case UTDANNING_OG_SITUASJON_SIST_ENDRET -> {
-                searchSourceBuilder.sort("utdanning_og_situasjon_sist_endret", order);
+                searchSourceBuilder.sort("utdanning_og_situasjon_sist_endret", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case HUSKELAPP_FRIST -> {
-                sorterHuskelappFrist(searchSourceBuilder, order);
+                sorterHuskelappFrist(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case HUSKELAPP -> {
-                sorterHuskelappEksistere(searchSourceBuilder, order);
+                sorterHuskelappEksistere(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case HUSKELAPP_KOMMENTAR -> {
-                searchSourceBuilder.sort("huskelapp.kommentar", order);
+                searchSourceBuilder.sort("huskelapp.kommentar", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case FARGEKATEGORI -> {
-                searchSourceBuilder.sort("fargekategori", order);
+                searchSourceBuilder.sort("fargekategori", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case TILTAKSHENDELSE_DATO_OPPRETTET -> {
-                sorterTiltakshendelseOpprettetDato(searchSourceBuilder, order);
+                sorterTiltakshendelseOpprettetDato(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case TILTAKSHENDELSE_TEKST -> {
-                searchSourceBuilder.sort("tiltakshendelse.tekst", order);
+                searchSourceBuilder.sort("tiltakshendelse.tekst", sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             case UTGATT_VARSEL_DATO -> {
-                sorterUtgattVarselHendelseDato(searchSourceBuilder, order);
+                sorterUtgattVarselHendelseDato(searchSourceBuilder, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
             // Vi har eksplisitt latt være å definere en "default" case i switch-en for å tvinge oss selv til å håndtere
@@ -621,7 +623,7 @@ public class OpensearchQueryBuilder {
                  FORRIGE_DATO_FOR_AVTALT_AKTIVITET, UTKAST_14A_STATUS_ENDRET, UTKAST_14A_ANSVARLIG_VEILEDER,
                  BOSTED_KOMMUNE, BOSTED_BYDEL, BOSTED_SIST_OPPDATERT, OPPFOLGING_STARTET, UTLOPSDATO, VEILEDER_IDENT,
                  DAGPENGER_UTLOP_UKE, DAGPENGER_PERM_UTLOP_UKE -> {
-                searchSourceBuilder.sort(sorteringsfelt.sorteringsverdi, order);
+                searchSourceBuilder.sort(sorteringsfelt.sorteringsverdi, sorteringsrekkefolgeOpenSearch);
                 yield searchSourceBuilder;
             }
         };

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchService.java
@@ -50,8 +50,8 @@ public class OpensearchService {
     public BrukereMedAntall hentBrukere(
             String enhetId,
             Optional<String> veilederIdent,
-            String sortOrder,
-            String sortField,
+            Sorteringsrekkefolge sorteringsrekkefolge,
+            Sorteringsfelt sorteringsfelt,
             Filtervalg filtervalg,
             Integer fra,
             Integer antall
@@ -102,7 +102,7 @@ public class OpensearchService {
             leggTilBrukerinnsynTilgangFilter(boolQuery, authService.hentVeilederBrukerInnsynTilganger(), BRUKERE_SOM_VEILEDER_HAR_INNSYNSRETT_PÅ);
         }
 
-        sorterQueryParametere(sortOrder, sortField, searchSourceBuilder, filtervalg, authService.hentVeilederBrukerInnsynTilganger());
+        sorterQueryParametere(sorteringsrekkefolge, sorteringsfelt, searchSourceBuilder, filtervalg, authService.hentVeilederBrukerInnsynTilganger());
 
         OpensearchResponse response = search(searchSourceBuilder, indexName.getValue(), OpensearchResponse.class);
         int totalHits = response.hits().getTotal().getValue();

--- a/src/main/java/no/nav/pto/veilarbportefolje/util/ValideringsRegler.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/util/ValideringsRegler.java
@@ -7,7 +7,8 @@ import no.nav.pto.veilarbportefolje.arbeidsliste.Arbeidsliste;
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteDTO;
 import no.nav.pto.veilarbportefolje.arbeidsliste.v1.ArbeidslisteRequest;
 import no.nav.pto.veilarbportefolje.arbeidsliste.v2.ArbeidslisteV2Request;
-import no.nav.pto.veilarbportefolje.domene.Filtervalg;
+import no.nav.pto.veilarbportefolje.domene.Sorteringsfelt;
+import no.nav.pto.veilarbportefolje.domene.Sorteringsrekkefolge;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -16,97 +17,36 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
 
 import static io.vavr.control.Validation.invalid;
 import static io.vavr.control.Validation.valid;
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
 import static no.nav.common.utils.StringUtils.nullOrEmpty;
-import static no.nav.pto.veilarbportefolje.domene.Sorteringsfelt.*;
 
 public class ValideringsRegler {
-    private static List<String> sortDirs = asList("ikke_satt", "ascending", "descending");
-    public static List<String> sortFields = asList(
-           IKKE_SATT.sorteringsverdi,
-           VALGTE_AKTIVITETER.sorteringsverdi,
-           ETTERNAVN.sorteringsverdi,
-           FODSELSNUMMER.sorteringsverdi,
-           UTLOPSDATO.sorteringsverdi,
-           DAGPENGER_UTLOP_UKE.sorteringsverdi,
-           DAGPENGER_PERM_UTLOP_UKE.sorteringsverdi,
-           AAP_TYPE.sorteringsverdi,
-           AAP_VURDERINGSFRIST.sorteringsverdi,
-           AAP_MAXTID_UKE.sorteringsverdi,
-           AAP_UNNTAK_UKER_IGJEN.sorteringsverdi,
-           ARBEIDSLISTE_FRIST.sorteringsverdi,
-           VENTER_PA_SVAR_FRA_NAV.sorteringsverdi,
-           VENTER_PA_SVAR_FRA_BRUKER.sorteringsverdi,
-           UTLOPTE_AKTIVITETER.sorteringsverdi,
-           STARTDATO_FOR_AVTALT_AKTIVITET.sorteringsverdi,
-           NESTE_STARTDATO_FOR_AVTALT_AKTIVITET.sorteringsverdi,
-           FORRIGE_DATO_FOR_AVTALT_AKTIVITET.sorteringsverdi,
-           I_AVTALT_AKTIVITET.sorteringsverdi,
-           AAP_RETTIGHETSPERIODE.sorteringsverdi,
-           MOTER_MED_NAV_IDAG.sorteringsverdi,
-           MOTESTATUS.sorteringsverdi,
-           OPPFOLGING_STARTET.sorteringsverdi,
-           VEILEDER_IDENT.sorteringsverdi,
-           GJELDENDE_VEDTAK_14A_INNSATSGRUPPE.sorteringsverdi,
-           GJELDENDE_VEDTAK_14A_HOVEDMAL.sorteringsverdi,
-           GJELDENDE_VEDTAK_14A_VEDTAKSDATO.sorteringsverdi,
-           UTKAST_14A_STATUS.sorteringsverdi,
-           UTKAST_14A_ANSVARLIG_VEILEDER.sorteringsverdi,
-           UTKAST_14A_STATUS_ENDRET.sorteringsverdi,
-           ARBEIDSLISTE_KATEGORI.sorteringsverdi,
-           ARBEIDSLISTE_OVERSKRIFT.sorteringsverdi,
-           SISTE_ENDRING_DATO.sorteringsverdi,
-           FODELAND.sorteringsverdi,
-           STATSBORGERSKAP.sorteringsverdi,
-           STATSBORGERSKAP_GYLDIG_FRA.sorteringsverdi,
-           TOLKESPRAK.sorteringsverdi,
-           TOLKEBEHOV_SIST_OPPDATERT.sorteringsverdi,
-           BOSTED_KOMMUNE.sorteringsverdi,
-           BOSTED_BYDEL.sorteringsverdi,
-           BOSTED_SIST_OPPDATERT.sorteringsverdi,
-           CV_SVARFRIST.sorteringsverdi,
-           ENSLIGE_FORSORGERE_UTLOP_YTELSE.sorteringsverdi,
-           ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE.sorteringsverdi,
-           ENSLIGE_FORSORGERE_AKTIVITETSPLIKT.sorteringsverdi,
-           ENSLIGE_FORSORGERE_OM_BARNET.sorteringsverdi,
-           BARN_UNDER_18_AR.sorteringsverdi,
-           BRUKERS_SITUASJON_SIST_ENDRET.sorteringsverdi,
-           HUSKELAPP_FRIST.sorteringsverdi,
-           HUSKELAPP_KOMMENTAR.sorteringsverdi,
-           HUSKELAPP.sorteringsverdi,
-           FARGEKATEGORI.sorteringsverdi,
-           UTDANNING_OG_SITUASJON_SIST_ENDRET.sorteringsverdi,
-           TILTAKSHENDELSE_DATO_OPPRETTET.sorteringsverdi,
-           TILTAKSHENDELSE_TEKST.sorteringsverdi,
-           UTGATT_VARSEL_DATO.sorteringsverdi
-    );
-
     public static void sjekkEnhet(String enhet) {
         test("enhet", enhet, enhet.matches("\\d{4}"));
     }
-
 
     public static void sjekkVeilederIdent(String veilederIdent, boolean optional) {
 
         test("veilederident", veilederIdent, optional || veilederIdent.matches("[A-Z]\\d{6}"));
     }
 
-    public static void sjekkFiltervalg(Filtervalg filtervalg) {
-        test("filtervalg", filtervalg, filtervalg::valider);
+    public static Sorteringsfelt sjekkSorteringsfelt(String sorteringsFelt) {
+        try {
+            return Sorteringsfelt.toSorteringsfelt(sorteringsFelt);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, format("%s er ikke et gyldig sorteringsfelt", sorteringsFelt));
+        }
     }
 
-    public static void sjekkSortering(String sortDirection, String sortField) {
-        test("sortDirection", sortDirection, sortDirs.contains(sortDirection));
-        test("sortField", sortField, sortFields.contains(sortField));
-    }
-
-    private static void test(String navn, Object data, Supplier<Boolean> matches) {
-        test(navn, data, matches.get());
+    public static Sorteringsrekkefolge sjekkSorteringsrekkefolge(String sorteringsRekkefolge) {
+        try {
+            return Sorteringsrekkefolge.toSorteringsrekkefolge(sorteringsRekkefolge);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, format("%s er ikke en gyldig sorteringsrekkefølge", sorteringsRekkefolge));
+        }
     }
 
     private static void test(String navn, Object data, boolean matches) {

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterOpensearchIntegrasjonTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterOpensearchIntegrasjonTest.java
@@ -80,8 +80,8 @@ public class AktiviteterOpensearchIntegrasjonTest extends EndToEndTest {
                     BrukereMedAntall responseBrukere = opensearchService.hentBrukere(
                             navKontor.getValue(),
                             empty(),
-                            "asc",
-                            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                            Sorteringsrekkefolge.STIGENDE,
+                            Sorteringsfelt.IKKE_SATT,
                             new Filtervalg().setFerdigfilterListe(List.of(I_AKTIVITET)),
                             null,
                             null);
@@ -114,8 +114,8 @@ public class AktiviteterOpensearchIntegrasjonTest extends EndToEndTest {
                     BrukereMedAntall responseBrukere = opensearchService.hentBrukere(
                             navKontor.getValue(),
                             empty(),
-                            "asc",
-                            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                            Sorteringsrekkefolge.STIGENDE,
+                            Sorteringsfelt.IKKE_SATT,
                             new Filtervalg().setNavnEllerFnrQuery(fodselsnummer.toString()).setFerdigfilterListe(new ArrayList<>()),
                             null,
                             null);
@@ -165,8 +165,8 @@ public class AktiviteterOpensearchIntegrasjonTest extends EndToEndTest {
             BrukereMedAntall responseBrukere = opensearchService.hentBrukere(
                     navKontor.getValue(),
                     empty(),
-                    "asc",
-                    Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                    Sorteringsrekkefolge.STIGENDE,
+                    Sorteringsfelt.IKKE_SATT,
                     new Filtervalg().setFerdigfilterListe(List.of(I_AKTIVITET)),
                     null,
                     null);
@@ -179,8 +179,8 @@ public class AktiviteterOpensearchIntegrasjonTest extends EndToEndTest {
         BrukereMedAntall responseBrukere = opensearchService.hentBrukere(
                 navKontor.getValue(),
                 empty(),
-                "asc",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg().setStillingFraNavFilter(List.of(StillingFraNAVFilter.CV_KAN_DELES_STATUS_JA)).setFerdigfilterListe(new ArrayList<>()),
                 null,
                 null);

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/LonnstilskuddUtAvArenaTest.java
@@ -184,8 +184,8 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                     BrukereMedAntall response1 = opensearchService.hentBrukere(
                             navKontor.getValue(),
                             empty(),
-                            "asc",
-                            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                            Sorteringsrekkefolge.STIGENDE,
+                            Sorteringsfelt.IKKE_SATT,
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
                             null);
@@ -195,8 +195,8 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                     BrukereMedAntall response2 = opensearchService.hentBrukere(
                             navKontor.getValue(),
                             empty(),
-                            "asc",
-                            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                            Sorteringsrekkefolge.STIGENDE,
+                            Sorteringsfelt.IKKE_SATT,
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
                             null);
@@ -291,8 +291,8 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                     BrukereMedAntall response1 = opensearchService.hentBrukere(
                             navKontor.getValue(),
                             empty(),
-                            "asc",
-                            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                            Sorteringsrekkefolge.STIGENDE,
+                            Sorteringsfelt.IKKE_SATT,
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
                             null);
@@ -302,8 +302,8 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                     BrukereMedAntall response2 = opensearchService.hentBrukere(
                             navKontor.getValue(),
                             empty(),
-                            "asc",
-                            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                            Sorteringsrekkefolge.STIGENDE,
+                            Sorteringsfelt.IKKE_SATT,
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
                             null);
@@ -343,8 +343,8 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                     BrukereMedAntall response1 = opensearchService.hentBrukere(
                             navKontor.getValue(),
                             empty(),
-                            "asc",
-                            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                            Sorteringsrekkefolge.STIGENDE,
+                            Sorteringsfelt.IKKE_SATT,
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
                             null);
@@ -642,8 +642,8 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                     BrukereMedAntall responseBrukereMIDLONTIL = opensearchService.hentBrukere(
                             navKontor.getValue(),
                             empty(),
-                            "asc",
-                            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                            Sorteringsrekkefolge.STIGENDE,
+                            Sorteringsfelt.IKKE_SATT,
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("MIDLONTIL")),
                             null,
                             null);
@@ -651,8 +651,8 @@ public class LonnstilskuddUtAvArenaTest extends EndToEndTest {
                     BrukereMedAntall responseBrukereLONNTILS = opensearchService.hentBrukere(
                             navKontor.getValue(),
                             empty(),
-                            "asc",
-                            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                            Sorteringsrekkefolge.STIGENDE,
+                            Sorteringsfelt.IKKE_SATT,
                             new Filtervalg().setFerdigfilterListe(List.of()).setTiltakstyper(List.of("VARLONTIL")),
                             null,
                             null);

--- a/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslistaSorteringOpensearchTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/arbeidsliste/ArbeidslistaSorteringOpensearchTest.java
@@ -2,10 +2,7 @@ package no.nav.pto.veilarbportefolje.arbeidsliste;
 
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
-import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
-import no.nav.pto.veilarbportefolje.domene.Brukerstatus;
-import no.nav.pto.veilarbportefolje.domene.Filtervalg;
-import no.nav.pto.veilarbportefolje.domene.Sorteringsfelt;
+import no.nav.pto.veilarbportefolje.domene.*;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService;
@@ -76,8 +73,8 @@ public class ArbeidslistaSorteringOpensearchTest extends EndToEndTest {
             final BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                     enhetId.getValue(),
                     empty(),
-                    "ascending",
-                    Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                    Sorteringsrekkefolge.STIGENDE,
+                    Sorteringsfelt.IKKE_SATT,
                     getArbeidslisteFilter(),
                     null,
                     null);
@@ -88,8 +85,8 @@ public class ArbeidslistaSorteringOpensearchTest extends EndToEndTest {
         var sortertResponsAscending = opensearchService.hentBrukere(
                 enhetId.getValue(),
                 empty(),
-                "ascending",
-                Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT,
                 getArbeidslisteFilter(),
                 null,
                 null);
@@ -97,8 +94,8 @@ public class ArbeidslistaSorteringOpensearchTest extends EndToEndTest {
         var sortertResponsDescending = opensearchService.hentBrukere(
                 enhetId.getValue(),
                 empty(),
-                "desc",
-                Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.ARBEIDSLISTE_OVERSKRIFT,
                 getArbeidslisteFilter(),
                 null,
                 null);

--- a/src/test/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereServiceTest.java
@@ -73,8 +73,8 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                     BrukereMedAntall responseBrukere = opensearchService.hentBrukere(
                             navKontor.toString(),
                             empty(),
-                            "asc",
-                            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                            Sorteringsrekkefolge.STIGENDE,
+                            Sorteringsfelt.IKKE_SATT,
                             filtervalg,
                             null,
                             null);
@@ -113,8 +113,8 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                     BrukereMedAntall responseBrukere = opensearchService.hentBrukere(
                             navKontor.toString(),
                             empty(),
-                            "asc",
-                            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                            Sorteringsrekkefolge.STIGENDE,
+                            Sorteringsfelt.IKKE_SATT,
                             filtervalg,
                             null,
                             null);
@@ -173,8 +173,8 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 navKontor.toString(),
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null

--- a/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseIntegrationTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseIntegrationTest.kt
@@ -5,6 +5,7 @@ import no.nav.pto.veilarbportefolje.database.PostgresTable.HENDELSE
 import no.nav.pto.veilarbportefolje.domene.Bruker
 import no.nav.pto.veilarbportefolje.domene.Filtervalg
 import no.nav.pto.veilarbportefolje.domene.Sorteringsfelt
+import no.nav.pto.veilarbportefolje.domene.Sorteringsrekkefolge
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchService
 import no.nav.pto.veilarbportefolje.util.EndToEndTest
 import no.nav.pto.veilarbportefolje.util.OpensearchTestClient.pollOpensearchUntil
@@ -54,8 +55,8 @@ class HendelseIntegrationTest(
         val brukerFraRespons: Bruker = opensearchService.hentBrukere(
             brukerOppfolgingsEnhet.value,
             Optional.empty(),
-            "asc",
-            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Sorteringsrekkefolge.STIGENDE,
+            Sorteringsfelt.IKKE_SATT,
             Filtervalg().setFerdigfilterListe(emptyList()),
             null,
             null
@@ -83,8 +84,8 @@ class HendelseIntegrationTest(
         val brukerFraRespons: Bruker = opensearchService.hentBrukere(
             brukerOppfolgingsEnhet.value,
             Optional.empty(),
-            "asc",
-            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Sorteringsrekkefolge.STIGENDE,
+            Sorteringsfelt.IKKE_SATT,
             Filtervalg().setFerdigfilterListe(emptyList()),
             null,
             null
@@ -116,8 +117,8 @@ class HendelseIntegrationTest(
         val brukerFraRespons: Bruker = opensearchService.hentBrukere(
             brukerOppfolgingsEnhet.value,
             Optional.empty(),
-            "asc",
-            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Sorteringsrekkefolge.STIGENDE,
+            Sorteringsfelt.IKKE_SATT,
             Filtervalg().setFerdigfilterListe(emptyList()),
             null,
             null
@@ -162,8 +163,8 @@ class HendelseIntegrationTest(
         val brukerFraRespons: Bruker = opensearchService.hentBrukere(
             brukerOppfolgingsEnhet.value,
             Optional.empty(),
-            "asc",
-            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Sorteringsrekkefolge.STIGENDE,
+            Sorteringsfelt.IKKE_SATT,
             Filtervalg().setFerdigfilterListe(emptyList()),
             null,
             null
@@ -205,8 +206,8 @@ class HendelseIntegrationTest(
         val brukerFraRespons: Bruker = opensearchService.hentBrukere(
             brukerOppfolgingsEnhet.value,
             Optional.empty(),
-            "asc",
-            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Sorteringsrekkefolge.STIGENDE,
+            Sorteringsfelt.IKKE_SATT,
             Filtervalg().setFerdigfilterListe(emptyList()),
             null,
             null
@@ -249,8 +250,8 @@ class HendelseIntegrationTest(
         val brukerFraRespons: Bruker = opensearchService.hentBrukere(
             brukerOppfolgingsEnhet.value,
             Optional.empty(),
-            "asc",
-            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Sorteringsrekkefolge.STIGENDE,
+            Sorteringsfelt.IKKE_SATT,
             Filtervalg().setFerdigfilterListe(emptyList()),
             null,
             null
@@ -301,8 +302,8 @@ class HendelseIntegrationTest(
         val brukerFraRespons: Bruker = opensearchService.hentBrukere(
             brukerOppfolgingsEnhet.value,
             Optional.empty(),
-            "asc",
-            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Sorteringsrekkefolge.STIGENDE,
+            Sorteringsfelt.IKKE_SATT,
             Filtervalg().setFerdigfilterListe(emptyList()),
             null,
             null
@@ -338,8 +339,8 @@ class HendelseIntegrationTest(
         val brukerFraRespons: Bruker = opensearchService.hentBrukere(
             brukerOppfolgingsEnhet.value,
             Optional.empty(),
-            "asc",
-            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Sorteringsrekkefolge.STIGENDE,
+            Sorteringsfelt.IKKE_SATT,
             Filtervalg().setFerdigfilterListe(emptyList()),
             null,
             null
@@ -384,8 +385,8 @@ class HendelseIntegrationTest(
         val brukerFraRespons: Bruker = opensearchService.hentBrukere(
             brukerOppfolgingsEnhet.value,
             Optional.empty(),
-            "asc",
-            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Sorteringsrekkefolge.STIGENDE,
+            Sorteringsfelt.IKKE_SATT,
             Filtervalg().setFerdigfilterListe(emptyList()),
             null,
             null
@@ -440,8 +441,8 @@ class HendelseIntegrationTest(
         val brukerFraRespons: Bruker = opensearchService.hentBrukere(
             brukerOppfolgingsEnhet.value,
             Optional.empty(),
-            "asc",
-            Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+            Sorteringsrekkefolge.STIGENDE,
+            Sorteringsfelt.IKKE_SATT,
             Filtervalg().setFerdigfilterListe(emptyList()),
             null,
             null

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilderTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilderTest.java
@@ -4,6 +4,7 @@ import no.nav.pto.veilarbportefolje.auth.BrukerinnsynTilganger;
 import no.nav.pto.veilarbportefolje.domene.AktivitetFiltervalg;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.Sorteringsfelt;
+import no.nav.pto.veilarbportefolje.domene.Sorteringsrekkefolge;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -14,15 +15,9 @@ import java.util.Map;
 
 import static no.nav.pto.veilarbportefolje.domene.AktivitetFiltervalg.JA;
 import static no.nav.pto.veilarbportefolje.domene.AktivitetFiltervalg.NEI;
-import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.byggAktivitetFilterQuery;
-import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.byggAlderQuery;
-import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.byggPortefoljestorrelserQuery;
-import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.byggVeilederPaaEnhetScript;
-import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.sorterQueryParametere;
-import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.sorterValgteAktiviteter;
+import static no.nav.pto.veilarbportefolje.opensearch.OpensearchQueryBuilder.*;
 import static no.nav.pto.veilarbportefolje.util.TestUtil.readFileAsJsonString;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.fail;
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
 import static org.opensearch.search.sort.SortOrder.ASC;
 
@@ -36,21 +31,9 @@ public class OpensearchQueryBuilderTest {
 
     @Test
     public void skal_sortere_etternavn_paa_etternavn_feltet() {
-        var searchSourceBuilder = sorterQueryParametere("asc", Sorteringsfelt.ETTERNAVN.sorteringsverdi, new SearchSourceBuilder(), new Filtervalg(), new BrukerinnsynTilganger(true, true, true));
+        var searchSourceBuilder = sorterQueryParametere(Sorteringsrekkefolge.STIGENDE, Sorteringsfelt.ETTERNAVN, new SearchSourceBuilder(), new Filtervalg(), new BrukerinnsynTilganger(true, true, true));
         var fieldName = searchSourceBuilder.sorts().get(0).toString();
         assertThat(fieldName).contains(Sorteringsfelt.ETTERNAVN.sorteringsverdi);
-    }
-
-    @Test
-    public void skal_ikke_sortere_pa_ugyldig_sorteringsverdi() {
-        String ugyldigSorteringsverdi = "Dette kommer sannsynligvis aldri til å bli en gyldig filterverdi";
-
-        try {
-            sorterQueryParametere("asc", ugyldigSorteringsverdi, new SearchSourceBuilder(), new Filtervalg(), new BrukerinnsynTilganger(true, true, true));
-            fail("Ugyldig input ble godtatt og brukt til sortering");
-        } catch (Exception e) {
-            assertThat(e).isNotNull();
-        }
     }
 
     @Test

--- a/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchServiceIntegrationTest.java
@@ -33,7 +33,6 @@ import no.nav.pto.veilarbportefolje.util.DateUtils;
 import no.nav.pto.veilarbportefolje.util.EndToEndTest;
 import no.nav.pto.veilarbportefolje.vedtakstotte.Hovedmal;
 import no.nav.pto.veilarbportefolje.vedtakstotte.Innsatsgruppe;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -333,8 +332,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg(),
                 null,
                 null
@@ -371,8 +370,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filtervalg,
                 null,
                 null
@@ -430,8 +429,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filtervalg,
                 null,
                 null);
@@ -475,8 +474,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filtervalg,
                 null,
                 null);
@@ -1000,8 +999,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.empty(),
-                "desc",
-                Sorteringsfelt.ARBEIDSLISTE_KATEGORI.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.ARBEIDSLISTE_KATEGORI,
                 new Filtervalg(),
                 null,
                 null
@@ -1060,8 +1059,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.empty(),
-                "desc",
-                Sorteringsfelt.VALGTE_AKTIVITETER.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.VALGTE_AKTIVITETER,
                 filtervalg1,
                 null,
                 null
@@ -1069,8 +1068,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall brukereMedAntall2 = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.empty(),
-                "desc",
-                Sorteringsfelt.VALGTE_AKTIVITETER.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.VALGTE_AKTIVITETER,
                 filtervalg2,
                 null,
                 null
@@ -1124,8 +1123,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg().setFerdigfilterListe(ferdigFiltere),
                 null,
                 null
@@ -1160,8 +1159,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(TEST_VEILEDER_0),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg(),
                 null,
                 null
@@ -1199,8 +1198,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(LITE_PRIVILEGERT_VEILEDER),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg().setFerdigfilterListe(List.of(Brukerstatus.UFORDELTE_BRUKERE)),
                 null,
                 null
@@ -1244,8 +1243,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(TEST_VEILEDER_0),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1286,8 +1285,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(TEST_VEILEDER_0),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1328,8 +1327,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(TEST_VEILEDER_0),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1393,8 +1392,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(TEST_VEILEDER_0),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1444,8 +1443,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1493,8 +1492,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1544,8 +1543,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1596,8 +1595,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1671,8 +1670,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.UTKAST_14A_ANSVARLIG_VEILEDER,
                 filterValg,
                 null,
                 null
@@ -1746,8 +1745,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1765,8 +1764,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1781,8 +1780,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1801,8 +1800,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1818,8 +1817,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1899,8 +1898,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1918,8 +1917,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1935,8 +1934,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -1951,8 +1950,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -2042,8 +2041,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.FODELAND.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.FODELAND,
                 filterValg,
                 null,
                 null
@@ -2060,8 +2059,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "descending",
-                Sorteringsfelt.FODELAND.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.FODELAND,
                 filterValg,
                 null,
                 null
@@ -2078,8 +2077,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.STATSBORGERSKAP.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.STATSBORGERSKAP,
                 filterValg,
                 null,
                 null
@@ -2154,8 +2153,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -2172,8 +2171,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -2189,8 +2188,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -2262,8 +2261,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.BOSTED_KOMMUNE.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.BOSTED_KOMMUNE,
                 filterValg,
                 null,
                 null
@@ -2279,8 +2278,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "descending",
-                Sorteringsfelt.BOSTED_BYDEL.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.BOSTED_BYDEL,
                 filterValg,
                 null,
                 null
@@ -2345,8 +2344,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -2408,8 +2407,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -2469,8 +2468,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -2518,8 +2517,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 Optional.of(TEST_VEILEDER_0),
-                "descending",
-                Sorteringsfelt.ETTERNAVN.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.ETTERNAVN,
                 filterValg,
                 null,
                 null
@@ -2566,8 +2565,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         var response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "descending",
-                Sorteringsfelt.ETTERNAVN.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.ETTERNAVN,
                 filterValg,
                 null,
                 null
@@ -2640,8 +2639,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOP_YTELSE.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.ENSLIGE_FORSORGERE_UTLOP_YTELSE,
                 filterValg,
                 null,
                 null
@@ -2657,8 +2656,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.ENSLIGE_FORSORGERE_OM_BARNET,
                 filterValg,
                 null,
                 null
@@ -2674,8 +2673,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.ENSLIGE_FORSORGERE_AKTIVITETSPLIKT,
                 filterValg,
                 null,
                 null
@@ -2690,8 +2689,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.ENSLIGE_FORSORGERE_VEDTAKSPERIODETYPE,
                 filterValg,
                 null,
                 null
@@ -2773,8 +2772,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -2829,8 +2828,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -2883,8 +2882,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -2949,8 +2948,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -3013,8 +3012,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -3122,8 +3121,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.BARN_UNDER_18_AR.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.BARN_UNDER_18_AR,
                 filterValg,
                 null,
                 null
@@ -3206,8 +3205,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.BARN_UNDER_18_AR.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.BARN_UNDER_18_AR,
                 filterValg,
                 null,
                 null
@@ -3275,8 +3274,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -3345,8 +3344,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall responseDefaultSortering = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -3361,8 +3360,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall responseSortertNyesteDato = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "descending",
-                Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.TILTAKSHENDELSE_DATO_OPPRETTET,
                 filterValg,
                 null,
                 null
@@ -3377,8 +3376,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall responseSortertAlfabetisk = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.TILTAKSHENDELSE_TEKST.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.TILTAKSHENDELSE_TEKST,
                 filterValg,
                 null,
                 null
@@ -3439,8 +3438,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -3510,8 +3509,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filtervalg,
                 null,
                 null
@@ -3576,8 +3575,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.UTGATT_VARSEL_DATO.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.UTGATT_VARSEL_DATO,
                 filtervalg,
                 null,
                 null
@@ -3729,8 +3728,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.BARN_UNDER_18_AR.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.BARN_UNDER_18_AR,
                 filterValg,
                 null,
                 null
@@ -3883,8 +3882,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.BARN_UNDER_18_AR.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.BARN_UNDER_18_AR,
                 filterValg,
                 null,
                 null
@@ -4033,8 +4032,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.BARN_UNDER_18_AR.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.BARN_UNDER_18_AR,
                 filterValg,
                 null,
                 null
@@ -4122,8 +4121,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.AAP_VURDERINGSFRIST.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.AAP_VURDERINGSFRIST,
                 filterValg,
                 null,
                 null
@@ -4141,8 +4140,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.AAP_VURDERINGSFRIST.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.AAP_VURDERINGSFRIST,
                 filterValg,
                 null,
                 null
@@ -4221,8 +4220,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.HUSKELAPP_KOMMENTAR.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.HUSKELAPP_KOMMENTAR,
                 filterValg,
                 null,
                 null
@@ -4238,8 +4237,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "descending",
-                Sorteringsfelt.HUSKELAPP_FRIST.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.HUSKELAPP_FRIST,
                 filterValg,
                 null,
                 null
@@ -4320,8 +4319,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -4337,8 +4336,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 filterValg,
                 null,
                 null
@@ -4354,8 +4353,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         response = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.FARGEKATEGORI.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.FARGEKATEGORI,
                 filterValg,
                 null,
                 null
@@ -4412,8 +4411,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall respons = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg().setFerdigfilterListe(emptyList()),
                 null,
                 null
@@ -4465,8 +4464,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall respons = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg().setFerdigfilterListe(emptyList()).setGjeldendeVedtak14a(List.of("HAR_14A_VEDTAK")),
                 null,
                 null
@@ -4523,8 +4522,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall respons = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg().setFerdigfilterListe(emptyList()).setGjeldendeVedtak14a(List.of("HAR_IKKE_14A_VEDTAK")),
                 null,
                 null
@@ -4578,8 +4577,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall respons = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg().setFerdigfilterListe(emptyList()).setGjeldendeVedtak14a(List.of("HAR_14A_VEDTAK", "HAR_IKKE_14A_VEDTAK")),
                 null,
                 null
@@ -4649,8 +4648,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall responsFiltrertGjeldendeVedtak = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filtrertHarGjeldendeVedtak,
                 null,
                 null
@@ -4671,8 +4670,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall responsFiltrertInnsatsgruppe = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filtrertInnsatsgruppe,
                 null,
                 null
@@ -4696,8 +4695,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall responsFiltrertHovedmal = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 filtrertHovedmal,
                 null,
                 null
@@ -4776,8 +4775,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall responsInnsatsgruppeStigende = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE,
                 filtervalg,
                 null,
                 null
@@ -4792,8 +4791,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall responsInnsatsgruppeSynkende = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "descending",
-                Sorteringsfelt.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE,
                 filtervalg,
                 null,
                 null
@@ -4808,8 +4807,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall responsHovedmalStigende = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.GJELDENDE_VEDTAK_14A_HOVEDMAL.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.GJELDENDE_VEDTAK_14A_HOVEDMAL,
                 filtervalg,
                 null,
                 null
@@ -4824,8 +4823,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall responsVedtaksdatoStigende = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.GJELDENDE_VEDTAK_14A_VEDTAKSDATO.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.GJELDENDE_VEDTAK_14A_VEDTAKSDATO,
                 filtervalg,
                 null,
                 null
@@ -4895,8 +4894,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall respons = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.GJELDENDE_VEDTAK_14A_INNSATSGRUPPE,
                 filtervalg,
                 null,
                 null
@@ -4967,8 +4966,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall respons = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.GJELDENDE_VEDTAK_14A_HOVEDMAL.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.GJELDENDE_VEDTAK_14A_HOVEDMAL,
                 filtervalg,
                 null,
                 null
@@ -5025,8 +5024,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall respons = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg().setFerdigfilterListe(emptyList()),
                 null,
                 null
@@ -5035,26 +5034,6 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         assertEquals(respons.getBrukere().get(0).getAktoerid(), bruker2.getAktoer_id());
         assertEquals(respons.getBrukere().get(1).getAktoerid(), bruker3.getAktoer_id());
         assertEquals(respons.getBrukere().get(2).getAktoerid(), bruker1.getAktoer_id());
-    }
-
-    @Test
-    public void skal_ikke_kunne_sortere_pa_ugyldig_sorteringsverdi() {
-        String ugyldigSorteringsverdi = "Dette kommer sannsynligvis aldri til å bli en gyldig filterverdi";
-
-        try {
-            opensearchService.hentBrukere(
-                    TEST_ENHET,
-                    empty(),
-                    "ascending",
-                    ugyldigSorteringsverdi,
-                    new Filtervalg().setFerdigfilterListe(emptyList()),
-                    null,
-                    null
-            );
-            fail("Ugyldig input ble godtatt og brukt til sortering");
-        } catch (Exception e) {
-            AssertionsForClassTypes.assertThat(e).isNotNull();
-        }
     }
 
     @Test
@@ -5067,8 +5046,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 opensearchService.hentBrukere(
                         TEST_ENHET,
                         empty(),
-                        "ascending",
-                        sorteringsfelt.sorteringsverdi,
+                        Sorteringsrekkefolge.STIGENDE,
+                        sorteringsfelt,
                         new Filtervalg().setFerdigfilterListe(emptyList()),
                         null,
                         null
@@ -5100,8 +5079,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         BrukereMedAntall respons = opensearchService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ascending",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg().setFerdigfilterListe(emptyList()),
                 null,
                 null
@@ -5120,8 +5099,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
         return osService.hentBrukere(
                 TEST_ENHET,
                 empty(),
-                "ikke_satt",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.IKKE_SATT,
+                Sorteringsfelt.IKKE_SATT,
                 new Filtervalg().setFerdigfilterListe(emptyList()),
                 null,
                 null
@@ -5156,8 +5135,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 () -> opensearchService.hentBrukere(
                         TEST_ENHET,
                         empty(),
-                        "ikke_satt",
-                        Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                        Sorteringsrekkefolge.IKKE_SATT,
+                        Sorteringsfelt.IKKE_SATT,
                         new Filtervalg(),
                         null,
                         null
@@ -5171,8 +5150,8 @@ public class OpensearchServiceIntegrationTest extends EndToEndTest {
                 () -> opensearchService.hentBrukere(
                         TEST_ENHET,
                         Optional.of(veilederId),
-                        "ikke_satt",
-                        Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                        Sorteringsrekkefolge.IKKE_SATT,
+                        Sorteringsfelt.IKKE_SATT,
                         new Filtervalg(),
                         null,
                         null

--- a/src/test/java/no/nav/pto/veilarbportefolje/sisteendring/SisteEndringIntegrationTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/sisteendring/SisteEndringIntegrationTest.java
@@ -9,6 +9,7 @@ import no.nav.pto.veilarbportefolje.arenapakafka.aktiviteter.TiltakService;
 import no.nav.pto.veilarbportefolje.domene.BrukereMedAntall;
 import no.nav.pto.veilarbportefolje.domene.Filtervalg;
 import no.nav.pto.veilarbportefolje.domene.Sorteringsfelt;
+import no.nav.pto.veilarbportefolje.domene.Sorteringsrekkefolge;
 import no.nav.pto.veilarbportefolje.domene.value.NavKontor;
 import no.nav.pto.veilarbportefolje.domene.value.VeilederId;
 import no.nav.pto.veilarbportefolje.mal.MalEndringKafkaDTO;
@@ -28,18 +29,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Optional.empty;
-import static no.nav.pto.veilarbportefolje.sisteendring.SisteEndringsKategori.FULLFORT_EGEN;
-import static no.nav.pto.veilarbportefolje.sisteendring.SisteEndringsKategori.FULLFORT_IJOBB;
-import static no.nav.pto.veilarbportefolje.sisteendring.SisteEndringsKategori.MAL;
-import static no.nav.pto.veilarbportefolje.sisteendring.SisteEndringsKategori.NY_IJOBB;
+import static no.nav.pto.veilarbportefolje.sisteendring.SisteEndringsKategori.*;
 import static no.nav.pto.veilarbportefolje.util.OpensearchTestClient.pollOpensearchUntil;
 import static no.nav.pto.veilarbportefolje.util.TestDataUtils.randomAktorId;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -158,8 +152,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
             final BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                     testEnhet.getValue(),
                     empty(),
-                    "asc",
-                    Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                    Sorteringsrekkefolge.STIGENDE,
+                    Sorteringsfelt.IKKE_SATT,
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
                     null);
@@ -170,8 +164,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
             var responseBrukere = opensearchService.hentBrukere(
                     testEnhet.getValue(),
                     empty(),
-                    "asc",
-                    Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                    Sorteringsrekkefolge.STIGENDE,
+                    Sorteringsfelt.IKKE_SATT,
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
                     null);
@@ -191,8 +185,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
             final BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                     testEnhet.getValue(),
                     empty(),
-                    "asc",
-                    Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                    Sorteringsrekkefolge.STIGENDE,
+                    Sorteringsfelt.IKKE_SATT,
                     new Filtervalg(),
                     null,
                     null);
@@ -203,8 +197,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
         var responseBrukere = opensearchService.hentBrukere(
                 testEnhet.getValue(),
                 empty(),
-                "asc",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 getFiltervalg(FULLFORT_IJOBB, true),
                 null,
                 null);
@@ -226,8 +220,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
             final BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                     testEnhet.getValue(),
                     empty(),
-                    "asc",
-                    Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                    Sorteringsrekkefolge.STIGENDE,
+                    Sorteringsfelt.IKKE_SATT,
                     new Filtervalg(),
                     null,
                     null);
@@ -248,8 +242,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
             final BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                     testEnhet.getValue(),
                     empty(),
-                    "asc",
-                    Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                    Sorteringsrekkefolge.STIGENDE,
+                    Sorteringsfelt.IKKE_SATT,
                     getFiltervalg(NY_IJOBB),
                     null,
                     null);
@@ -262,8 +256,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
             final BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                     testEnhet.getValue(),
                     empty(),
-                    "asc",
-                    Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                    Sorteringsrekkefolge.STIGENDE,
+                    Sorteringsfelt.IKKE_SATT,
                     getFiltervalg(FULLFORT_IJOBB, true),
                     null,
                     null);
@@ -273,8 +267,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
         var responseBrukere1 = opensearchService.hentBrukere(
                 testEnhet.getValue(),
                 empty(),
-                "asc",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 getFiltervalg(NY_IJOBB, true),
                 null,
                 null);
@@ -284,8 +278,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
         var responseBrukere2 = opensearchService.hentBrukere(
                 testEnhet.getValue(),
                 empty(),
-                "asc",
-                Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.IKKE_SATT,
                 getFiltervalg(FULLFORT_IJOBB, true),
                 null,
                 null);
@@ -314,8 +308,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
             final BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                     testEnhet.getValue(),
                     empty(),
-                    "asc",
-                    Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                    Sorteringsrekkefolge.STIGENDE,
+                    Sorteringsfelt.IKKE_SATT,
                     new Filtervalg(),
                     null,
                     null);
@@ -347,8 +341,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
             final BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                     testEnhet.getValue(),
                     empty(),
-                    "ascending",
-                    Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                    Sorteringsrekkefolge.STIGENDE,
+                    Sorteringsfelt.IKKE_SATT,
                     getFiltervalg(FULLFORT_IJOBB),
                     null,
                     null);
@@ -360,8 +354,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
             final BrukereMedAntall brukereMedAntall = opensearchService.hentBrukere(
                     testEnhet.getValue(),
                     empty(),
-                    "ascending",
-                    Sorteringsfelt.IKKE_SATT.sorteringsverdi,
+                    Sorteringsrekkefolge.STIGENDE,
+                    Sorteringsfelt.IKKE_SATT,
                     getFiltervalg(FULLFORT_EGEN),
                     null,
                     null);
@@ -372,8 +366,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
         var responseSortertFULLFORT_IJOBB = opensearchService.hentBrukere(
                 testEnhet.getValue(),
                 empty(),
-                "descending",
-                Sorteringsfelt.SISTE_ENDRING_DATO.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.SISTE_ENDRING_DATO,
                 getFiltervalg(FULLFORT_IJOBB),
                 null,
                 null);
@@ -385,8 +379,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
         var responseSortertFULLFORT_EGEN = opensearchService.hentBrukere(
                 testEnhet.getValue(),
                 empty(),
-                "ascending",
-                Sorteringsfelt.SISTE_ENDRING_DATO.sorteringsverdi,
+                Sorteringsrekkefolge.STIGENDE,
+                Sorteringsfelt.SISTE_ENDRING_DATO,
                 getFiltervalg(FULLFORT_EGEN),
                 null,
                 null);
@@ -399,8 +393,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
         var responseSortertTomRes1 = opensearchService.hentBrukere(
                 testEnhet.getValue(),
                 empty(),
-                "descending",
-                Sorteringsfelt.SISTE_ENDRING_DATO.sorteringsverdi,
+                Sorteringsrekkefolge.SYNKENDE,
+                Sorteringsfelt.SISTE_ENDRING_DATO,
                 getFiltervalg(NY_IJOBB),
                 null,
                 null);
@@ -413,8 +407,8 @@ public class SisteEndringIntegrationTest extends EndToEndTest {
                 () -> opensearchService.hentBrukere(
                         testEnhet.getValue(),
                         empty(),
-                        "descending",
-                        Sorteringsfelt.SISTE_ENDRING_DATO.sorteringsverdi,
+                        Sorteringsrekkefolge.SYNKENDE,
+                        Sorteringsfelt.SISTE_ENDRING_DATO,
                         getFiltervalg(FULLFORT_IJOBB, FULLFORT_EGEN),
                         null,
                         null));


### PR DESCRIPTION
## Describe your changes

Bygger litt vidare på opprydningsarbeidet som blei starta for filtreringsverdiar.
Denne PR-en gjer hovedsakleg følgande:

* Byttar frå Switch Statement til Switch Expression og fjernar default-case i `OpensearchQueryBuilder.sorterQueryParametere` - dette for at vi skal kunne få hjelp av Java-kompilatoren til å hugse på å eksplisitt ha ein mapping frå alle kjente `Sorteringsfelt`-enums til korresponderande Opensearch-filter
  * I forbindelse med dette har eg også lagt inn ein kommentar om samanhengen mellom `Sorteringsfelt` / `OppfolgingsBruker.java`
* Legger til enum for lovlige sorteringsrekkefølge-verdiar, `Sorteringsrekkefolge.java`
* Gjer litt om på valideringen av høvesvis sorteringsfelt og sorteringsrekkefølge, slik at vi no får ei direkte kopling til enumen og slepp å vedlikehalde ei separat liste inne i `ValideringsRegler.java`
* Gjer tidleg konvertering/validering av `sortOrder`/`sortField` - no får vi sterk typing allereie i controllerane slik at vi kan forholde oss til sterke typar nedover i kallkjeda, i staden for `String` - fjernar også nokre dupliserte valideringar som vi allereie gjorde i controllerane
* Fjernar nokre testar som ikkje lenger er nødvendige

## Trello ticket number and link

[TC-878](https://trello.com/c/S3jvGp9S/878-fiks-kolonner-det-ikkje-g%C3%A5r-an-%C3%A5-sortere-p%C3%A5)

## Type of change

Please delete options that are not relevant.

- [X] Maintenance

## Checklist before requesting a review
- [X] I have performed a self-review of my code
