### PR TITLE
Ikke bruk ø i felt til frontend

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Bruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Bruker.java
@@ -86,7 +86,7 @@ public class Bruker {
     Avvik14aVedtak avvik14aVedtak;
     List<BarnUnder18AarData> barnUnder18AarData;
 
-    EnsligeForsorgereOvergangsstonad ensligeForsorgereOvergangsstonad;
+    EnsligeForsorgereOvergangsstonadFrontend ensligeForsorgereOvergangsstonad;
 
     LocalDate utdanningOgSituasjonSistEndret;
 
@@ -171,7 +171,7 @@ public class Bruker {
                 .setBostedSistOppdatert(bruker.getBostedSistOppdatert())
                 .setAvvik14aVedtak(bruker.getAvvik14aVedtak())
                 .setBarnUnder18AarData(bruker.getBarn_under_18_aar())
-                .setEnsligeForsorgereOvergangsstonad(bruker.getEnslige_forsorgere_overgangsstonad())
+                .setEnsligeForsorgereOvergangsstonad(EnsligeForsorgereOvergangsstonadFrontend.of(bruker.getEnslige_forsorgere_overgangsstonad()))
                 .setUtdanningOgSituasjonSistEndret(bruker.getUtdanning_og_situasjon_sist_endret())
                 .setHuskelapp(bruker.getHuskelapp())
                 .setFargekategori(bruker.getFargekategori())

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/EnsligeForsorgereOvergangsstonadFrontend.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/EnsligeForsorgereOvergangsstonadFrontend.java
@@ -1,0 +1,29 @@
+package no.nav.pto.veilarbportefolje.domene;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public record EnsligeForsorgereOvergangsstonadFrontend(
+        String vedtaksPeriodetype,
+        Boolean harAktivitetsplikt,
+        LocalDate utlopsDato,
+        LocalDate yngsteBarnsFodselsdato) {
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public EnsligeForsorgereOvergangsstonadFrontend {
+    }
+
+    public static EnsligeForsorgereOvergangsstonadFrontend of(EnsligeForsorgereOvergangsstonad ensligeForsorgereOvergangsstonad) {
+        if (Objects.nonNull(ensligeForsorgereOvergangsstonad)) {
+            return new EnsligeForsorgereOvergangsstonadFrontend(
+                    ensligeForsorgereOvergangsstonad.vedtaksPeriodetype(),
+                    ensligeForsorgereOvergangsstonad.harAktivitetsplikt(),
+                    ensligeForsorgereOvergangsstonad.utlopsDato(),
+                    ensligeForsorgereOvergangsstonad.yngsteBarnsFødselsdato()
+            );
+        }
+        return null;
+    }
+}

--- a/src/test/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereServiceTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/ensligforsorger/EnsligeForsorgereServiceTest.java
@@ -91,7 +91,7 @@ public class EnsligeForsorgereServiceTest extends EndToEndTest {
                     assertThat(responseBrukere.getBrukere().get(0).getEnsligeForsorgereOvergangsstonad().vedtaksPeriodetype()).isEqualTo("Ny periode for nytt barn");
                     assertThat(responseBrukere.getBrukere().get(0).getEnsligeForsorgereOvergangsstonad().harAktivitetsplikt()).isEqualTo(false);
                     assertThat(responseBrukere.getBrukere().get(0).getEnsligeForsorgereOvergangsstonad().utlopsDato()).isEqualTo(LocalDate.now().plusDays(20));
-                    assertThat(responseBrukere.getBrukere().get(0).getEnsligeForsorgereOvergangsstonad().yngsteBarnsFødselsdato()).isEqualTo(LocalDate.of(2023, 5, 4));
+                    assertThat(responseBrukere.getBrukere().get(0).getEnsligeForsorgereOvergangsstonad().yngsteBarnsFodselsdato()).isEqualTo(LocalDate.of(2023, 5, 4));
                 }
         );
     }


### PR DESCRIPTION
## Describe your changes
Lagar ein eigen Ensligforsorgen-type vi kan sende til frontend, så vi slepp sende "yngstebarnFødselsdato" (med ø i).
Dette fikser ein bug der info om born ikkje vart vist i frontend sidan dei prøvde å leite etter info på feltet "yngstebarnFodselsdato".

## Trello ticket number and link
https://trello.com/c/2ROGh1hn/1188-oversikten-mismatch-mellom-felt-p%C3%A5-brukermodell-i-frontend-og-backend

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
