### PR TITLE
TK-1130 Legger til unik indeks på tabell huskelapp for å hindre at en person …

### DIFF
--- a/src/main/resources/db/postgres/V1_94__create_unique_index_huskelapp_status.sql
+++ b/src/main/resources/db/postgres/V1_94__create_unique_index_huskelapp_status.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX unique_fnr_active_status
+    ON HUSKELAPP (FNR)
+    WHERE STATUS = 'AKTIV';


### PR DESCRIPTION
…har to aktive huskelapper. Situasjonen ser ut til å ha oppstått pga teknisk feil, to identiske rader er insertet med millisekunders mellomrom.

