### PR TITLE
Lese stopp melding

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseService.kt
@@ -93,7 +93,7 @@ class HendelseService(
             }
 
             Kategori.UDELT_SAMTALEREFERAT -> {
-                /** Vi har et trellokort for å implementere hendelsesfilter udelt samtalereferat men det mangler noen tekniske avklaringer
+                /** Vi har et trellokort for å implementere hendelsesfilter udelt samtalereferat men vi venter på noen tekniske avklaringer
                  * https://trello.com/c/wntTp8oG/1099-hendelsesfilter-for-udelte-samtalereferat?filter=udelte
                  */
                 logger.info("Hendelse med id ${hendelse.id} og kategori ${hendelse.kategori} ble lagret i DB")
@@ -131,7 +131,7 @@ class HendelseService(
             }
 
             Kategori.UDELT_SAMTALEREFERAT -> {
-                /** Vi har et trellokort for å implementere hendelsesfilter udelt samtalereferat men det mangler noen tekniske avklaringer
+                /** Vi har et trellokort for å implementere hendelsesfilter udelt samtalereferat men vi venter på noen tekniske avklaringer
                  * https://trello.com/c/wntTp8oG/1099-hendelsesfilter-for-udelte-samtalereferat?filter=udelte
                  */
                 logger.info("Hendelse med id ${hendelse.id} og kategori ${hendelse.kategori} ble oppdatert i DB")
@@ -180,7 +180,7 @@ class HendelseService(
             }
 
             Kategori.UDELT_SAMTALEREFERAT -> {
-                /** Vi har et trellokort for å implementere hendelsesfilter udelt samtalereferat men det mangler noen tekniske avklaringer
+                /** Vi har et trellokort for å implementere hendelsesfilter udelt samtalereferat men vi venter på noen tekniske avklaringer
                  * https://trello.com/c/wntTp8oG/1099-hendelsesfilter-for-udelte-samtalereferat?filter=udelte
                  */
                 logger.info("Hendelse med id ${hendelse.id} og kategori ${hendelse.kategori} ble slettet i DB.")

--- a/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/hendelsesfilter/HendelseService.kt
@@ -86,7 +86,6 @@ class HendelseService(
 
                 if (eldsteUtgattVarselHendelse.id == hendelse.id) {
                     oppdaterUtgattVarselForBrukerIOpenSearch(hendelse)
-
                     logger.info("Hendelse med id ${hendelse.id} og kategori ${Kategori.UTGATT_VARSEL} ble lagret i DB og OpenSearch ble oppdatert med ny eldste utgåtte varsel for person.")
                 } else {
                     logger.info("Hendelse med id ${hendelse.id} og kategori ${Kategori.UTGATT_VARSEL} ble lagret i DB")
@@ -94,6 +93,9 @@ class HendelseService(
             }
 
             Kategori.UDELT_SAMTALEREFERAT -> {
+                /** Vi har et trellokort for å implementere hendelsesfilter udelt samtalereferat men det mangler noen tekniske avklaringer
+                 * https://trello.com/c/wntTp8oG/1099-hendelsesfilter-for-udelte-samtalereferat?filter=udelte
+                 */
                 logger.info("Hendelse med id ${hendelse.id} og kategori ${hendelse.kategori} ble lagret i DB")
             }
         }
@@ -129,6 +131,9 @@ class HendelseService(
             }
 
             Kategori.UDELT_SAMTALEREFERAT -> {
+                /** Vi har et trellokort for å implementere hendelsesfilter udelt samtalereferat men det mangler noen tekniske avklaringer
+                 * https://trello.com/c/wntTp8oG/1099-hendelsesfilter-for-udelte-samtalereferat?filter=udelte
+                 */
                 logger.info("Hendelse med id ${hendelse.id} og kategori ${hendelse.kategori} ble oppdatert i DB")
             }
         }
@@ -170,12 +175,14 @@ class HendelseService(
 
                 if (resultatAvGetEldsteUtgattVarselHendelse is Hendelse) {
                     oppdaterUtgattVarselForBrukerIOpenSearch(resultatAvGetEldsteUtgattVarselHendelse)
-
                     logger.info("Hendelse med id ${hendelse.id}  og kategori ${Kategori.UTGATT_VARSEL} ble slettet i DB og OpenSearch ble oppdatert med ny eldste utgåtte varsel for person, med id ${resultatAvGetEldsteUtgattVarselHendelse.id}")
                 }
             }
 
             Kategori.UDELT_SAMTALEREFERAT -> {
+                /** Vi har et trellokort for å implementere hendelsesfilter udelt samtalereferat men det mangler noen tekniske avklaringer
+                 * https://trello.com/c/wntTp8oG/1099-hendelsesfilter-for-udelte-samtalereferat?filter=udelte
+                 */
                 logger.info("Hendelse med id ${hendelse.id} og kategori ${hendelse.kategori} ble slettet i DB.")
             }
         }

--- a/src/test/java/no/nav/pto/veilarbportefolje/util/EndToEndTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/util/EndToEndTest.java
@@ -93,6 +93,10 @@ public abstract class EndToEndTest {
         oppfolgingRepositoryV2.settUnderOppfolging(aktorId, ZonedDateTime.now());
     }
 
+    public void slettOppfolgingsInformasjon(AktorId aktorId) {
+        oppfolgingRepositoryV2.slettOppfolgingData(aktorId);
+    }
+
     @SneakyThrows
     public static void verifiserAsynkront(long timeout, TimeUnit unit, Runnable verifiser) {
         long timeoutMillis = unit.toMillis(timeout);


### PR DESCRIPTION
## Oppdatert tester til HendelseService
I denne PRen har vi oppdatert en test som tester hendelsen (Utgått varsel, udelt samtalereferat) skal slettes uavhengig av bruker under oppfølging når veilarbportefolje mottar STOPP hendelsen fra team DAB. 

## [Trello ticket number and link](https://trello.com/c/SXus2YFm/1322-lese-avslutt-meldingar-sj%C3%B8lv-om-person-ikkje-er-under-oppf%C3%B8lging)



## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
