### PR TITLE
Send med varighet på møter til Møteplan

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterRepositoryV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/AktiviteterRepositoryV2.java
@@ -25,8 +25,7 @@ import static no.nav.pto.veilarbportefolje.database.PostgresTable.AKTIVITETER.*;
 import static no.nav.pto.veilarbportefolje.postgres.AktivitetEntityDto.leggTilAktivitetPaResultat;
 import static no.nav.pto.veilarbportefolje.postgres.AktivitetEntityDto.mapAktivitetTilEntity;
 import static no.nav.pto.veilarbportefolje.postgres.PostgresUtils.queryForObjectOrNull;
-import static no.nav.pto.veilarbportefolje.util.DateUtils.toIsoUTC;
-import static no.nav.pto.veilarbportefolje.util.DateUtils.toTimestamp;
+import static no.nav.pto.veilarbportefolje.util.DateUtils.*;
 import static no.nav.pto.veilarbportefolje.util.SecureLog.secureLog;
 
 @Slf4j
@@ -127,7 +126,7 @@ public class AktiviteterRepositoryV2 {
         params.addValue("veilederIdent", veilederIdent.getValue());
         params.addValue("enhet", enhet.get());
         return namedDb.query("""
-                        SELECT op.fodselsnr, a.fradato, a.avtalt, bd.fornavn, bd.etternavn
+                        SELECT op.fodselsnr, a.fradato, a.tildato, a.avtalt, bd.fornavn, bd.etternavn
                          from oppfolgingsbruker_arena_v2 op
                          left join bruker_data bd on bd.freg_ident = op.fodselsnr
                         inner join aktive_identer ai on op.fodselsnr = ai.fnr
@@ -151,9 +150,20 @@ public class AktiviteterRepositoryV2 {
     @SneakyThrows
     private Moteplan mapTilMoteplan(ResultSet rs) {
         return new Moteplan(
-                new Motedeltaker(rs.getString("fornavn"), rs.getString("etternavn"),
-                        rs.getString("fodselsnr")),
-                toIsoUTC(rs.getTimestamp("fradato")),
+                new Motedeltaker(
+                        rs.getString("fornavn"),
+                        rs.getString("etternavn"),
+                        rs.getString("fodselsnr")
+                ),
+                toIsoUTC(
+                        rs.getTimestamp("fradato")
+                ),
+                toZonedDateTime(
+                        rs.getTimestamp("fradato")
+                ),
+                toZonedDateTime(
+                        rs.getTimestamp("tildato")
+                ),
                 rs.getBoolean("avtalt")
         );
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/controller/VeilederController.java
@@ -82,7 +82,7 @@ public class VeilederController {
 
     @GetMapping("{veilederident}/moteplan")
     @Operation(summary = "Hent møteplan for veileder", description = "Henter en liste av fremtidige møter for en gitt veileder på en gitt enhet.")
-    public List<Moteplan> hentMoteplanForVeileder(@PathVariable("veilederident") VeilederId veilederIdent, @RequestParam("enhet") EnhetId enhet) {
+    public List<MoteplanDTO> hentMoteplanForVeileder(@PathVariable("veilederident") VeilederId veilederIdent, @RequestParam("enhet") EnhetId enhet) {
         ValideringsRegler.sjekkEnhet(enhet.get());
         ValideringsRegler.sjekkVeilederIdent(veilederIdent.getValue(), false);
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/Moteplan.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/Moteplan.java
@@ -1,4 +1,7 @@
 package no.nav.pto.veilarbportefolje.domene;
 
-public record Moteplan (Motedeltaker deltaker, String dato, boolean avtaltMedNav) {
+import java.time.ZonedDateTime;
+
+/** Møteplandata som hentes ut fra database. */
+public record Moteplan(Motedeltaker deltaker, String dato, ZonedDateTime starttidspunkt, ZonedDateTime sluttidspunkt, boolean avtaltMedNav) {
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/MoteplanDTO.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/MoteplanDTO.java
@@ -1,0 +1,12 @@
+package no.nav.pto.veilarbportefolje.domene;
+
+import java.time.Duration;
+
+/** Møteplan-data som sendes til frontend. */
+public record MoteplanDTO(Motedeltaker deltaker, String dato, int varighetMinutter, boolean avtaltMedNav) {
+    public static MoteplanDTO of(Moteplan moteplan) {
+        Long varighet = Duration.between(moteplan.starttidspunkt(), moteplan.sluttidspunkt()).toMinutes();
+
+        return new MoteplanDTO(moteplan.deltaker(), moteplan.dato(), varighet.intValue(), moteplan.avtaltMedNav());
+    }
+}

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetUtilsTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/AktivitetUtilsTest.java
@@ -1,14 +1,16 @@
 package no.nav.pto.veilarbportefolje.aktiviteter;
 
 import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest;
+import no.nav.pto.veilarbportefolje.domene.Motedeltaker;
+import no.nav.pto.veilarbportefolje.domene.MoteplanDTO;
+import no.nav.pto.veilarbportefolje.domene.Moteplan;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.sql.Timestamp;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.*;
 
 import static java.util.Arrays.asList;
 import static no.nav.pto.veilarbportefolje.aktiviteter.AktivitetUtils.finnNyesteUtlopteAktivAktivitet;
@@ -43,5 +45,20 @@ public class AktivitetUtilsTest {
         Timestamp nyesteIkkeFullforte = finnNyesteUtlopteAktivAktivitet(asList(denEldsteAktiviteten, denNyesteAktiviteten), today);
 
         assertThat(nyesteIkkeFullforte).isNull();
+    }
+
+    @Test
+    public void skalMappeMellomMoteplanOgMoteplanDTO() {
+        Motedeltaker deltaker = new Motedeltaker("Test", "Testesen", "01010112345");
+        String dato = "2025-08-21T09:00:00Z";
+        ZonedDateTime moteFra = ZonedDateTime.now();
+        ZonedDateTime moteTil = moteFra.plusMinutes(123);
+
+        Moteplan moteplan = new Moteplan(deltaker, dato, moteFra, moteTil, false);
+        MoteplanDTO forventet = new MoteplanDTO(deltaker, dato, 123, false);
+
+        MoteplanDTO result = MoteplanDTO.of(moteplan);
+
+        assertThat(result).isEqualTo(forventet);
     }
 }


### PR DESCRIPTION
## Describe your changes
Legg til varighet på møteplan-type som sendes til Frontend på møteplan-endepunkt.

Lagar ein eigen type for sending til frontend (MoteplanDTO) og ein for å hente ut frå databasen (Moteplan), slik at service kan vere den som gjer utrekninga av møte-varighet basert på start- og sluttidspunkt.


Verdi: Gjere det mogleg for veileder å oppdage overlapp mellom møter.

## Trello ticket number and link
https://trello.com/c/5VGKMOpx/1266-vise-kolonne-for-varighet-i-m%C3%B8teplan?filter=*


## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.

