### PR TITLE
Fiks test som feila pga. "NullPointerException"

### DIFF
--- a/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlBrukerdataKafkaServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlBrukerdataKafkaServiceTest.java
@@ -34,11 +34,6 @@ public class PdlBrukerdataKafkaServiceTest extends EndToEndTest {
 
     private static PdlBrukerdataKafkaService pdlBrukerdataKafkaService;
 
-    @MockBean
-    private static OpensearchIndexer opensearchIndexer;
-    @MockBean
-    private static OpensearchIndexerV2 opensearchIndexerV2;
-
     private static JdbcTemplate db;
 
     public PdlBrukerdataKafkaServiceTest() throws JsonProcessingException {
@@ -74,8 +69,8 @@ public class PdlBrukerdataKafkaServiceTest extends EndToEndTest {
                 , pdlIdentRepository,
                 new BrukerServiceV2(pdlIdentRepository, oppfolgingsbrukerRepositoryV3, oppfolgingRepositoryV2),
                 barnUnder18AarService,
-                opensearchIndexer,
-                opensearchIndexerV2
+                Mockito.mock(OpensearchIndexer.class),
+                Mockito.mock(OpensearchIndexerV2.class)
         );
     }
 


### PR DESCRIPTION
## Describe your changes

Commit https://github.com/navikt/veilarbportefolje/commit/fe224fe73035222c7ffd48dc4d3e625c6f6aa153 innførte ei endring som resulterte i at ein av testane våra plutseleg feila i GH-actions eller når ein bygde lokalt vha. `mvn clean install`.

Det var litt vanskeleg å forstå kvifor feilen plutseleg oppstod, men det var [denne endringen som framprovoserte den](https://github.com/navikt/veilarbportefolje/commit/fe224fe73#diff-2f18b906920ceeed6473bcfc973eb4e9463046ad76bf750c60816b4f5c2ecb60L68-L70). Grunnen er at metoden `oppdaterOpensearch` no faktisk blir kalla, noko den ikkje vart før. Dette i sin tur framprovoserte ein `NullPointerException` ved kallet til `opensearchIndexerV2.slettDokumenter(inaktiveAktorider);`. Rotårsaken til feilen er med andre ord at `OpenSearchIndexerV2` ikkje har blitt initialisert riktig. Ved å bytte frå `@MockBean` til `Mockito.mock` løyste det seg. 

## Trello ticket number and link

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X] I have performed a self-review of my code