### PR TITLE
Sette loggdestinasjonar eksplisitt

### DIFF
--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -21,6 +21,7 @@ spec:
     logging:
       destinations:
         - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:

--- a/.nais/application/application-config-prod.yaml
+++ b/.nais/application/application-config-prod.yaml
@@ -21,6 +21,7 @@ spec:
     logging:
       destinations:
         - id: elastic
+        - id: loki
   secureLogs:
     enabled: true
   kafka:


### PR DESCRIPTION
[Nais skal/har gått over til Grafana Loki som default loggverktøy og Elastic Kibana er difor deprekert](https://nav-it.slack.com/docs/T5LNAMWNA/F08RNSRJ934). Elastic vil vere tilgjengeleg ut året, så inntil vi får migrert til Grafana Loki, må vi eksplisitt spesifisere Elastic Kibana som loggdestinasjon. Legg difor til både `elastic` og `loki` som loggdestinasjonar slik at vi kan halde fram med å få loggar i Kibana. Når vi er blitt vande nok med Loki kan vi gå over permanent og fjerne `elastic`.