### PR TITLE
Rettet opensearch query for å hente inn riktig brukere i filteret 'Trenger Vurdering'

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexerV2.java
@@ -87,8 +87,8 @@ public class OpensearchIndexerV2 {
                 .field("fodselsdato", FodselsnummerUtils.lagFodselsdato(oppfolgingsbruker.fodselsnr()))
                 .field("kjonn", FodselsnummerUtils.lagKjonn(oppfolgingsbruker.fodselsnr()))
                 .field("fodselsdag_i_mnd", Integer.parseInt(FodselsnummerUtils.lagFodselsdagIMnd(oppfolgingsbruker.fodselsnr())))
-
                 .field("trenger_revurdering", OppfolgingUtils.trengerRevurderingVedtakstotte(oppfolgingsbruker.formidlingsgruppekode(), oppfolgingsbruker.kvalifiseringsgruppekode(), utkast14aStatus))
+                //Ikke i bruk
                 .field("trenger_vurdering", OppfolgingUtils.trengerVurdering(oppfolgingsbruker.rettighetsgruppekode(), oppfolgingsbruker.kvalifiseringsgruppekode()))
                 .endObject();
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchQueryBuilder.java
@@ -839,7 +839,7 @@ public class OpensearchQueryBuilder {
                 queryBuilder = byggUfordeltBrukereQuery(veiledereMedTilgangTilEnhet);
                 break;
             case TRENGER_VURDERING:
-                queryBuilder = byggTrengerVurderingFilter(erVedtakstottePilotPa);
+                queryBuilder = byggTrengerVurderingFilter();
                 break;
             case INAKTIVE_BRUKERE:
                 queryBuilder = matchQuery("formidlingsgruppekode", "ISERV");
@@ -878,11 +878,7 @@ public class OpensearchQueryBuilder {
                 queryBuilder = byggErSykmeldtMedArbeidsgiverFilter(erVedtakstottePilotPa);
                 break;
             case UNDER_VURDERING:
-                if (erVedtakstottePilotPa) {
-                    queryBuilder = existsQuery("utkast_14a_status");
-                } else {
-                    throw new IllegalStateException();
-                }
+                queryBuilder = existsQuery("utkast_14a_status");
                 break;
             case TILTAKSHENDELSER:
                 queryBuilder = existsQuery("tiltakshendelse");
@@ -892,20 +888,16 @@ public class OpensearchQueryBuilder {
                 break;
             default:
                 throw new IllegalStateException();
-
         }
         return queryBuilder;
     }
 
     // Brukere med veileder uten tilgang til denne enheten ansees som ufordelte brukere
-    static QueryBuilder byggTrengerVurderingFilter(boolean erVedtakstottePilotPa) {
-        if (erVedtakstottePilotPa) {
-            return boolQuery()
-                    .must(matchQuery("trenger_vurdering", true))
-                    .mustNot(existsQuery("utkast_14a_status"));
-        }
-
-        return matchQuery("trenger_vurdering", true);
+    static QueryBuilder byggTrengerVurderingFilter() {
+        return boolQuery()
+                .must(matchQuery("trenger_vurdering", true))
+                .mustNot(existsQuery("gjeldendeVedtak14a"))
+                .mustNot(existsQuery("utkast_14a_status"));
 
     }
 


### PR DESCRIPTION
Denne PRen handler om å trekke ut de brukere som har fattet 14a vedtak eller som har pågående utkast i nåværende oppfølgingsperiode fra filter "Trenger vurdering". Opensearch query sier ikke om vi filtrer på brukere er under oppfølging men jeg antar at vi ser bare de brukere som er under oppfølging i portefolje.

[https://trello.com/c/Soxo7Fhj/1070-hente-inn-riktig-brukere-i-filter-trenger-vurdering]


- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
