### PR TITLE
Gjer "Under vurdering"-filter tilgjengeleg utan feature-toggle i backend

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Statustall.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Statustall.java
@@ -67,7 +67,7 @@ public class Statustall {
         this.utgatteVarsel = 0;
     }
 
-    public Statustall(StatustallResponse.StatustallAggregation.StatustallFilter.StatustallBuckets buckets, boolean vedtakstottePilotErPa) {
+    public Statustall(StatustallResponse.StatustallAggregation.StatustallFilter.StatustallBuckets buckets) {
         this.totalt = buckets.getTotalt().getDoc_count();
         this.ufordelteBrukere = buckets.getUfordelteBrukere().getDoc_count();
         this.trengerVurdering = buckets.getTrengerVurdering().getDoc_count();
@@ -85,7 +85,7 @@ public class Statustall {
         this.minArbeidslisteLilla = buckets.getMinArbeidslisteLilla().getDoc_count();
         this.minArbeidslisteGronn = buckets.getMinArbeidslisteGronn().getDoc_count();
         this.minArbeidslisteGul = buckets.getMinArbeidslisteGul().getDoc_count();
-        this.underVurdering = vedtakstottePilotErPa ? buckets.getUnderVurdering().getDoc_count() : 0;
+        this.underVurdering = buckets.getUnderVurdering().getDoc_count();
         this.mineHuskelapper = buckets.getMineHuskelapper().getDoc_count();
         this.fargekategoriA = buckets.getFargekategoriA().getDoc_count();
         this.fargekategoriB = buckets.getFargekategoriB().getDoc_count();


### PR DESCRIPTION
## Describe your changes
Har teke bort sperra for filter om feature-toggle er av i backend. Bruk og visning av filteret i frontend ligg framleis bak feature-toggle. Eg har også opna opp statustala når ein ikkje har toggle på, ingen info vert vist om toggle ikkje er på i frontend. Dessutan: for kontor som ikkje er utrulla vil framleis statustala vere 0.



## Trello ticket number and link
TC1025
https://trello.com/c/KOwjJJOm/1025-bruk-vis-vedtaksl%C3%B8sning-toggle-i-portefoljeflate-slik-at-ein-ser-under-vurdering-filteret

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
