### PR TITLE
Hent tildelingsdato batch

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/admin/v1/AdminController.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/admin/v1/AdminController.java
@@ -69,6 +69,15 @@ public class AdminController {
         return "Innlastning av oppfolgingsdata har startet";
     }
 
+
+    @PostMapping("/lastInnTildelingsdatoForBrukere")
+    @Operation(summary = "Oppdater tildelingsdato for alle brukere", description = "Går gjennom alle brukere med tildelt veileder i løsningen og oppdaterer tildelingsdato for disse.")
+    public String lastInnTildelingstidspunktForVeileder() {
+        oppfolgingService.lastInnTildelingstidspunktForVeileder();
+        return "Innlastning av tildelingsdato for veileder har startet";
+    }
+
+
     @PostMapping("/lastInnOppfolgingForBruker")
     @Operation(summary = "Oppdater data for bruker", description = "Oppdaterer oppfølgingsdata for en gitt bruker. Dersom brukeren eventuelt ikke er under oppfølging slettes den.")
     public String lastInnOppfolgingsDataForBruker(@RequestBody LastInnOppfolgingForBrukerRequest request) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingRepositoryV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingRepositoryV2.java
@@ -117,6 +117,14 @@ public class OppfolgingRepositoryV2 {
         return alleIder;
     }
 
+    public List<AktorId> hentAlleBrukerUnderOppfolgingMedTildeltVeileder() {
+        db.setFetchSize(10_000);
+        List<AktorId> alleIder = db.queryForList("SELECT aktoerid FROM oppfolging_data WHERE oppfolging AND veilederid IS NOT NULL", AktorId.class);
+        db.setFetchSize(-1);
+
+        return alleIder;
+    }
+
     public Optional<VeilederId> hentVeilederForBruker(AktorId aktoerId) {
         return Optional.ofNullable(
                 queryForObjectOrNull(

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingService.java
@@ -72,6 +72,34 @@ public class OppfolgingService {
         this.veilarboppfolgingUrl = url;
     }
 
+    public void lastInnTildelingstidspunktForVeileder() {
+        log.info("Startet: Innlastning av tildelingstidspunkt for veileder");
+        JobRunner.runAsync("OppfolgingSyncTildelingstidspunkt",
+                () -> {
+                    List<AktorId> oppfolgingsBruker = List.of(AktorId.of("2596043099670")); //oppfolgingRepositoryV2.hentAlleBrukerUnderOppfolgingMedTildeltVeileder();
+                    oppfolgingsBruker.forEach(this::oppdaterTildelingstidspunkt);
+
+                    log.info("OppfolgingsJobb: oppdaterte tildelingstidspunkt pa: {} brukere ", oppfolgingsBruker.size());
+                });
+        log.info("Ferdig: Innlastning av tildelingstidspunkt for veileder");
+    }
+
+    public void oppdaterTildelingstidspunkt(AktorId aktorId) {
+        try {
+            Veilarbportefoljeinfo veialrbinfo = hentVeilarbData(aktorId);
+            if (veialrbinfo.isErUnderOppfolging() && veialrbinfo.getSistTilordnetDato() != null) {
+                oppfolgingRepositoryV2.settTilordningstidspunkt(aktorId, veialrbinfo.getSistTilordnetDato());
+            }
+
+        }  catch (RuntimeException e) {
+        secureLog.error("RuntimeException i OppfolgingsJobb tildelingstidspunkt for bruker {}", aktorId);
+        secureLog.error("RuntimeException i OppfolgingsJobb tildelingstidspunkt", e);
+    } catch (Exception e) {
+        secureLog.error("Exception i OppfolgingsJobb tildelingstidspunkt for bruker {}", aktorId);
+        secureLog.error("Exception i OppfolgingsJobb tildelingstidspunkt", e);
+    }
+    }
+
     public void lastInnDataPaNytt() {
         JobRunner.runAsync("OppfolgingSync",
                 () -> {

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingService.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingService.java
@@ -76,7 +76,7 @@ public class OppfolgingService {
         log.info("Startet: Innlastning av tildelingstidspunkt for veileder");
         JobRunner.runAsync("OppfolgingSyncTildelingstidspunkt",
                 () -> {
-                    List<AktorId> oppfolgingsBruker = List.of(AktorId.of("2596043099670")); //oppfolgingRepositoryV2.hentAlleBrukerUnderOppfolgingMedTildeltVeileder();
+                    List<AktorId> oppfolgingsBruker = oppfolgingRepositoryV2.hentAlleBrukerUnderOppfolgingMedTildeltVeileder();
                     oppfolgingsBruker.forEach(this::oppdaterTildelingstidspunkt);
 
                     log.info("OppfolgingsJobb: oppdaterte tildelingstidspunkt pa: {} brukere ", oppfolgingsBruker.size());
@@ -87,8 +87,8 @@ public class OppfolgingService {
     public void oppdaterTildelingstidspunkt(AktorId aktorId) {
         try {
             Veilarbportefoljeinfo veialrbinfo = hentVeilarbData(aktorId);
-            if (veialrbinfo.isErUnderOppfolging() && veialrbinfo.getSistTilordnetDato() != null) {
-                oppfolgingRepositoryV2.settTilordningstidspunkt(aktorId, veialrbinfo.getSistTilordnetDato());
+            if (veialrbinfo.isErUnderOppfolging() && veialrbinfo.getTilordnetTidspunkt() != null) {
+                oppfolgingRepositoryV2.settTilordningstidspunkt(aktorId, veialrbinfo.getTilordnetTidspunkt());
             }
 
         }  catch (RuntimeException e) {

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/response/Veilarbportefoljeinfo.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/response/Veilarbportefoljeinfo.java
@@ -17,6 +17,6 @@ public class Veilarbportefoljeinfo {
     private boolean nyForVeileder;
     private boolean erManuell;
     private ZonedDateTime startDato;
-    private ZonedDateTime sistTilordnetDato;
+    private ZonedDateTime tilordnetTidspunkt;
 
 }


### PR DESCRIPTION
Enkel batchjobb som henter tildelingsdato for oppfølging api og populerer databasen. Fungerer fint i dev. 

Tanker er midlertidig kode som skal slettes etter jobben er kjørt (kafka er alt på plass).