### PR TITLE
Håndter flere identer for aap

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepository.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/persononinfo/PdlIdentRepository.java
@@ -73,6 +73,16 @@ public class PdlIdentRepository {
         return new IdenterForBruker(identer);
     }
 
+    public IdenterForBruker hentFnrIdenterForBruker(String brukerId) {
+        List<String> identer = db.queryForList("""
+                select bi2.ident
+                from bruker_identer bi1
+                inner join bruker_identer bi2 on bi2.person = bi1.person
+                where bi2.gruppe = 'FOLKEREGISTERIDENT' and bi1.ident = ?
+                """, String.class, brukerId);
+        return new IdenterForBruker(identer);
+    }
+
     @SneakyThrows
     public static PDLIdent mapTilident(Map<String, Object> rs) {
         return new PDLIdent()

--- a/src/test/java/no/nav/pto/veilarbportefolje/aap/AapServiceTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aap/AapServiceTest.kt
@@ -12,6 +12,7 @@ import no.nav.pto.veilarbportefolje.opensearch.OpensearchService
 import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingRepositoryV2
 import no.nav.pto.veilarbportefolje.oppfolging.domene.OppfolgingMedStartdato
 import no.nav.pto.veilarbportefolje.persononinfo.PdlIdentRepository
+import no.nav.pto.veilarbportefolje.persononinfo.domene.IdenterForBruker
 import no.nav.pto.veilarbportefolje.util.DateUtils.toTimestamp
 import no.nav.pto.veilarbportefolje.util.EndToEndTest
 import no.nav.pto.veilarbportefolje.util.TestDataUtils.randomAktorId
@@ -65,6 +66,7 @@ class AapServiceTest(
         val aktorId = randomAktorId()
 
         `when`(pdlIdentRepository.erBrukerUnderOppfolging(norskIdent)).thenReturn(true)
+        `when`(pdlIdentRepository.hentFnrIdenterForBruker(norskIdent)).thenReturn(IdenterForBruker(listOf(norskIdent)))
         `when`(aktorClient.hentAktorId(any())).thenReturn(aktorId)
         `when`(oppfolgingRepositoryV2.hentOppfolgingMedStartdato(any())).thenReturn(
             Optional.of(OppfolgingMedStartdato(true, toTimestamp(LocalDate.now().minusMonths(2))))
@@ -107,6 +109,7 @@ class AapServiceTest(
         val aktorId = randomAktorId()
 
         `when`(pdlIdentRepository.erBrukerUnderOppfolging(norskIdent)).thenReturn(true)
+        `when`(pdlIdentRepository.hentFnrIdenterForBruker(norskIdent)).thenReturn(IdenterForBruker(listOf(norskIdent)))
         `when`(aktorClient.hentAktorId(any())).thenReturn(aktorId)
         `when`(oppfolgingRepositoryV2.hentOppfolgingMedStartdato(any())).thenReturn(
             Optional.of(OppfolgingMedStartdato(true, toTimestamp(LocalDate.now().minusMonths(2))))
@@ -274,6 +277,7 @@ class AapServiceTest(
         populateOpensearch(navKontor, veilederId, aktorId.get(),)
 
         `when`(pdlIdentRepository.erBrukerUnderOppfolging(norskIdent.toString())).thenReturn(true)
+        `when`(pdlIdentRepository.hentFnrIdenterForBruker(norskIdent.toString())).thenReturn(IdenterForBruker(listOf(norskIdent.toString())))
         `when`(aktorClient.hentAktorId(any())).thenReturn(aktorId)
         `when`(oppfolgingRepositoryV2.hentOppfolgingMedStartdato(any())).thenReturn(
             Optional.of(OppfolgingMedStartdato(true, toTimestamp(LocalDate.now().minusMonths(2))))


### PR DESCRIPTION
Har laget en sjekk på identer for AAP. 

Når en aap periode skal slettes, så gjøres det en sjekk på alle fnr identer og evt rader blir slettet for hver ident. 

Når en aap periode skal lagres, så gjøres det er sjekk på alle fnr identer. Om det er flere enn en, så slettes alle rader før de nye perioden blir lagret. Hvis ikke kjøres en upsert som vanlig. 
