### PR TITLE
Legg til støtte for datotid uten tidssone

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/util/DateUtils.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/util/DateUtils.java
@@ -7,6 +7,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalField;
 import java.time.temporal.WeekFields;
@@ -168,7 +169,11 @@ public class DateUtils {
         if (date == null) {
             return null;
         }
-        return LocalDateTime.ofInstant(Instant.parse(date), ZoneId.systemDefault());
+        try {
+            return LocalDateTime.ofInstant(Instant.parse(date), ZoneId.systemDefault());
+        } catch (DateTimeParseException e) {
+            return LocalDateTime.parse(date);
+        }
     }
 
     public static LocalDateTime toLocalDateTimeOrNull(Timestamp date) {

--- a/src/test/java/no/nav/pto/veilarbportefolje/util/DateUtilsTest.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/util/DateUtilsTest.java
@@ -187,4 +187,30 @@ public class DateUtilsTest {
     public void skalLageFodselsdatoStringPaaUTCFormat() {
         assertThat(DateUtils.lagFodselsdato(fodselsdato)).isEqualTo("1980-10-10T00:00:00Z");
     }
+
+    @Test
+    public void toLocalDateTimeOrNull_isoInstantFormat() {
+        LocalDateTime result = DateUtils.toLocalDateTimeOrNull("2022-09-28T12:23:36Z");
+        assertThat(result).isNotNull();
+        assertThat(result.getYear()).isEqualTo(2022);
+        assertThat(result.getMonthValue()).isEqualTo(9);
+        assertThat(result.getDayOfMonth()).isEqualTo(28);
+    }
+
+    @Test
+    public void toLocalDateTimeOrNull_localDateTimeFormat() {
+        LocalDateTime result = DateUtils.toLocalDateTimeOrNull("2022-09-28T12:23:36");
+        assertThat(result).isNotNull();
+        assertThat(result.getYear()).isEqualTo(2022);
+        assertThat(result.getMonthValue()).isEqualTo(9);
+        assertThat(result.getDayOfMonth()).isEqualTo(28);
+        assertThat(result.getHour()).isEqualTo(12);
+        assertThat(result.getMinute()).isEqualTo(23);
+        assertThat(result.getSecond()).isEqualTo(36);
+    }
+
+    @Test
+    public void toLocalDateTimeOrNull_nullReturnsNull() {
+        assertThat(DateUtils.toLocalDateTimeOrNull((String) null)).isNull();
+    }
 }


### PR DESCRIPTION
Parsing av datotid feiler når vi prøver å lage en instant fordi det ikke har tidssone. I de tilfellene parser vi bare datoen istedenfor å lage en instant