### PR TITLE
Endret urlen til appen arbeidssoekerregisteret

### DIFF
--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -90,7 +90,7 @@ spec:
           cluster: dev-fss
         - application: poao-tilgang
           namespace: poao
-        - application: paw-arbeidssoekerregisteret-api-oppslag
+        - application: paw-arbeidssoekerregisteret-api-oppslag-v2
           namespace: paw
         - application: veilarbvedtaksstotte
           namespace: obo
@@ -145,9 +145,9 @@ spec:
     - name: KODEVERK_SCOPE
       value: "api://dev-gcp.team-rocket.kodeverk-api/.default"
     - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_URL
-      value: "http://paw-arbeidssoekerregisteret-api-oppslag.paw"
+      value: "http://paw-arbeidssoekerregisteret-api-oppslag-v2.paw"
     - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_SCOPE
-      value: "api://dev-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag/.default"
+      value: "api://dev-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag-v2/.default"
     - name: ENSLIG_FORSORGER_URL
       value: "http://familie-ef-sak.teamfamilie"
     - name: ENSLIG_FORSORGER_SCOPE

--- a/.nais/application/application-config-prod.yaml
+++ b/.nais/application/application-config-prod.yaml
@@ -87,7 +87,7 @@ spec:
           cluster: prod-fss
         - application: poao-tilgang
           namespace: poao
-        - application: paw-arbeidssoekerregisteret-api-oppslag
+        - application: paw-arbeidssoekerregisteret-api-oppslag-v2
           namespace: paw
         - application: veilarboppfolging
           namespace: poao
@@ -139,9 +139,9 @@ spec:
     - name: KODEVERK_SCOPE
       value: "api://prod-gcp.team-rocket.kodeverk-api/.default"
     - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_URL
-      value: "http://paw-arbeidssoekerregisteret-api-oppslag.paw"
+      value: "http://paw-arbeidssoekerregisteret-api-oppslag-v2.paw"
     - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_SCOPE
-      value: "api://prod-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag/.default"
+      value: "api://prod-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag-v2/.default"
     - name: ENSLIG_FORSORGER_URL
       value: "http://familie-ef-sak.teamfamilie"
     - name: ENSLIG_FORSORGER_SCOPE


### PR DESCRIPTION
følgende tjeneste vil etterhvert fases ut:
ingress: https://oppslag-arbeidssoekerregisteret.intern.nav.no/
service discovery: paw-arbeidssoekerregisteret-api-oppslag
Erstatning er alt klar i dev og prod. Den er tilgjengelig via service discovery: paw-arbeidssoekerregisteret-api-oppslag-v2

https://trello.com/c/XncmtMMv/1090-endre-paw-arbeidssokerregister-til-v2

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] We need to implement grafana analytics
