### PR TITLE
Legg til respons på oppfølgingsmeldinger for aap

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/aap/AapController.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aap/AapController.kt
@@ -24,12 +24,6 @@ class AapController(
         )
     }
 
-    @PostMapping("/hent-aap-vedtak-for-oppfolging-periode")
-    fun hentAapVedtakForOppfolgingPeriode(@RequestBody request: AapVedtakRequest): AapVedtakResponseDto.Vedtak? {
-        return aapService.hentSisteAapPeriodeFraApi(
-            personIdent = request.personidentifikator
-        )
-    }
 
     @PostMapping("/hent-aap-for-kafkamelding")
     fun hentAapForKafkamelding(@RequestBody request: AapVedtakRequest) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/aap/AapService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aap/AapService.kt
@@ -12,11 +12,13 @@ import no.nav.pto.veilarbportefolje.kafka.KafkaConfigCommon.Topic
 import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingRepositoryV2
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository
 import no.nav.pto.veilarbportefolje.util.DateUtils.toLocalDate
+import no.nav.pto.veilarbportefolje.util.SecureLog.secureLog
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.util.*
 
 
 /**
@@ -45,7 +47,14 @@ class AapService(
             return
         }
 
-        val sisteAapPeriode = hentSisteAapPeriodeFraApi(kafkaMelding.personident)
+        val aktorId = aktorClient.hentAktorId(Fnr.of(kafkaMelding.personident))
+        hentOgLagreAapForBruker(kafkaMelding.personident, aktorId)
+    }
+
+
+    fun hentOgLagreAapForBruker(_personIdent: String?, aktorId: AktorId) {
+        val personIdent = _personIdent ?: aktorClient.hentFnr(aktorId).get()
+        val sisteAapPeriode = hentSisteAapPeriodeFraApi(personIdent, aktorId)
 
         //todo håndtere tilfeller hvor denne er null, men vi har data i db fra før
         if (sisteAapPeriode == null) {
@@ -53,11 +62,10 @@ class AapService(
             return
         }
 
-        aapRepository.upsertAap(kafkaMelding.personident, sisteAapPeriode)
+        aapRepository.upsertAap(personIdent, sisteAapPeriode)
     }
 
-    fun hentSisteAapPeriodeFraApi(personIdent: String): AapVedtakResponseDto.Vedtak? {
-        val aktorId: AktorId = aktorClient.hentAktorId(Fnr.of(personIdent))
+    fun hentSisteAapPeriodeFraApi(personIdent: String, aktorId: AktorId): AapVedtakResponseDto.Vedtak? {
         val oppfolgingsStartdato = hentOppfolgingStartdato(aktorId)
         //Fordi vi må sett en tom-dato i requesten så setter vi en dato langt frem i tid. Bør sjekkes nøyere med aap om
         // hvordan periodene man sender inn behandles (de ser ikke ut til å filtrere på periodene)
@@ -72,6 +80,23 @@ class AapService(
 
         val sistePeriode = aapIOppfolgingsPeriode.maxByOrNull { it.periode.fraOgMedDato }
         return sistePeriode
+    }
+
+    fun slettAapData(aktorId: AktorId, maybeFnr: Optional<Fnr>) {
+        if (maybeFnr.isEmpty) {
+            secureLog.warn(
+                "Kunne ikke slette AAP bruker med Aktør-ID {}. Årsak fødselsnummer-parameter var tom.",
+                aktorId.get()
+            )
+            return
+        }
+
+        try {
+            aapRepository.slettAapForBruker(maybeFnr.get().toString())
+        } catch (e: Exception) {
+            secureLog.error("Feil ved sletting av AAP data for bruker med fnr: ${maybeFnr.get()}", e)
+            return
+        }
     }
 
     fun filtrerAapKunIOppfolgingPeriode(

--- a/src/main/java/no/nav/pto/veilarbportefolje/aap/repository/AapVedtakPeriode.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aap/repository/AapVedtakPeriode.kt
@@ -16,7 +16,6 @@ enum class AapStatus {
     companion object {
         private val mapping = mapOf(
             "LØPENDE" to LOPENDE,
-            "LOPENDE" to LOPENDE,
             "UTREDES" to UTREDES,
             "AVSLUTTET" to AVSLUTTET
         )

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingAvsluttetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingAvsluttetService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.pto.veilarbportefolje.aap.AapService;
 import no.nav.pto.veilarbportefolje.arbeidsliste.ArbeidslisteService;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v1.ArbeidssokerRegistreringRepositoryV2;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerService;
@@ -43,6 +44,7 @@ public class OppfolgingAvsluttetService {
     private final OppfolgingsbrukerServiceV2 oppfolgingsbrukerServiceV2;
     private final ArbeidssoekerService arbeidssoekerService;
     private final ArbeidssokerRegistreringRepositoryV2 arbeidssokerRegistreringRepositoryV2;
+    private final AapService aapService;
 
     public void avsluttOppfolging(AktorId aktoerId) {
         Optional<Fnr> maybeFnr = Optional.ofNullable(pdlIdentRepository.hentFnrForAktivBruker(aktoerId));
@@ -61,6 +63,7 @@ public class OppfolgingAvsluttetService {
         fargekategoriService.slettFargekategoriPaaBruker(aktoerId, maybeFnr);
         oppfolgingsbrukerServiceV2.slettOppfolgingsbruker(aktoerId, maybeFnr);
         arbeidssoekerService.slettArbeidssoekerData(aktoerId, maybeFnr);
+        aapService.slettAapData(aktoerId, maybeFnr);
 
         opensearchIndexerV2.slettDokumenter(List.of(aktoerId));
         secureLog.info("Bruker: {} har avsluttet oppfølging og er slettet", aktoerId);

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingStartetService.java
@@ -3,6 +3,7 @@ package no.nav.pto.veilarbportefolje.oppfolging;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.types.identer.AktorId;
+import no.nav.pto.veilarbportefolje.aap.AapService;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerService;
 import no.nav.pto.veilarbportefolje.ensligforsorger.EnsligeForsorgereService;
 import no.nav.pto.veilarbportefolje.opensearch.OpensearchIndexer;
@@ -27,6 +28,7 @@ public class OppfolgingStartetService {
     private final OppfolgingsbrukerServiceV2 oppfolgingsbrukerServiceV2;
     private final ArbeidssoekerService arbeidssoekerService;
     private final EnsligeForsorgereService ensligeForsorgereService;
+    private final AapService aapService;
 
     // TODO: Dersom en eller flere av disse operasjonene feiler og kaster exception vil
     //  kafka-meldingen bli lagret og retryet. Dette kan resultere i at vi mellomlagrer data
@@ -41,6 +43,7 @@ public class OppfolgingStartetService {
         oppfolgingsbrukerServiceV2.hentOgLagreOppfolgingsbruker(aktorId);
         arbeidssoekerService.hentOgLagreArbeidssoekerdataForBruker(aktorId);
         ensligeForsorgereService.hentOgLagreEnsligForsorgerDataFraApi(aktorId);
+        aapService.hentOgLagreAapForBruker(null, aktorId);
 
         opensearchIndexer.indekser(aktorId);
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/aap/AapServiceTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aap/AapServiceTest.kt
@@ -131,7 +131,7 @@ class AapServiceTest(
         val apiResponse = AapVedtakResponseDto(vedtak = listOf(vedtakInnenfor, vedtakForTidlig))
         `when`(aapClient.hentAapVedtak(anyString(), anyString(), anyString())).thenReturn(apiResponse)
 
-        val resultat = aapService.hentSisteAapPeriodeFraApi(fnr)
+        val resultat = aapService.hentSisteAapPeriodeFraApi(fnr, aktorId)
         assertThat(resultat).isEqualTo(vedtakInnenfor)
     }
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepositoryTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepositoryTest.java
@@ -2,6 +2,7 @@ package no.nav.pto.veilarbportefolje.persononinfo;
 
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.pto.veilarbportefolje.aap.AapService;
 import no.nav.pto.veilarbportefolje.arbeidssoeker.v2.ArbeidssoekerService;
 import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest;
 import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingPeriodeService;
@@ -39,6 +40,9 @@ public class PdlIdentRepositoryTest {
 
     @MockBean
     private ArbeidssoekerService arbeidssoekerService;
+
+    @MockBean
+    private AapService aapService;
 
     @Test
     public void identSplitt_allePersonerMedTidligereIdenterSkalSlettes() {


### PR DESCRIPTION
Ved kafkamelding om oppfølging start blir AAP data for bruker hentest og evt lagret

Ved kafkamelding om oppfølging slutt blir AAP data for bruker slettet

Testet i dev 

