### PR TITLE
sykmeldt-tag i oversikten

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/util/OppfolgingUtils.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/util/OppfolgingUtils.java
@@ -22,7 +22,7 @@ public class OppfolgingUtils {
     }
 
     public static boolean erSykmeldtMedArbeidsgiver (String formidlingsgruppekode, String kvalifiseringsgruppekode) {
-        return "IARBS".equals(formidlingsgruppekode) && !OPPFOLGINGKODER.contains(kvalifiseringsgruppekode);
+        return "IARBS".equals(formidlingsgruppekode) && kvalifiseringsgruppekode.equals("VURDI");
     }
 
     public static boolean trengerRevurderingVedtakstotte (String formidlingsgruppekode, String kvalifiseringsgruppekode, String utkast14aStatus) {


### PR DESCRIPTION
## Describe your changes
Logikken vi har i dag på sykmeldtstatus er feil.
Dette blir ekstra tydlig når INNGAR kommer på luften (i morgen). Alle som registreres gjennom INNGAR vil få sykmeldt-status, noe de absloutt ikke skal ha.

Vi forsøker derfor å ha samme logikk som i visittkort.
Vi vet ikke alle tilfellene som kanskje mangler tag da, men det blir i alle fall mer riktig enn å beholde slik det er p.t. Følger med om det kommer jirasaker på dette. 

## Trello ticket number and link
https://trello.com/c/dsvng8Wk/1003-for-blanke-brukere-som-kommer-inn-via-inngar-ser-det-ut-til-at-det-blir-sykmeldt-etikett-i-oversikten-men-ikke-i-visittkortet-hv

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
ature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
