### PR TITLE
Formater rettighetstype til lower-case i backend

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/aap/domene/Rettighetstype.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aap/domene/Rettighetstype.kt
@@ -5,5 +5,19 @@ enum class Rettighetstype {
     SYKEPENGEERSTATNING,
     STUDENT,
     ARBEIDSSØKER,
-    VURDERES_FOR_UFØRETRYGD
+    VURDERES_FOR_UFØRETRYGD;
+
+    companion object {
+        fun tilFrontendtekst(rettighetstype: Rettighetstype?): String? {
+            if (rettighetstype == null) return null
+
+            return when (rettighetstype) {
+                BISTANDSBEHOV -> "Bistandsbehov"
+                SYKEPENGEERSTATNING -> "Sykepengeerstatning"
+                STUDENT -> "Student"
+                ARBEIDSSØKER -> "Arbeidssøker"
+                VURDERES_FOR_UFØRETRYGD -> "Vurderes for uføretrygd"
+            }
+        }
+    }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/domene/AapKelvinForBruker.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/domene/AapKelvinForBruker.java
@@ -10,8 +10,8 @@ public record AapKelvinForBruker(
         String rettighetstype
 ) {
     public static AapKelvinForBruker of(LocalDate vedtaksdatoTilOgMed, Rettighetstype rettighetstype) {
-        if(vedtaksdatoTilOgMed != null || rettighetstype != null){
-            return new AapKelvinForBruker(vedtaksdatoTilOgMed, String.valueOf(rettighetstype));
+        if (vedtaksdatoTilOgMed != null || rettighetstype != null) {
+            return new AapKelvinForBruker(vedtaksdatoTilOgMed, Rettighetstype.Companion.tilFrontendtekst(rettighetstype));
         } else {
             return null;
         }

--- a/src/test/java/no/nav/pto/veilarbportefolje/domene/AapKelvinForBrukerTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/domene/AapKelvinForBrukerTest.kt
@@ -1,0 +1,45 @@
+package no.nav.pto.veilarbportefolje.domene
+
+import no.nav.pto.veilarbportefolje.aap.domene.Rettighetstype
+import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import java.time.LocalDate
+
+class AapKelvinForBrukerTest {
+
+    @Test
+    fun `AapKelvinForBruker skal mappe data rett`() {
+        val rettighetstype = Rettighetstype.VURDERES_FOR_UFØRETRYGD
+        val vedtaksdatoTilOgMed = LocalDate.now()
+        val aapKelvinForBruker = AapKelvinForBruker.of(vedtaksdatoTilOgMed, rettighetstype)
+
+        val forventetRettighetstype = "Vurderes for uføretrygd"
+
+        Assertions.assertEquals(forventetRettighetstype, aapKelvinForBruker.rettighetstype())
+        Assertions.assertEquals(vedtaksdatoTilOgMed, aapKelvinForBruker.vedtaksdatoTilOgMed())
+    }
+
+    @Test
+    fun `AapKelvinForBruker skal mappe data rett også om vi mangler et datafelt`() {
+        val rettighetstype = Rettighetstype.VURDERES_FOR_UFØRETRYGD
+        val vedtaksdatoTilOgMed = LocalDate.now()
+        val aapKelvinForBrukerUtenRettighetstype = AapKelvinForBruker.of(vedtaksdatoTilOgMed, null)
+        val aapKelvinForBrukerUtenVedtaksdatoTilOgMed = AapKelvinForBruker.of(null, rettighetstype)
+
+        val forventetRettighetstype = "Vurderes for uføretrygd"
+
+        Assertions.assertEquals(null, aapKelvinForBrukerUtenRettighetstype.rettighetstype())
+        Assertions.assertEquals(vedtaksdatoTilOgMed, aapKelvinForBrukerUtenRettighetstype.vedtaksdatoTilOgMed())
+
+        Assertions.assertEquals(forventetRettighetstype, aapKelvinForBrukerUtenVedtaksdatoTilOgMed.rettighetstype())
+        Assertions.assertEquals(null, aapKelvinForBrukerUtenVedtaksdatoTilOgMed.vedtaksdatoTilOgMed())
+    }
+
+    @Test
+    fun `AapKelvinForBruker skal bli null om det ikke finnes data for vedtaket`() {
+        val aapKelvinForBruker = AapKelvinForBruker.of(null, null)
+
+        Assertions.assertNull(aapKelvinForBruker)
+    }
+
+}


### PR DESCRIPTION
## Describe your changes
Formater rettighetstype til lower-case i backend så vi slepp logikk for dette i frontend.

Rettighetstype er ein streng i `ALL_CAPS`. Vi vil ha ein streng med `Stor forbokstav og resten lowercase og ingen understrekar`. Og teste at det er det vi får. 

Vi vil også i størst mogleg grad slippe å manipulere data i frontend, så 🎉 

## Trello ticket number and link
https://trello.com/c/NdTlYFO7/1334-rydd-litt-i-aap-kelvin-respons-til-frontend

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code

