### PR TITLE
Lese aktiviteter nytt format

### DIFF
--- a/.nais/application/application-config-dev.yaml
+++ b/.nais/application/application-config-dev.yaml
@@ -9,8 +9,8 @@ metadata:
 spec:
   image: {{image}}
   replicas:
-    min: 1
-    max: 3
+    min: 4
+    max: 4
     cpuThresholdPercentage: 50
   port: 8080
   ingresses:
@@ -171,4 +171,3 @@ spec:
       value: "http://dp-datadeling.teamdagpenger"
     - name: DAGPENGER_SCOPE
       value: "api://dev-gcp.teamdagpenger.dp-datadeling/.default"
-

--- a/.nais/application/application-config-prod.yaml
+++ b/.nais/application/application-config-prod.yaml
@@ -9,8 +9,8 @@ metadata:
 spec:
   image: {{image}}
   replicas:
-    min: 3
-    max: 3
+    min: 4
+    max: 4
     cpuThresholdPercentage: 50
   port: 8080
   ingresses:

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,10 @@
         <!-- Kafka -->
 
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>8.1.0</version>

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
@@ -22,15 +22,11 @@ import org.springframework.kafka.listener.RetryListener
 import org.springframework.util.backoff.ExponentialBackOff
 
 /**
- * Setter opp Spring Kafka for batch-konsumering av aktivitet-meldinger.
- *
  * Nøkkelvalg:
- * - concurrency=1: Én tråd prosesserer alle partisjoner sekvensielt → garantert rekkefølge.
- * - batchListener=true: Spring samler opp meldinger fra én poll() og sender dem som en liste.
- * - AckMode.BATCH: Spring committer offsets automatisk etter at listener-metoden returnerer uten feil.
- * - autoStartup=false: Consumeren starter ikke automatisk — styres av Unleash-toggle i PortefoljeAktivitetKafkaConsumer.
- * - DefaultErrorHandler med ExponentialBackOff: Ved feil vert batchen forsøkt på nytt med aukande
- *   ventetid (0.5s → 1s → 2s → ... maks 60s). Etter 15 minutt utan suksess stoppar containeren.
+ * - concurrency=1: Garanterer rekkefølge — éin tråd prosesserer alle partisjonar sekvensielt.
+ * - autoStartup=false: Consumeren styres av Unleash-toggle i [PortefoljeAktivitetKafkaConsumer].
+ * - DefaultErrorHandler med ExponentialBackOff: Ved vedvarande feil, retry med aukande ventetid
+ *   (0.5s → 1s → 2s → ... maks 60s). Etter 15 minutt stoppar containeren.
  *   Offsets vert ALDRI committa for feila meldingar — dei vert konsumerte på nytt ved restart.
  */
 @Configuration
@@ -75,15 +71,9 @@ class PortefoljeAktivitetKafkaConfig {
         }
 
     /**
-     * Retry med exponential back-off → stopp container.
-     *
-     * Flyt ved vedvarande feil:
-     * 1. Batch feilar → vent 0.5s → retry
-     * 2. Feilar igjen → vent 1s → retry
-     * 3. Feilar igjen → vent 2s → retry → ... (maks 60s mellom forsøk)
-     * 4. Etter 15 minutt totalt → recoverer kastar exception → containeren stoppar
-     * 5. Offsets er IKKJE committa
-     * 6. sjekkToggle() kan restarte containeren (meldingane vert konsumerte på nytt)
+     * Ved vedvarande feil: retry med exponential back-off, deretter stopp container.
+     * Recoverer kastar exception i staden for å hoppe over meldingar — dette sikrar at
+     * offsets aldri vert committa for feila meldingar.
      */
     private fun batchErrorHandler(): DefaultErrorHandler {
         val backOff = ExponentialBackOff().apply {
@@ -93,8 +83,7 @@ class PortefoljeAktivitetKafkaConfig {
             maxElapsedTime = 15 * 60 * 1_000L
         }
 
-        // Når alle retry-forsøk er brukte opp: kast exception slik at containeren stoppar.
-        // Dette sikrar at offsets ALDRI vert committa for feila meldingar.
+        // Kast exception for å stoppe containeren — ikkje hopp over meldingar
         val stopContainerRecoverer = ConsumerRecordRecoverer { _, exception ->
             log.error(
                 "Alle retry-forsøk brukte opp — stoppar container. Offsets er ikkje committa. Feiltype: {}",
@@ -109,9 +98,6 @@ class PortefoljeAktivitetKafkaConfig {
         }
     }
 
-    /**
-     * Loggar kvart retry-forsøk slik at det er synleg i loggane kva som skjer.
-     */
     private class RetryLogger : RetryListener {
         override fun failedDelivery(
             record: ConsumerRecord<*, *>,

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
@@ -20,13 +20,14 @@ import org.springframework.kafka.listener.ContainerProperties
 import org.springframework.kafka.listener.DefaultErrorHandler
 import org.springframework.kafka.listener.RetryListener
 import org.springframework.util.backoff.ExponentialBackOff
+import java.time.Duration
 
 /**
  * Nøkkelvalg:
  * - concurrency=1: Garanterer rekkefølge — éin tråd prosesserer alle partisjonar sekvensielt.
  * - autoStartup=false: Consumeren styres av Unleash-toggle i [PortefoljeAktivitetKafkaConsumer].
  * - DefaultErrorHandler med ExponentialBackOff: Ved vedvarande feil, retry med aukande ventetid
- *   (0.5s → 1s → 2s → ... maks 60s) heilt til batchen lykkast.
+ *   (0.5s → 1s → 2s → ... maks 10 minutt) heilt til batchen lykkast.
  *   Offsets vert ALDRI committa for feila meldingar.
  */
 @Configuration
@@ -76,10 +77,10 @@ class PortefoljeAktivitetKafkaConfig {
      */
     private fun batchErrorHandler(): DefaultErrorHandler {
         val backOff = ExponentialBackOff().apply {
-            initialInterval = 500L
-            multiplier = 2.0
-            maxInterval = 60_000L
-            maxElapsedTime = Long.MAX_VALUE
+            initialInterval = HALVT_SEKUND
+            multiplier = DOBLING
+            maxInterval = TI_MINUTT
+            maxElapsedTime = UENDELEG_TID
         }
 
         // Skal i praksis ikkje kallast med Long.MAX_VALUE, men hindrar offset-skip dersom back-off stoppar.
@@ -109,5 +110,9 @@ class PortefoljeAktivitetKafkaConfig {
 
     private companion object {
         private val log = LoggerFactory.getLogger(PortefoljeAktivitetKafkaConfig::class.java)
+        private val HALVT_SEKUND = Duration.ofMillis(500).toMillis()
+        private const val DOBLING = 2.0
+        private val TI_MINUTT = Duration.ofMinutes(10).toMillis()
+        private const val UENDELEG_TID = Long.MAX_VALUE
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
@@ -26,8 +26,8 @@ import org.springframework.util.backoff.ExponentialBackOff
  * - concurrency=1: Garanterer rekkefølge — éin tråd prosesserer alle partisjonar sekvensielt.
  * - autoStartup=false: Consumeren styres av Unleash-toggle i [PortefoljeAktivitetKafkaConsumer].
  * - DefaultErrorHandler med ExponentialBackOff: Ved vedvarande feil, retry med aukande ventetid
- *   (0.5s → 1s → 2s → ... maks 60s). Etter 15 minutt stoppar containeren.
- *   Offsets vert ALDRI committa for feila meldingar — dei vert konsumerte på nytt ved restart.
+ *   (0.5s → 1s → 2s → ... maks 60s) heilt til batchen lykkast.
+ *   Offsets vert ALDRI committa for feila meldingar.
  */
 @Configuration
 @EnableKafka
@@ -71,29 +71,28 @@ class PortefoljeAktivitetKafkaConfig {
         }
 
     /**
-     * Ved vedvarande feil: retry med exponential back-off, deretter stopp container.
-     * Recoverer kastar exception i staden for å hoppe over meldingar — dette sikrar at
-     * offsets aldri vert committa for feila meldingar.
+     * Ved vedvarande feil: retry med capped exponential back-off utan å stoppe containeren.
+     * Då kan ikkje feature-toggle-sjekken restarte containeren og starte ein ny retry-syklus.
      */
     private fun batchErrorHandler(): DefaultErrorHandler {
         val backOff = ExponentialBackOff().apply {
             initialInterval = 500L
             multiplier = 2.0
             maxInterval = 60_000L
-            maxElapsedTime = 15 * 60 * 1_000L
+            maxElapsedTime = Long.MAX_VALUE
         }
 
-        // Kast exception for å stoppe containeren — ikkje hopp over meldingar
-        val stopContainerRecoverer = ConsumerRecordRecoverer { _, exception ->
+        // Skal i praksis ikkje kallast med Long.MAX_VALUE, men hindrar offset-skip dersom back-off stoppar.
+        val failIfBackOffStopsRecoverer = ConsumerRecordRecoverer { _, exception ->
             log.error(
-                "Alle retry-forsøk brukte opp — stoppar container. Offsets er ikkje committa. Feiltype: {}",
+                "Back-off stoppa uventa. Offsets er ikkje committa. Feiltype: {}",
                 exception.javaClass.name
             )
             throw exception
         }
 
-        return DefaultErrorHandler(stopContainerRecoverer, backOff).apply {
-            setLogLevel(KafkaException.Level.ERROR)
+        return DefaultErrorHandler(failIfBackOffStopsRecoverer, backOff).apply {
+            setLogLevel(KafkaException.Level.DEBUG)
             setRetryListeners(RetryLogger())
         }
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
@@ -8,11 +8,13 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.slf4j.LoggerFactory
+import org.springframework.core.task.SimpleAsyncTaskExecutor
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.KafkaException
 import org.springframework.kafka.annotation.EnableKafka
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry
 import org.springframework.kafka.core.ConsumerFactory
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
 import org.springframework.kafka.listener.ConsumerRecordRecoverer
@@ -27,7 +29,7 @@ import java.time.Duration
  * - concurrency=1: Garanterer rekkefølge — éin tråd prosesserer alle partisjonar sekvensielt.
  * - autoStartup=false: Consumeren styres av Unleash-toggle i [PortefoljeAktivitetKafkaConsumer].
  * - DefaultErrorHandler med ExponentialBackOff: Ved vedvarande feil, retry med aukande ventetid
- *   (10s → 20s → 40s → ... maks 1 time) heilt til batchen lykkast.
+ *   (10s → 20s → 40s → ... maks 1 time) i inntil 1 time før containeren stoppar.
  *   Offsets vert ALDRI committa for feila meldingar.
  */
 @Configuration
@@ -61,6 +63,8 @@ class PortefoljeAktivitetKafkaConfig {
     @Bean
     fun portefoljeAktivitetKafkaListenerContainerFactory(
         portefoljeAktivitetConsumerFactory: ConsumerFactory<String, PortefoljeAktivitetKafkaMelding>,
+        registry: KafkaListenerEndpointRegistry,
+        consumerState: PortefoljeAktivitetKafkaConsumerState,
     ): ConcurrentKafkaListenerContainerFactory<String, PortefoljeAktivitetKafkaMelding> =
         ConcurrentKafkaListenerContainerFactory<String, PortefoljeAktivitetKafkaMelding>().apply {
             setConsumerFactory(portefoljeAktivitetConsumerFactory)
@@ -68,31 +72,38 @@ class PortefoljeAktivitetKafkaConfig {
             setBatchListener(true)
             containerProperties.ackMode = ContainerProperties.AckMode.BATCH
             setAutoStartup(false)
-            setCommonErrorHandler(batchErrorHandler())
+            setCommonErrorHandler(batchErrorHandler(registry, consumerState))
         }
 
     /**
-     * Ved vedvarande feil: retry med capped exponential back-off utan å stoppe containeren.
-     * Då kan ikkje feature-toggle-sjekken restarte containeren og starte ein ny retry-syklus.
+     * Ved vedvarande feil: retry med capped exponential back-off før containeren stoppar.
+     * Feilstopp-state hindrar at feature-toggle-sjekken startar consumeren på nytt automatisk.
      */
-    private fun batchErrorHandler(): DefaultErrorHandler {
+    private fun batchErrorHandler(
+        registry: KafkaListenerEndpointRegistry,
+        consumerState: PortefoljeAktivitetKafkaConsumerState,
+    ): DefaultErrorHandler {
         val backOff = ExponentialBackOff().apply {
             initialInterval = TI_SEKUND
             multiplier = DOBLING
             maxInterval = EIN_TIME
-            maxElapsedTime = UENDELEG_TID
+            maxElapsedTime = EIN_TIME
         }
 
-        // Skal i praksis ikkje kallast med Long.MAX_VALUE, men hindrar offset-skip dersom back-off stoppar.
-        val failIfBackOffStopsRecoverer = ConsumerRecordRecoverer { _, exception ->
+        // Stopp containeren i staden for å recovere/skippa meldingar når back-off er brukt opp.
+        val stopContainerRecoverer = ConsumerRecordRecoverer { _, exception ->
+            consumerState.markerStoppetPaaGrunnAvVedvarendeFeil()
             log.error(
-                "Back-off stoppa uventa. Offsets er ikkje committa. Feiltype: {}",
+                "Back-off brukt opp — stoppar container. Offsets er ikkje committa. Feiltype: {}",
                 exception.javaClass.name
             )
+            CONTAINER_STOP_EXECUTOR.execute {
+                registry.getListenerContainer(PORTEFOLJE_AKTIVITET_CONTAINER_ID)?.stop()
+            }
             throw exception
         }
 
-        return DefaultErrorHandler(failIfBackOffStopsRecoverer, backOff).apply {
+        return DefaultErrorHandler(stopContainerRecoverer, backOff).apply {
             setLogLevel(KafkaException.Level.DEBUG)
             setRetryListeners(RetryLogger())
         }
@@ -110,9 +121,9 @@ class PortefoljeAktivitetKafkaConfig {
 
     private companion object {
         private val log = LoggerFactory.getLogger(PortefoljeAktivitetKafkaConfig::class.java)
+        private val CONTAINER_STOP_EXECUTOR = SimpleAsyncTaskExecutor("portefolje-aktivitet-container-stop-")
         private val TI_SEKUND = Duration.ofSeconds(10).toMillis()
         private const val DOBLING = 2.0
         private val EIN_TIME = Duration.ofHours(1).toMillis()
-        private const val UENDELEG_TID = Long.MAX_VALUE
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
@@ -26,7 +26,7 @@ import java.time.Duration
 
 /**
  * Nøkkelvalg:
- * - concurrency=1: Garanterer rekkefølge — éin tråd prosesserer alle partisjonar sekvensielt.
+ * - concurrency=1: Garanterer rekkefølge — éin tråd prosesserer alle partisjonar (som consumeren får tildelt) sekvensielt.
  * - autoStartup=false: Consumeren styres av Unleash-toggle i [PortefoljeAktivitetKafkaConsumer].
  * - DefaultErrorHandler med ExponentialBackOff: Ved vedvarande feil, retry med aukande ventetid
  *   (10s → 20s → 40s → ... maks 1 time) i inntil 1 time før containeren stoppar.

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
@@ -1,0 +1,66 @@
+package no.nav.pto.veilarbportefolje.aktiviteter.v1
+
+import no.nav.common.kafka.consumer.util.deserializer.Deserializers
+import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.config.SslConfigs
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.listener.ContainerProperties
+
+/**
+ * Setter opp Spring Kafka for batch-konsumering av aktivitet-meldinger.
+ *
+ * Nøkkelvalg:
+ * - concurrency=1: Én tråd prosesserer alle partisjoner sekvensielt → garantert rekkefølge.
+ * - batchListener=true: Spring samler opp meldinger fra én poll() og sender dem som en liste.
+ * - AckMode.BATCH: Spring committer offsets automatisk etter at listener-metoden returnerer uten feil.
+ * - autoStartup=false: Consumeren starter ikke automatisk — styres av Unleash-toggle i PortefoljeAktivitetKafkaConsumer.
+ */
+@Configuration
+@EnableKafka
+class PortefoljeAktivitetKafkaConfig {
+
+    @Bean
+    fun portefoljeAktivitetConsumerFactory(): ConsumerFactory<String, PortefoljeAktivitetKafkaMelding> {
+        val credstorePassword = getRequiredProperty("KAFKA_CREDSTORE_PASSWORD")
+
+        val props = mapOf<String, Any>(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to getRequiredProperty("KAFKA_BROKERS"),
+            ConsumerConfig.GROUP_ID_CONFIG to "veilarbportefolje-portefolje-aktivitet-consumer",
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
+            ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
+            ConsumerConfig.MAX_POLL_RECORDS_CONFIG to 200,
+            CommonClientConfigs.SECURITY_PROTOCOL_CONFIG to "SSL",
+            SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG to getRequiredProperty("KAFKA_TRUSTSTORE_PATH"),
+            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG to credstorePassword,
+            SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG to getRequiredProperty("KAFKA_KEYSTORE_PATH"),
+            SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG to credstorePassword,
+            SslConfigs.SSL_KEY_PASSWORD_CONFIG to credstorePassword,
+        )
+
+        return DefaultKafkaConsumerFactory(
+            props,
+            StringDeserializer(),
+            Deserializers.jsonDeserializer(PortefoljeAktivitetKafkaMelding::class.java),
+        )
+    }
+
+    @Bean
+    fun portefoljeAktivitetKafkaListenerContainerFactory(
+        portefoljeAktivitetConsumerFactory: ConsumerFactory<String, PortefoljeAktivitetKafkaMelding>,
+    ): ConcurrentKafkaListenerContainerFactory<String, PortefoljeAktivitetKafkaMelding> =
+        ConcurrentKafkaListenerContainerFactory<String, PortefoljeAktivitetKafkaMelding>().apply {
+            setConsumerFactory(portefoljeAktivitetConsumerFactory)
+            setConcurrency(1)
+            setBatchListener(true)
+            containerProperties.ackMode = ContainerProperties.AckMode.BATCH
+            setAutoStartup(false)
+        }
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
@@ -27,7 +27,7 @@ import java.time.Duration
  * - concurrency=1: Garanterer rekkefølge — éin tråd prosesserer alle partisjonar sekvensielt.
  * - autoStartup=false: Consumeren styres av Unleash-toggle i [PortefoljeAktivitetKafkaConsumer].
  * - DefaultErrorHandler med ExponentialBackOff: Ved vedvarande feil, retry med aukande ventetid
- *   (0.5s → 1s → 2s → ... maks 10 minutt) heilt til batchen lykkast.
+ *   (10s → 20s → 40s → ... maks 1 time) heilt til batchen lykkast.
  *   Offsets vert ALDRI committa for feila meldingar.
  */
 @Configuration
@@ -77,9 +77,9 @@ class PortefoljeAktivitetKafkaConfig {
      */
     private fun batchErrorHandler(): DefaultErrorHandler {
         val backOff = ExponentialBackOff().apply {
-            initialInterval = HALVT_SEKUND
+            initialInterval = TI_SEKUND
             multiplier = DOBLING
-            maxInterval = TI_MINUTT
+            maxInterval = EIN_TIME
             maxElapsedTime = UENDELEG_TID
         }
 
@@ -110,9 +110,9 @@ class PortefoljeAktivitetKafkaConfig {
 
     private companion object {
         private val log = LoggerFactory.getLogger(PortefoljeAktivitetKafkaConfig::class.java)
-        private val HALVT_SEKUND = Duration.ofMillis(500).toMillis()
+        private val TI_SEKUND = Duration.ofSeconds(10).toMillis()
         private const val DOBLING = 2.0
-        private val TI_MINUTT = Duration.ofMinutes(10).toMillis()
+        private val EIN_TIME = Duration.ofHours(1).toMillis()
         private const val UENDELEG_TID = Long.MAX_VALUE
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
@@ -33,7 +33,6 @@ class PortefoljeAktivitetKafkaConfig {
 
         val props = mapOf<String, Any>(
             ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to getRequiredProperty("KAFKA_BROKERS"),
-            ConsumerConfig.GROUP_ID_CONFIG to "veilarbportefolje-portefolje-aktivitet-consumer",
             ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
             ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG to false,
             ConsumerConfig.MAX_POLL_RECORDS_CONFIG to 200,

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConfig.kt
@@ -4,15 +4,22 @@ import no.nav.common.kafka.consumer.util.deserializer.Deserializers
 import no.nav.common.utils.EnvironmentUtils.getRequiredProperty
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.serialization.StringDeserializer
+import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.KafkaException
 import org.springframework.kafka.annotation.EnableKafka
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
 import org.springframework.kafka.core.ConsumerFactory
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.listener.ConsumerRecordRecoverer
 import org.springframework.kafka.listener.ContainerProperties
+import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.kafka.listener.RetryListener
+import org.springframework.util.backoff.ExponentialBackOff
 
 /**
  * Setter opp Spring Kafka for batch-konsumering av aktivitet-meldinger.
@@ -22,6 +29,9 @@ import org.springframework.kafka.listener.ContainerProperties
  * - batchListener=true: Spring samler opp meldinger fra én poll() og sender dem som en liste.
  * - AckMode.BATCH: Spring committer offsets automatisk etter at listener-metoden returnerer uten feil.
  * - autoStartup=false: Consumeren starter ikke automatisk — styres av Unleash-toggle i PortefoljeAktivitetKafkaConsumer.
+ * - DefaultErrorHandler med ExponentialBackOff: Ved feil vert batchen forsøkt på nytt med aukande
+ *   ventetid (0.5s → 1s → 2s → ... maks 60s). Etter 15 minutt utan suksess stoppar containeren.
+ *   Offsets vert ALDRI committa for feila meldingar — dei vert konsumerte på nytt ved restart.
  */
 @Configuration
 @EnableKafka
@@ -61,5 +71,58 @@ class PortefoljeAktivitetKafkaConfig {
             setBatchListener(true)
             containerProperties.ackMode = ContainerProperties.AckMode.BATCH
             setAutoStartup(false)
+            setCommonErrorHandler(batchErrorHandler())
         }
+
+    /**
+     * Retry med exponential back-off → stopp container.
+     *
+     * Flyt ved vedvarande feil:
+     * 1. Batch feilar → vent 0.5s → retry
+     * 2. Feilar igjen → vent 1s → retry
+     * 3. Feilar igjen → vent 2s → retry → ... (maks 60s mellom forsøk)
+     * 4. Etter 15 minutt totalt → recoverer kastar exception → containeren stoppar
+     * 5. Offsets er IKKJE committa
+     * 6. sjekkToggle() kan restarte containeren (meldingane vert konsumerte på nytt)
+     */
+    private fun batchErrorHandler(): DefaultErrorHandler {
+        val backOff = ExponentialBackOff().apply {
+            initialInterval = 500L
+            multiplier = 2.0
+            maxInterval = 60_000L
+            maxElapsedTime = 15 * 60 * 1_000L
+        }
+
+        // Når alle retry-forsøk er brukte opp: kast exception slik at containeren stoppar.
+        // Dette sikrar at offsets ALDRI vert committa for feila meldingar.
+        val stopContainerRecoverer = ConsumerRecordRecoverer { _, exception ->
+            log.error(
+                "Alle retry-forsøk brukte opp — stoppar container. Offsets er ikkje committa. Feiltype: {}",
+                exception.javaClass.name
+            )
+            throw exception
+        }
+
+        return DefaultErrorHandler(stopContainerRecoverer, backOff).apply {
+            setLogLevel(KafkaException.Level.ERROR)
+            setRetryListeners(RetryLogger())
+        }
+    }
+
+    /**
+     * Loggar kvart retry-forsøk slik at det er synleg i loggane kva som skjer.
+     */
+    private class RetryLogger : RetryListener {
+        override fun failedDelivery(
+            record: ConsumerRecord<*, *>,
+            ex: Exception?,
+            deliveryAttempt: Int
+        ) {
+            log.warn("Retry-forsøk {} feilar. Feiltype: {}", deliveryAttempt, ex?.javaClass?.name)
+        }
+    }
+
+    private companion object {
+        private val log = LoggerFactory.getLogger(PortefoljeAktivitetKafkaConfig::class.java)
+    }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConsumer.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConsumer.kt
@@ -1,0 +1,69 @@
+package no.nav.pto.veilarbportefolje.aktiviteter.v1
+
+import io.getunleash.DefaultUnleash
+import no.nav.pto.veilarbportefolje.config.FeatureToggle
+import no.nav.pto.veilarbportefolje.kafka.unleash.KafkaAivenUnleash
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+/**
+ * Batch-consumer for aktivitet-meldinger fra Kafka.
+ *
+ * Hvordan dette fungerer:
+ * 1. Spring Kafka poller Kafka i bakgrunnen og samler opp meldinger.
+ * 2. Når det finnes meldinger, kaller Spring [onBatch] med alle meldinger fra én poll().
+ * 3. Vi prosesserer hele batchen i én transaksjon via [PortefoljeAktivitetKafkaMeldingService].
+ * 4. Hvis [onBatch] returnerer uten feil, committer Spring offsets automatisk (AckMode.BATCH).
+ *    Hvis [onBatch] kaster exception, committer Spring IKKE — meldingene vil bli levert på nytt.
+ * 5. [sjekkToggle] kjører hvert 30. sekund og starter/stopper consumeren basert på Unleash-toggles.
+ */
+@Component
+class PortefoljeAktivitetKafkaConsumer(
+    private val aktivitetKafkaMeldingService: PortefoljeAktivitetKafkaMeldingService,
+    private val registry: KafkaListenerEndpointRegistry,
+    private val defaultUnleash: DefaultUnleash,
+) {
+    private val kafkaAivenUnleash = KafkaAivenUnleash(defaultUnleash)
+
+    @KafkaListener(
+        id = CONTAINER_ID,
+        topics = [AKTIVITET_TOPIC],
+        containerFactory = "portefoljeAktivitetKafkaListenerContainerFactory",
+    )
+    fun onBatch(records: List<ConsumerRecord<String, PortefoljeAktivitetKafkaMelding>>) {
+        log.info(
+            "Mottok batch med {} meldinger fra topic {} (partitions: {}).",
+            records.size,
+            AKTIVITET_TOPIC,
+            records.map { it.partition() }.distinct().sorted(),
+        )
+
+        aktivitetKafkaMeldingService.behandleKafkaRecords(records)
+    }
+
+    @Scheduled(fixedDelay = 30_000, initialDelay = 5_000)
+    fun sjekkToggle() {
+        val container = registry.getListenerContainer(CONTAINER_ID) ?: return
+
+        if (skalKonsumere() && !container.isRunning) {
+            log.info("Starter aktivitet-consumer (toggle er på).")
+            container.start()
+        } else if (!skalKonsumere() && container.isRunning) {
+            log.info("Stopper aktivitet-consumer (toggle er av).")
+            container.stop()
+        }
+    }
+
+    private fun skalKonsumere(): Boolean =
+        defaultUnleash.isEnabled(FeatureToggle.KAFKA_PORTEFOLJE_AKTIVITET_V1_START) && !kafkaAivenUnleash.get()
+
+    private companion object {
+        private val log = LoggerFactory.getLogger(PortefoljeAktivitetKafkaConsumer::class.java)
+        private const val CONTAINER_ID = "portefolje-aktivitet-consumer"
+        const val AKTIVITET_TOPIC = "pto.aktivitet-portefolje-v1"
+    }
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConsumer.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConsumer.kt
@@ -31,6 +31,8 @@ class PortefoljeAktivitetKafkaConsumer(
 
     @KafkaListener(
         id = CONTAINER_ID,
+        idIsGroup = false,
+        groupId = CONSUMER_GROUP_ID,
         topics = [AKTIVITET_TOPIC],
         containerFactory = "portefoljeAktivitetKafkaListenerContainerFactory",
     )
@@ -64,6 +66,7 @@ class PortefoljeAktivitetKafkaConsumer(
     private companion object {
         private val log = LoggerFactory.getLogger(PortefoljeAktivitetKafkaConsumer::class.java)
         private const val CONTAINER_ID = "portefolje-aktivitet-consumer"
+        private const val CONSUMER_GROUP_ID = "veilarbportefolje-portefolje-aktivitet-consumer"
         const val AKTIVITET_TOPIC = "pto.aktivitet-portefolje-v1"
     }
 }

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConsumer.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConsumer.kt
@@ -13,13 +13,8 @@ import org.springframework.stereotype.Component
 /**
  * Batch-consumer for aktivitet-meldinger fra Kafka.
  *
- * Hvordan dette fungerer:
- * 1. Spring Kafka poller Kafka i bakgrunnen og samler opp meldinger.
- * 2. Når det finnes meldinger, kaller Spring [onBatch] med alle meldinger fra én poll().
- * 3. Vi prosesserer hele batchen i én transaksjon via [PortefoljeAktivitetKafkaMeldingService].
- * 4. Hvis [onBatch] returnerer uten feil, committer Spring offsets automatisk (AckMode.BATCH).
- *    Hvis [onBatch] kaster exception, committer Spring IKKE — meldingene vil bli levert på nytt.
- * 5. [sjekkToggle] kjører hvert 30. sekund og starter/stopper consumeren basert på Unleash-toggles.
+ * Consumeren styres av Unleash-toggles via [sjekkToggle], som køyrer kvart 30. sekund.
+ * autoStartup=false i config gjer at consumeren ikkje startar før togglen er på.
  */
 @Component
 class PortefoljeAktivitetKafkaConsumer(

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConsumer.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConsumer.kt
@@ -10,6 +10,8 @@ import org.springframework.kafka.config.KafkaListenerEndpointRegistry
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
+const val PORTEFOLJE_AKTIVITET_CONTAINER_ID = "portefolje-aktivitet-consumer"
+
 /**
  * Batch-consumer for aktivitet-meldinger fra Kafka.
  *
@@ -21,11 +23,12 @@ class PortefoljeAktivitetKafkaConsumer(
     private val aktivitetKafkaMeldingService: PortefoljeAktivitetKafkaMeldingService,
     private val registry: KafkaListenerEndpointRegistry,
     private val defaultUnleash: DefaultUnleash,
+    private val consumerState: PortefoljeAktivitetKafkaConsumerState,
 ) {
     private val kafkaAivenUnleash = KafkaAivenUnleash(defaultUnleash)
 
     @KafkaListener(
-        id = CONTAINER_ID,
+        id = PORTEFOLJE_AKTIVITET_CONTAINER_ID,
         idIsGroup = false,
         groupId = CONSUMER_GROUP_ID,
         topics = [AKTIVITET_TOPIC],
@@ -44,14 +47,24 @@ class PortefoljeAktivitetKafkaConsumer(
 
     @Scheduled(fixedDelay = 30_000, initialDelay = 5_000)
     fun sjekkToggle() {
-        val container = registry.getListenerContainer(CONTAINER_ID) ?: return
+        val container = registry.getListenerContainer(PORTEFOLJE_AKTIVITET_CONTAINER_ID) ?: return
 
-        if (skalKonsumere() && !container.isRunning) {
+        if (!skalKonsumere()) {
+            consumerState.nullstillFeilstopp()
+            if (container.isRunning) {
+                log.info("Stopper aktivitet-consumer (toggle er av).")
+                container.stop()
+            }
+            return
+        }
+
+        if (consumerState.erStoppetPaaGrunnAvVedvarendeFeil()) {
+            return
+        }
+
+        if (!container.isRunning) {
             log.info("Starter aktivitet-consumer (toggle er på).")
             container.start()
-        } else if (!skalKonsumere() && container.isRunning) {
-            log.info("Stopper aktivitet-consumer (toggle er av).")
-            container.stop()
         }
     }
 
@@ -60,7 +73,6 @@ class PortefoljeAktivitetKafkaConsumer(
 
     private companion object {
         private val log = LoggerFactory.getLogger(PortefoljeAktivitetKafkaConsumer::class.java)
-        private const val CONTAINER_ID = "portefolje-aktivitet-consumer"
         private const val CONSUMER_GROUP_ID = "veilarbportefolje-portefolje-aktivitet-consumer"
         const val AKTIVITET_TOPIC = "pto.aktivitet-portefolje-v1"
     }

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConsumerState.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaConsumerState.kt
@@ -1,0 +1,20 @@
+package no.nav.pto.veilarbportefolje.aktiviteter.v1
+
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Component
+class PortefoljeAktivitetKafkaConsumerState {
+    private val stoppetPaaGrunnAvVedvarendeFeil = AtomicBoolean(false)
+
+    fun markerStoppetPaaGrunnAvVedvarendeFeil() {
+        stoppetPaaGrunnAvVedvarendeFeil.set(true)
+    }
+
+    fun nullstillFeilstopp() {
+        stoppetPaaGrunnAvVedvarendeFeil.set(false)
+    }
+
+    fun erStoppetPaaGrunnAvVedvarendeFeil(): Boolean =
+        stoppetPaaGrunnAvVedvarendeFeil.get()
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMelding.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMelding.kt
@@ -1,0 +1,153 @@
+package no.nav.pto.veilarbportefolje.aktiviteter.v1
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import no.nav.pto.veilarbportefolje.kafka.KafkaMeldingMedMetadata
+import no.nav.pto.veilarbportefolje.util.DateUtils
+import java.sql.Timestamp
+import java.util.*
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PortefoljeAktivitetKafkaMelding(
+    @param:JsonProperty("aktivitetId")
+    val aktivitetId: String? = null,
+    @param:JsonProperty("version")
+    val version: Long? = null,
+    @param:JsonProperty("aktorId")
+    val aktorId: String? = null,
+    @param:JsonProperty("fraDato")
+    val fraDato: Date? = null,
+    @param:JsonProperty("tilDato")
+    val tilDato: Date? = null,
+    @param:JsonProperty("endretDato")
+    val endretDato: Date? = null,
+    @param:JsonProperty("aktivitetType")
+    val aktivitetType: AktivitetTypeDTO? = null,
+    @param:JsonProperty("aktivitetStatus")
+    val aktivitetStatus: AktivitetStatus? = null,
+    @param:JsonProperty("endringsType")
+    val endringsType: EndringsType? = null,
+    @param:JsonProperty("lagtInnAv")
+    val lagtInnAv: Innsender? = null,
+    @param:JsonProperty("stillingFraNavData")
+    val stillingFraNavData: StillingFraNavPortefoljeData? = null,
+    @param:JsonProperty("avtalt")
+    val avtalt: Boolean = false,
+    @param:JsonProperty("historisk")
+    val historisk: Boolean = false,
+    @param:JsonProperty("tiltakskode")
+    val tiltakskode: String? = null,
+) {
+    fun toEntity(metadata: KafkaMeldingMetadata): KafkaAktivitetMeldingEntity {
+        return KafkaAktivitetMeldingEntity(
+            value = KafkaAktivitetMeldingValue(
+                aktivitetId = requireNotNull(aktivitetId) { "Mangler aktivitetId i aktivitet-melding" },
+                aktorId = requireNotNull(aktorId) { "Mangler aktorId i aktivitet-melding" },
+                aktivitetType = requireNotNull(aktivitetType) { "Mangler aktivitetType i aktivitet-melding" }.name,
+                aktivitetStatus = requireNotNull(aktivitetStatus) { "Mangler aktivitetStatus i aktivitet-melding" }.name,
+                endringsType = requireNotNull(endringsType) { "Mangler endringsType i aktivitet-melding" }.name,
+                fraDato = DateUtils.dateToTimestamp(fraDato),
+                tilDato = DateUtils.dateToTimestamp(tilDato),
+                endretDato = DateUtils.dateToTimestamp(endretDato),
+                tiltakskode = tiltakskode,
+                lagtInnAv = requireNotNull(lagtInnAv) { "Mangler lagtInnAv i aktivitet-melding" }.name,
+                avtalt = avtalt,
+                version = requireNotNull(version) { "Mangler version i aktivitet-melding" },
+                historisk = historisk,
+                cvKanDelesStatus = stillingFraNavData?.cvKanDelesStatus?.name,
+                svarfristStillingFraNav = stillingFraNavData?.svarfrist?.toLocalDate()?.let(DateUtils::toTimestamp),
+            ),
+            metadata = metadata,
+        )
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class StillingFraNavPortefoljeData(
+        @param:JsonProperty("cvKanDelesStatus")
+        val cvKanDelesStatus: CvKanDelesStatus? = null,
+        @param:JsonProperty("svarfrist")
+        val svarfrist: java.sql.Date? = null,
+    )
+
+    enum class AktivitetStatus {
+        PLANLAGT,
+        GJENNOMFORES,
+        FULLFORT,
+        BRUKER_ER_INTERESSERT,
+        AVBRUTT,
+    }
+
+    enum class AktivitetTypeDTO {
+        EGEN,
+        STILLING,
+        SOKEAVTALE,
+        IJOBB,
+        BEHANDLING,
+        MOTE,
+        SAMTALEREFERAT,
+        STILLING_FRA_NAV,
+        TILTAK,
+    }
+
+    enum class EndringsType {
+        OPPRETTET,
+        FLYTTET,
+        REDIGERT,
+        HISTORISK,
+    }
+
+    enum class Innsender {
+        BRUKER,
+        NAV,
+        ARBEIDSGIVER,
+        TILTAKSARRANGOER,
+        ARENAIDENT,
+        SYSTEM,
+    }
+
+    enum class CvKanDelesStatus {
+        JA,
+        NEI,
+        IKKE_SVART,
+    }
+}
+
+data class KafkaAktivitetMeldingEntity(
+    val value: KafkaAktivitetMeldingValue,
+    val metadata: KafkaMeldingMetadata,
+)
+
+data class KafkaAktivitetMeldingValue(
+    val aktivitetId: String,
+    val aktorId: String,
+    val aktivitetType: String,
+    val aktivitetStatus: String,
+    val endringsType: String,
+    val fraDato: Timestamp?,
+    val tilDato: Timestamp?,
+    val endretDato: Timestamp?,
+    val tiltakskode: String?,
+    val lagtInnAv: String,
+    val avtalt: Boolean,
+    val version: Long,
+    val historisk: Boolean,
+    val cvKanDelesStatus: String?,
+    val svarfristStillingFraNav: Timestamp?,
+)
+
+data class KafkaMeldingMetadata(
+    val recordOffset: Long,
+    val recordPartition: Int,
+    val recordKey: String,
+)
+
+fun KafkaMeldingMedMetadata<PortefoljeAktivitetKafkaMelding>.toEntity(): KafkaAktivitetMeldingEntity =
+    value.toEntity(
+        metadata = KafkaMeldingMetadata(
+            recordOffset = metadata.offset,
+            recordPartition = metadata.partition,
+            recordKey = requireNotNull(metadata.key) {
+                "Kafka-record mangler key for aktivitetId=${value.aktivitetId}"
+            },
+        ),
+    )

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMelding.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMelding.kt
@@ -2,137 +2,106 @@ package no.nav.pto.veilarbportefolje.aktiviteter.v1
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
 import no.nav.pto.veilarbportefolje.kafka.KafkaMeldingMedMetadata
-import no.nav.pto.veilarbportefolje.util.DateUtils
-import java.sql.Timestamp
-import java.util.*
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PortefoljeAktivitetKafkaMelding(
-    @param:JsonProperty("aktivitetId")
-    val aktivitetId: String? = null,
-    @param:JsonProperty("version")
-    val version: Long? = null,
-    @param:JsonProperty("aktorId")
-    val aktorId: String? = null,
+    @param:JsonProperty("aktivitetId", required = true)
+    @param:JsonSetter(nulls = Nulls.FAIL)
+    val aktivitetId: String,
+    @param:JsonProperty("version", required = true)
+    @param:JsonSetter(nulls = Nulls.FAIL)
+    val version: Long,
+    @param:JsonProperty("aktorId", required = true)
+    @param:JsonSetter(nulls = Nulls.FAIL)
+    val aktorId: String,
     @param:JsonProperty("fraDato")
-    val fraDato: Date? = null,
+    val fraDato: String? = null,
     @param:JsonProperty("tilDato")
-    val tilDato: Date? = null,
+    val tilDato: String? = null,
     @param:JsonProperty("endretDato")
-    val endretDato: Date? = null,
-    @param:JsonProperty("aktivitetType")
-    val aktivitetType: AktivitetTypeDTO? = null,
-    @param:JsonProperty("aktivitetStatus")
-    val aktivitetStatus: AktivitetStatus? = null,
-    @param:JsonProperty("endringsType")
-    val endringsType: EndringsType? = null,
-    @param:JsonProperty("lagtInnAv")
-    val lagtInnAv: Innsender? = null,
+    val endretDato: String? = null,
+    @param:JsonProperty("aktivitetType", required = true)
+    @param:JsonSetter(nulls = Nulls.FAIL)
+    val aktivitetType: String,
+    @param:JsonProperty("aktivitetStatus", required = true)
+    @param:JsonSetter(nulls = Nulls.FAIL)
+    val aktivitetStatus: String,
+    @param:JsonProperty("endringsType", required = true)
+    @param:JsonSetter(nulls = Nulls.FAIL)
+    val endringsType: String,
+    @param:JsonProperty("lagtInnAv", required = true)
+    @param:JsonSetter(nulls = Nulls.FAIL)
+    val lagtInnAv: String,
     @param:JsonProperty("stillingFraNavData")
     val stillingFraNavData: StillingFraNavPortefoljeData? = null,
-    @param:JsonProperty("avtalt")
-    val avtalt: Boolean = false,
-    @param:JsonProperty("historisk")
-    val historisk: Boolean = false,
+    @param:JsonProperty("avtalt", required = true)
+    @param:JsonSetter(nulls = Nulls.FAIL)
+    val avtalt: Boolean,
+    @param:JsonProperty("historisk", required = true)
+    @param:JsonSetter(nulls = Nulls.FAIL)
+    val historisk: Boolean,
     @param:JsonProperty("tiltakskode")
     val tiltakskode: String? = null,
 ) {
     fun toEntity(metadata: KafkaMeldingMetadata): KafkaAktivitetMeldingEntity {
         return KafkaAktivitetMeldingEntity(
-            value = KafkaAktivitetMeldingValue(
-                aktivitetId = requireNotNull(aktivitetId) { "Mangler aktivitetId i aktivitet-melding" },
-                aktorId = requireNotNull(aktorId) { "Mangler aktorId i aktivitet-melding" },
-                aktivitetType = requireNotNull(aktivitetType) { "Mangler aktivitetType i aktivitet-melding" }.name,
-                aktivitetStatus = requireNotNull(aktivitetStatus) { "Mangler aktivitetStatus i aktivitet-melding" }.name,
-                endringsType = requireNotNull(endringsType) { "Mangler endringsType i aktivitet-melding" }.name,
-                fraDato = DateUtils.dateToTimestamp(fraDato),
-                tilDato = DateUtils.dateToTimestamp(tilDato),
-                endretDato = DateUtils.dateToTimestamp(endretDato),
-                tiltakskode = tiltakskode,
-                lagtInnAv = requireNotNull(lagtInnAv) { "Mangler lagtInnAv i aktivitet-melding" }.name,
-                avtalt = avtalt,
-                version = requireNotNull(version) { "Mangler version i aktivitet-melding" },
-                historisk = historisk,
-                cvKanDelesStatus = stillingFraNavData?.cvKanDelesStatus?.name,
-                svarfristStillingFraNav = stillingFraNavData?.svarfrist?.toLocalDate()?.let(DateUtils::toTimestamp),
-            ),
-            metadata = metadata,
+            aktivitetId = aktivitetId,
+            aktorId = aktorId,
+            aktivitetType = aktivitetType,
+            aktivitetStatus = aktivitetStatus,
+            endringsType = endringsType,
+            fraDato = fraDato,
+            tilDato = tilDato,
+            endretDato = endretDato,
+            tiltakskode = tiltakskode,
+            lagtInnAv = lagtInnAv,
+            avtalt = avtalt,
+            version = version,
+            historisk = historisk,
+            cvKanDelesStatus = stillingFraNavData?.cvKanDelesStatus,
+            svarfristStillingFraNav = stillingFraNavData?.svarfrist,
+            recordOffset = metadata.recordOffset,
+            recordPartition = metadata.recordPartition,
+            recordKey = metadata.recordKey,
         )
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class StillingFraNavPortefoljeData(
         @param:JsonProperty("cvKanDelesStatus")
-        val cvKanDelesStatus: CvKanDelesStatus? = null,
+        val cvKanDelesStatus: String? = null,
         @param:JsonProperty("svarfrist")
-        val svarfrist: java.sql.Date? = null,
+        val svarfrist: String? = null,
     )
-
-    enum class AktivitetStatus {
-        PLANLAGT,
-        GJENNOMFORES,
-        FULLFORT,
-        BRUKER_ER_INTERESSERT,
-        AVBRUTT,
-    }
-
-    enum class AktivitetTypeDTO {
-        EGEN,
-        STILLING,
-        SOKEAVTALE,
-        IJOBB,
-        BEHANDLING,
-        MOTE,
-        SAMTALEREFERAT,
-        STILLING_FRA_NAV,
-        TILTAK,
-    }
-
-    enum class EndringsType {
-        OPPRETTET,
-        FLYTTET,
-        REDIGERT,
-        HISTORISK,
-    }
-
-    enum class Innsender {
-        BRUKER,
-        NAV,
-        ARBEIDSGIVER,
-        TILTAKSARRANGOER,
-        ARENAIDENT,
-        SYSTEM,
-    }
-
-    enum class CvKanDelesStatus {
-        JA,
-        NEI,
-        IKKE_SVART,
-    }
 }
 
 data class KafkaAktivitetMeldingEntity(
-    val value: KafkaAktivitetMeldingValue,
-    val metadata: KafkaMeldingMetadata,
-)
-
-data class KafkaAktivitetMeldingValue(
+    // Aktivitetdata frå Kafka-meldinga
     val aktivitetId: String,
     val aktorId: String,
     val aktivitetType: String,
     val aktivitetStatus: String,
     val endringsType: String,
-    val fraDato: Timestamp?,
-    val tilDato: Timestamp?,
-    val endretDato: Timestamp?,
+    val fraDato: String?,
+    val tilDato: String?,
+    val endretDato: String?,
     val tiltakskode: String?,
     val lagtInnAv: String,
     val avtalt: Boolean,
     val version: Long,
     val historisk: Boolean,
+
+    // Stilling fra Nav-data frå nested Kafka-payload
     val cvKanDelesStatus: String?,
-    val svarfristStillingFraNav: Timestamp?,
+    val svarfristStillingFraNav: String?,
+
+    // Kafka-metadata
+    val recordOffset: Long,
+    val recordPartition: Int,
+    val recordKey: String,
 )
 
 data class KafkaMeldingMetadata(
@@ -147,7 +116,7 @@ fun KafkaMeldingMedMetadata<PortefoljeAktivitetKafkaMelding>.toEntity(): KafkaAk
             recordOffset = metadata.offset,
             recordPartition = metadata.partition,
             recordKey = requireNotNull(metadata.key) {
-                "Kafka-record mangler key for aktivitetId=${value.aktivitetId}"
+                "Kafka-record mangler key for aktivitet-melding"
             },
         ),
     )

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepository.kt
@@ -1,0 +1,160 @@
+package no.nav.pto.veilarbportefolje.aktiviteter.v1
+
+import org.springframework.jdbc.core.BatchPreparedStatementSetter
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.sql.PreparedStatement
+import java.sql.Statement
+
+@Repository
+class PortefoljeAktivitetKafkaMeldingRepository(
+    private val db: JdbcTemplate,
+) {
+    @Transactional
+    fun tryLagreAktivitetDataBatch(aktiviteter: List<KafkaAktivitetMeldingEntity>): PortefoljeAktivitetBatchResult {
+        if (aktiviteter.isEmpty()) {
+            return PortefoljeAktivitetBatchResult(0, 0, 0, 0)
+        }
+
+        val endeligeAktiviteter = beholdSisteMeldingPerAktivitet(aktiviteter)
+        val slettinger = endeligeAktiviteter.filter { it.value.historisk }
+        val upserts = endeligeAktiviteter.filterNot { it.value.historisk }
+
+        val prosesserteSlettinger = batchDeleteById(slettinger).sumOf(::normaliserUpdateCount)
+        val prosesserteUpserts = batchUpsertAktivitet(upserts).sumOf(::normaliserUpdateCount)
+        val prosesserte = prosesserteSlettinger + prosesserteUpserts
+
+        return PortefoljeAktivitetBatchResult(
+            mottatte = aktiviteter.size,
+            dedupliserte = aktiviteter.size - endeligeAktiviteter.size,
+            prosesserte = prosesserte,
+            ignorert = endeligeAktiviteter.size - prosesserte,
+        )
+    }
+
+    private fun batchUpsertAktivitet(aktiviteter: List<KafkaAktivitetMeldingEntity>): IntArray {
+        if (aktiviteter.isEmpty()) {
+            return intArrayOf()
+        }
+
+        val sql = """
+            INSERT INTO KAFKA_AKTIVITET_MELDING (
+                AKTIVITET_ID,
+                AKTOR_ID,
+                AKTIVITET_TYPE,
+                AKTIVITET_STATUS,
+                ENDRINGS_TYPE,
+                FRA_DATO,
+                TIL_DATO,
+                ENDRET_DATO,
+                TILTAKSKODE,
+                LAGT_INN_AV,
+                AVTALT,
+                VERSION,
+                HISTORISK,
+                CV_KAN_DELES_STATUS,
+                SVARFRIST_STILLING_FRA_NAV,
+                RECORD_OFFSET,
+                RECORD_PARTITION,
+                RECORD_KEY,
+                RAD_OPPRETTET,
+                RAD_OPPDATERT
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            ON CONFLICT (AKTIVITET_ID) DO UPDATE
+            SET AKTOR_ID = excluded.AKTOR_ID,
+                AKTIVITET_TYPE = excluded.AKTIVITET_TYPE,
+                AKTIVITET_STATUS = excluded.AKTIVITET_STATUS,
+                ENDRINGS_TYPE = excluded.ENDRINGS_TYPE,
+                FRA_DATO = excluded.FRA_DATO,
+                TIL_DATO = excluded.TIL_DATO,
+                ENDRET_DATO = excluded.ENDRET_DATO,
+                TILTAKSKODE = excluded.TILTAKSKODE,
+                LAGT_INN_AV = excluded.LAGT_INN_AV,
+                AVTALT = excluded.AVTALT,
+                VERSION = excluded.VERSION,
+                HISTORISK = excluded.HISTORISK,
+                CV_KAN_DELES_STATUS = excluded.CV_KAN_DELES_STATUS,
+                SVARFRIST_STILLING_FRA_NAV = excluded.SVARFRIST_STILLING_FRA_NAV,
+                RECORD_OFFSET = excluded.RECORD_OFFSET,
+                RECORD_PARTITION = excluded.RECORD_PARTITION,
+                RECORD_KEY = excluded.RECORD_KEY,
+                RAD_OPPDATERT = CURRENT_TIMESTAMP
+            WHERE KAFKA_AKTIVITET_MELDING.VERSION <= excluded.VERSION
+        """.trimIndent()
+
+        return db.batchUpdate(sql, object : BatchPreparedStatementSetter {
+            override fun setValues(ps: PreparedStatement, i: Int) {
+                val aktivitet = aktiviteter[i]
+                ps.setString(1, aktivitet.value.aktivitetId)
+                ps.setString(2, aktivitet.value.aktorId)
+                ps.setString(3, aktivitet.value.aktivitetType)
+                ps.setString(4, aktivitet.value.aktivitetStatus)
+                ps.setString(5, aktivitet.value.endringsType)
+                ps.setTimestamp(6, aktivitet.value.fraDato)
+                ps.setTimestamp(7, aktivitet.value.tilDato)
+                ps.setTimestamp(8, aktivitet.value.endretDato)
+                ps.setString(9, aktivitet.value.tiltakskode)
+                ps.setString(10, aktivitet.value.lagtInnAv)
+                ps.setBoolean(11, aktivitet.value.avtalt)
+                ps.setLong(12, aktivitet.value.version)
+                ps.setBoolean(13, aktivitet.value.historisk)
+                ps.setString(14, aktivitet.value.cvKanDelesStatus)
+                ps.setTimestamp(15, aktivitet.value.svarfristStillingFraNav)
+                ps.setLong(16, aktivitet.metadata.recordOffset)
+                ps.setInt(17, aktivitet.metadata.recordPartition)
+                ps.setString(18, aktivitet.metadata.recordKey)
+            }
+
+            override fun getBatchSize(): Int = aktiviteter.size
+        })
+    }
+
+    private fun batchDeleteById(aktiviteter: List<KafkaAktivitetMeldingEntity>): IntArray {
+        if (aktiviteter.isEmpty()) {
+            return intArrayOf()
+        }
+
+        val sql = """
+            DELETE FROM KAFKA_AKTIVITET_MELDING
+            WHERE AKTIVITET_ID = ?
+              AND VERSION <= ?
+        """.trimIndent()
+
+        return db.batchUpdate(sql, object : BatchPreparedStatementSetter {
+            override fun setValues(ps: PreparedStatement, i: Int) {
+                val aktivitet = aktiviteter[i]
+                ps.setString(1, aktivitet.value.aktivitetId)
+                ps.setLong(2, aktivitet.value.version)
+            }
+
+            override fun getBatchSize(): Int = aktiviteter.size
+        })
+    }
+
+    private fun beholdSisteMeldingPerAktivitet(aktiviteter: List<KafkaAktivitetMeldingEntity>): List<KafkaAktivitetMeldingEntity> {
+        val sisteMeldingPerAktivitet = linkedMapOf<String, KafkaAktivitetMeldingEntity>()
+
+        aktiviteter.forEach { aktivitet ->
+            sisteMeldingPerAktivitet.remove(aktivitet.value.aktivitetId)
+            sisteMeldingPerAktivitet[aktivitet.value.aktivitetId] = aktivitet
+        }
+
+        return sisteMeldingPerAktivitet.values.toList()
+    }
+
+    private fun normaliserUpdateCount(updateCount: Int): Int =
+        when (updateCount) {
+            Statement.SUCCESS_NO_INFO -> 1
+            Statement.EXECUTE_FAILED -> error("Batch-operasjon mot aktivitet-tabellen feilet.")
+            else -> maxOf(updateCount, 0)
+        }
+}
+
+data class PortefoljeAktivitetBatchResult(
+    val mottatte: Int,
+    val dedupliserte: Int,
+    val prosesserte: Int,
+    val ignorert: Int,
+)

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepository.kt
@@ -1,5 +1,6 @@
 package no.nav.pto.veilarbportefolje.aktiviteter.v1
 
+import no.nav.pto.veilarbportefolje.database.PostgresTable.KAFKA_AKTIVITET_MELDING.*
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -38,27 +39,27 @@ class PortefoljeAktivitetKafkaMeldingRepository(
         }
 
         val sql = """
-            INSERT INTO KAFKA_AKTIVITET_MELDING (
-                AKTIVITET_ID,
-                AKTOR_ID,
-                AKTIVITET_TYPE,
-                AKTIVITET_STATUS,
-                ENDRINGS_TYPE,
-                FRA_DATO,
-                TIL_DATO,
-                ENDRET_DATO,
-                TILTAKSKODE,
-                LAGT_INN_AV,
-                AVTALT,
-                VERSION,
-                HISTORISK,
-                CV_KAN_DELES_STATUS,
-                SVARFRIST_STILLING_FRA_NAV,
-                RECORD_OFFSET,
-                RECORD_PARTITION,
-                RECORD_KEY,
-                RAD_OPPRETTET,
-                RAD_OPPDATERT
+            INSERT INTO $TABLE_NAME (
+                $AKTIVITET_ID,
+                $AKTOR_ID,
+                $AKTIVITET_TYPE,
+                $AKTIVITET_STATUS,
+                $ENDRINGS_TYPE,
+                $FRA_DATO,
+                $TIL_DATO,
+                $ENDRET_DATO,
+                $TILTAKSKODE,
+                $LAGT_INN_AV,
+                $AVTALT,
+                $VERSION,
+                $HISTORISK,
+                $CV_KAN_DELES_STATUS,
+                $SVARFRIST_STILLING_FRA_NAV,
+                $RECORD_OFFSET,
+                $RECORD_PARTITION,
+                $RECORD_KEY,
+                $RAD_OPPRETTET,
+                $RAD_OPPDATERT
             )
             VALUES (
                 :aktivitetId, :aktorId, :aktivitetType, :aktivitetStatus, :endringsType,
@@ -67,26 +68,26 @@ class PortefoljeAktivitetKafkaMeldingRepository(
                 :recordOffset, :recordPartition, :recordKey,
                 CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
             )
-            ON CONFLICT (AKTIVITET_ID) DO UPDATE
-            SET AKTOR_ID = excluded.AKTOR_ID,
-                AKTIVITET_TYPE = excluded.AKTIVITET_TYPE,
-                AKTIVITET_STATUS = excluded.AKTIVITET_STATUS,
-                ENDRINGS_TYPE = excluded.ENDRINGS_TYPE,
-                FRA_DATO = excluded.FRA_DATO,
-                TIL_DATO = excluded.TIL_DATO,
-                ENDRET_DATO = excluded.ENDRET_DATO,
-                TILTAKSKODE = excluded.TILTAKSKODE,
-                LAGT_INN_AV = excluded.LAGT_INN_AV,
-                AVTALT = excluded.AVTALT,
-                VERSION = excluded.VERSION,
-                HISTORISK = excluded.HISTORISK,
-                CV_KAN_DELES_STATUS = excluded.CV_KAN_DELES_STATUS,
-                SVARFRIST_STILLING_FRA_NAV = excluded.SVARFRIST_STILLING_FRA_NAV,
-                RECORD_OFFSET = excluded.RECORD_OFFSET,
-                RECORD_PARTITION = excluded.RECORD_PARTITION,
-                RECORD_KEY = excluded.RECORD_KEY,
-                RAD_OPPDATERT = CURRENT_TIMESTAMP
-            WHERE KAFKA_AKTIVITET_MELDING.VERSION <= excluded.VERSION
+            ON CONFLICT ($AKTIVITET_ID) DO UPDATE
+            SET $AKTOR_ID = excluded.$AKTOR_ID,
+                $AKTIVITET_TYPE = excluded.$AKTIVITET_TYPE,
+                $AKTIVITET_STATUS = excluded.$AKTIVITET_STATUS,
+                $ENDRINGS_TYPE = excluded.$ENDRINGS_TYPE,
+                $FRA_DATO = excluded.$FRA_DATO,
+                $TIL_DATO = excluded.$TIL_DATO,
+                $ENDRET_DATO = excluded.$ENDRET_DATO,
+                $TILTAKSKODE = excluded.$TILTAKSKODE,
+                $LAGT_INN_AV = excluded.$LAGT_INN_AV,
+                $AVTALT = excluded.$AVTALT,
+                $VERSION = excluded.$VERSION,
+                $HISTORISK = excluded.$HISTORISK,
+                $CV_KAN_DELES_STATUS = excluded.$CV_KAN_DELES_STATUS,
+                $SVARFRIST_STILLING_FRA_NAV = excluded.$SVARFRIST_STILLING_FRA_NAV,
+                $RECORD_OFFSET = excluded.$RECORD_OFFSET,
+                $RECORD_PARTITION = excluded.$RECORD_PARTITION,
+                $RECORD_KEY = excluded.$RECORD_KEY,
+                $RAD_OPPDATERT = CURRENT_TIMESTAMP
+            WHERE $TABLE_NAME.$VERSION <= excluded.$VERSION
         """.trimIndent()
 
         val params = aktiviteter.map { it.toSqlParams() }.toTypedArray()
@@ -100,9 +101,9 @@ class PortefoljeAktivitetKafkaMeldingRepository(
         }
 
         val sql = """
-            DELETE FROM KAFKA_AKTIVITET_MELDING
-            WHERE AKTIVITET_ID = :aktivitetId
-              AND VERSION <= :version
+            DELETE FROM $TABLE_NAME
+            WHERE $AKTIVITET_ID = :aktivitetId
+              AND $VERSION <= :version
         """.trimIndent()
 
         val params = aktiviteter.map {

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepository.kt
@@ -1,15 +1,14 @@
 package no.nav.pto.veilarbportefolje.aktiviteter.v1
 
-import org.springframework.jdbc.core.BatchPreparedStatementSetter
-import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
-import java.sql.PreparedStatement
 import java.sql.Statement
 
 @Repository
 class PortefoljeAktivitetKafkaMeldingRepository(
-    private val db: JdbcTemplate,
+    private val db: NamedParameterJdbcTemplate,
 ) {
     @Transactional
     fun tryLagreAktivitetDataBatch(aktiviteter: List<KafkaAktivitetMeldingEntity>): PortefoljeAktivitetBatchResult {
@@ -61,7 +60,13 @@ class PortefoljeAktivitetKafkaMeldingRepository(
                 RAD_OPPRETTET,
                 RAD_OPPDATERT
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            VALUES (
+                :aktivitetId, :aktorId, :aktivitetType, :aktivitetStatus, :endringsType,
+                :fraDato, :tilDato, :endretDato, :tiltakskode, :lagtInnAv,
+                :avtalt, :version, :historisk, :cvKanDelesStatus, :svarfristStillingFraNav,
+                :recordOffset, :recordPartition, :recordKey,
+                CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            )
             ON CONFLICT (AKTIVITET_ID) DO UPDATE
             SET AKTOR_ID = excluded.AKTOR_ID,
                 AKTIVITET_TYPE = excluded.AKTIVITET_TYPE,
@@ -84,31 +89,9 @@ class PortefoljeAktivitetKafkaMeldingRepository(
             WHERE KAFKA_AKTIVITET_MELDING.VERSION <= excluded.VERSION
         """.trimIndent()
 
-        return db.batchUpdate(sql, object : BatchPreparedStatementSetter {
-            override fun setValues(ps: PreparedStatement, i: Int) {
-                val aktivitet = aktiviteter[i]
-                ps.setString(1, aktivitet.value.aktivitetId)
-                ps.setString(2, aktivitet.value.aktorId)
-                ps.setString(3, aktivitet.value.aktivitetType)
-                ps.setString(4, aktivitet.value.aktivitetStatus)
-                ps.setString(5, aktivitet.value.endringsType)
-                ps.setTimestamp(6, aktivitet.value.fraDato)
-                ps.setTimestamp(7, aktivitet.value.tilDato)
-                ps.setTimestamp(8, aktivitet.value.endretDato)
-                ps.setString(9, aktivitet.value.tiltakskode)
-                ps.setString(10, aktivitet.value.lagtInnAv)
-                ps.setBoolean(11, aktivitet.value.avtalt)
-                ps.setLong(12, aktivitet.value.version)
-                ps.setBoolean(13, aktivitet.value.historisk)
-                ps.setString(14, aktivitet.value.cvKanDelesStatus)
-                ps.setTimestamp(15, aktivitet.value.svarfristStillingFraNav)
-                ps.setLong(16, aktivitet.metadata.recordOffset)
-                ps.setInt(17, aktivitet.metadata.recordPartition)
-                ps.setString(18, aktivitet.metadata.recordKey)
-            }
+        val params = aktiviteter.map { it.toSqlParams() }.toTypedArray()
 
-            override fun getBatchSize(): Int = aktiviteter.size
-        })
+        return db.batchUpdate(sql, params)
     }
 
     private fun batchDeleteById(aktiviteter: List<KafkaAktivitetMeldingEntity>): IntArray {
@@ -118,19 +101,17 @@ class PortefoljeAktivitetKafkaMeldingRepository(
 
         val sql = """
             DELETE FROM KAFKA_AKTIVITET_MELDING
-            WHERE AKTIVITET_ID = ?
-              AND VERSION <= ?
+            WHERE AKTIVITET_ID = :aktivitetId
+              AND VERSION <= :version
         """.trimIndent()
 
-        return db.batchUpdate(sql, object : BatchPreparedStatementSetter {
-            override fun setValues(ps: PreparedStatement, i: Int) {
-                val aktivitet = aktiviteter[i]
-                ps.setString(1, aktivitet.value.aktivitetId)
-                ps.setLong(2, aktivitet.value.version)
-            }
+        val params = aktiviteter.map {
+            MapSqlParameterSource()
+                .addValue("aktivitetId", it.value.aktivitetId)
+                .addValue("version", it.value.version)
+        }.toTypedArray()
 
-            override fun getBatchSize(): Int = aktiviteter.size
-        })
+        return db.batchUpdate(sql, params)
     }
 
     private fun beholdSisteMeldingPerAktivitet(aktiviteter: List<KafkaAktivitetMeldingEntity>): List<KafkaAktivitetMeldingEntity> {
@@ -150,6 +131,26 @@ class PortefoljeAktivitetKafkaMeldingRepository(
             Statement.EXECUTE_FAILED -> error("Batch-operasjon mot aktivitet-tabellen feilet.")
             else -> maxOf(updateCount, 0)
         }
+
+    private fun KafkaAktivitetMeldingEntity.toSqlParams() = MapSqlParameterSource()
+        .addValue("aktivitetId", value.aktivitetId)
+        .addValue("aktorId", value.aktorId)
+        .addValue("aktivitetType", value.aktivitetType)
+        .addValue("aktivitetStatus", value.aktivitetStatus)
+        .addValue("endringsType", value.endringsType)
+        .addValue("fraDato", value.fraDato)
+        .addValue("tilDato", value.tilDato)
+        .addValue("endretDato", value.endretDato)
+        .addValue("tiltakskode", value.tiltakskode)
+        .addValue("lagtInnAv", value.lagtInnAv)
+        .addValue("avtalt", value.avtalt)
+        .addValue("version", value.version)
+        .addValue("historisk", value.historisk)
+        .addValue("cvKanDelesStatus", value.cvKanDelesStatus)
+        .addValue("svarfristStillingFraNav", value.svarfristStillingFraNav)
+        .addValue("recordOffset", metadata.recordOffset)
+        .addValue("recordPartition", metadata.recordPartition)
+        .addValue("recordKey", metadata.recordKey)
 }
 
 data class PortefoljeAktivitetBatchResult(

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepository.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepository.kt
@@ -17,8 +17,8 @@ class PortefoljeAktivitetKafkaMeldingRepository(
         }
 
         val endeligeAktiviteter = beholdSisteMeldingPerAktivitet(aktiviteter)
-        val slettinger = endeligeAktiviteter.filter { it.value.historisk }
-        val upserts = endeligeAktiviteter.filterNot { it.value.historisk }
+        val slettinger = endeligeAktiviteter.filter { it.historisk }
+        val upserts = endeligeAktiviteter.filterNot { it.historisk }
 
         val prosesserteSlettinger = batchDeleteById(slettinger).sumOf(::normaliserUpdateCount)
         val prosesserteUpserts = batchUpsertAktivitet(upserts).sumOf(::normaliserUpdateCount)
@@ -107,8 +107,8 @@ class PortefoljeAktivitetKafkaMeldingRepository(
 
         val params = aktiviteter.map {
             MapSqlParameterSource()
-                .addValue("aktivitetId", it.value.aktivitetId)
-                .addValue("version", it.value.version)
+                .addValue("aktivitetId", it.aktivitetId)
+                .addValue("version", it.version)
         }.toTypedArray()
 
         return db.batchUpdate(sql, params)
@@ -118,8 +118,8 @@ class PortefoljeAktivitetKafkaMeldingRepository(
         val sisteMeldingPerAktivitet = linkedMapOf<String, KafkaAktivitetMeldingEntity>()
 
         aktiviteter.forEach { aktivitet ->
-            sisteMeldingPerAktivitet.remove(aktivitet.value.aktivitetId)
-            sisteMeldingPerAktivitet[aktivitet.value.aktivitetId] = aktivitet
+            sisteMeldingPerAktivitet.remove(aktivitet.aktivitetId)
+            sisteMeldingPerAktivitet[aktivitet.aktivitetId] = aktivitet
         }
 
         return sisteMeldingPerAktivitet.values.toList()
@@ -133,24 +133,24 @@ class PortefoljeAktivitetKafkaMeldingRepository(
         }
 
     private fun KafkaAktivitetMeldingEntity.toSqlParams() = MapSqlParameterSource()
-        .addValue("aktivitetId", value.aktivitetId)
-        .addValue("aktorId", value.aktorId)
-        .addValue("aktivitetType", value.aktivitetType)
-        .addValue("aktivitetStatus", value.aktivitetStatus)
-        .addValue("endringsType", value.endringsType)
-        .addValue("fraDato", value.fraDato)
-        .addValue("tilDato", value.tilDato)
-        .addValue("endretDato", value.endretDato)
-        .addValue("tiltakskode", value.tiltakskode)
-        .addValue("lagtInnAv", value.lagtInnAv)
-        .addValue("avtalt", value.avtalt)
-        .addValue("version", value.version)
-        .addValue("historisk", value.historisk)
-        .addValue("cvKanDelesStatus", value.cvKanDelesStatus)
-        .addValue("svarfristStillingFraNav", value.svarfristStillingFraNav)
-        .addValue("recordOffset", metadata.recordOffset)
-        .addValue("recordPartition", metadata.recordPartition)
-        .addValue("recordKey", metadata.recordKey)
+        .addValue("aktivitetId", aktivitetId)
+        .addValue("aktorId", aktorId)
+        .addValue("aktivitetType", aktivitetType)
+        .addValue("aktivitetStatus", aktivitetStatus)
+        .addValue("endringsType", endringsType)
+        .addValue("fraDato", fraDato)
+        .addValue("tilDato", tilDato)
+        .addValue("endretDato", endretDato)
+        .addValue("tiltakskode", tiltakskode)
+        .addValue("lagtInnAv", lagtInnAv)
+        .addValue("avtalt", avtalt)
+        .addValue("version", version)
+        .addValue("historisk", historisk)
+        .addValue("cvKanDelesStatus", cvKanDelesStatus)
+        .addValue("svarfristStillingFraNav", svarfristStillingFraNav)
+        .addValue("recordOffset", recordOffset)
+        .addValue("recordPartition", recordPartition)
+        .addValue("recordKey", recordKey)
 }
 
 data class PortefoljeAktivitetBatchResult(

--- a/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingService.kt
@@ -1,0 +1,39 @@
+package no.nav.pto.veilarbportefolje.aktiviteter.v1
+
+import no.nav.pto.veilarbportefolje.kafka.tilKafkaMeldingMedMetadata
+import no.nav.pto.veilarbportefolje.util.SecureLog.secureLog
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.springframework.stereotype.Service
+
+@Service
+class PortefoljeAktivitetKafkaMeldingService(
+    private val repository: PortefoljeAktivitetKafkaMeldingRepository,
+) {
+    fun behandleKafkaRecords(kafkaRecords: List<ConsumerRecord<String, PortefoljeAktivitetKafkaMelding>>): PortefoljeAktivitetBatchResult {
+        if (kafkaRecords.isEmpty()) {
+            return PortefoljeAktivitetBatchResult(0, 0, 0, 0)
+        }
+
+        secureLog.info(
+            "Behandler kafka-batch med {} meldinger fra topic {} partition {} (offset {}-{}).",
+            kafkaRecords.size,
+            kafkaRecords.first().topic(),
+            kafkaRecords.first().partition(),
+            kafkaRecords.first().offset(),
+            kafkaRecords.last().offset(),
+        )
+
+        val resultat = repository.tryLagreAktivitetDataBatch(
+            kafkaRecords.map { it.tilKafkaMeldingMedMetadata().toEntity() },
+        )
+
+        if (resultat.ignorert > 0) {
+            secureLog.info(
+                "{} meldinger ble ikke prosessert fordi nyere versjon allerede er lagret eller fordi de ble overstyrt av en nyere melding i samme batch.",
+                resultat.ignorert,
+            )
+        }
+
+        return resultat
+    }
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/config/EnvironmentProperties.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/config/EnvironmentProperties.java
@@ -41,4 +41,3 @@ public class EnvironmentProperties {
     private String dagpengerUrl;
     private String dagpengerScope;
 }
-

--- a/src/main/java/no/nav/pto/veilarbportefolje/config/FeatureToggle.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/config/FeatureToggle.java
@@ -11,6 +11,7 @@ public class FeatureToggle {
     public static final String ALIAS_INDEKSERING = "veilarbportefolje.aliasIndeksering";
     public static final String KAFKA_AIVEN_CONSUMERS_STOP = "veilarbportefolje.kafka_aiven_consumers_stop";
     public static final String KAFKA_SISTE_14A_STOP = "veilarbportefolje.kafka_siste_14a_stop";
+    public static final String KAFKA_PORTEFOLJE_AKTIVITET_V1_START = "veilarbportefolje.kafka_portefolje_aktivitet_v1_start";
     public static final String BRUK_FILTER_FOR_BRUKERINNSYN_TILGANGER = "veilarbportefolje.bruk_filter_for_brukerinnsyn_tilganger";
     public static final String BRUK_KONTOR_FRA_AOKONTOR = "veilarbportefolje.bruk_kontor_fra_aokontor";
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/database/PostgresTable.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/database/PostgresTable.java
@@ -353,6 +353,32 @@ public class PostgresTable {
         public static final String VERSION = "VERSION";
     }
 
+    public static final class KAFKA_AKTIVITET_MELDING {
+        private KAFKA_AKTIVITET_MELDING() { /* no-op */ }
+
+        public static final String TABLE_NAME = "KAFKA_AKTIVITET_MELDING";
+        public static final String AKTIVITET_ID = "AKTIVITET_ID";
+        public static final String AKTOR_ID = "AKTOR_ID";
+        public static final String AKTIVITET_TYPE = "AKTIVITET_TYPE";
+        public static final String AKTIVITET_STATUS = "AKTIVITET_STATUS";
+        public static final String ENDRINGS_TYPE = "ENDRINGS_TYPE";
+        public static final String FRA_DATO = "FRA_DATO";
+        public static final String TIL_DATO = "TIL_DATO";
+        public static final String ENDRET_DATO = "ENDRET_DATO";
+        public static final String TILTAKSKODE = "TILTAKSKODE";
+        public static final String LAGT_INN_AV = "LAGT_INN_AV";
+        public static final String AVTALT = "AVTALT";
+        public static final String VERSION = "VERSION";
+        public static final String HISTORISK = "HISTORISK";
+        public static final String CV_KAN_DELES_STATUS = "CV_KAN_DELES_STATUS";
+        public static final String SVARFRIST_STILLING_FRA_NAV = "SVARFRIST_STILLING_FRA_NAV";
+        public static final String RECORD_OFFSET = "RECORD_OFFSET";
+        public static final String RECORD_PARTITION = "RECORD_PARTITION";
+        public static final String RECORD_KEY = "RECORD_KEY";
+        public static final String RAD_OPPRETTET = "RAD_OPPRETTET";
+        public static final String RAD_OPPDATERT = "RAD_OPPDATERT";
+    }
+
     public static final class BRUKERTILTAK {
         private BRUKERTILTAK() { /* no-op */ }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaConfigCommon.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaConfigCommon.java
@@ -3,7 +3,6 @@ package no.nav.pto.veilarbportefolje.kafka;
 import io.getunleash.DefaultUnleash;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
-import lombok.Getter;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import no.nav.arbeid.cv.avro.Melding;
 import no.nav.common.kafka.consumer.KafkaConsumerClient;
@@ -77,7 +76,7 @@ import java.util.stream.Collectors;
 import static no.nav.common.kafka.consumer.util.ConsumerUtils.findConsumerConfigsWithStoreOnFailure;
 import static no.nav.common.kafka.util.KafkaPropertiesPreset.aivenDefaultConsumerProperties;
 import static no.nav.common.utils.EnvironmentUtils.isDevelopment;
-import static no.nav.pto.veilarbportefolje.config.FeatureToggle.*;
+import static no.nav.pto.veilarbportefolje.config.FeatureToggle.KAFKA_SISTE_14A_STOP;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
 
 @Configuration
@@ -141,11 +140,14 @@ public class KafkaConfigCommon {
         YTELSER_TOPIC("obo.ytelser-v1");
 
 
-        @Getter
         final String topicName;
 
         Topic(String topicName) {
             this.topicName = topicName;
+        }
+
+        public String getTopicName() {
+            return this.topicName;
         }
     }
 

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaMeldingMedMetadata.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/KafkaMeldingMedMetadata.kt
@@ -1,0 +1,29 @@
+package no.nav.pto.veilarbportefolje.kafka
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+
+data class KafkaMeldingMedMetadata<T>(
+    val value: T,
+    val metadata: KafkaRecordMetadata,
+)
+
+data class KafkaRecordMetadata(
+    val partition: Int,
+    val offset: Long,
+    val key: String?,
+)
+
+fun <T> ConsumerRecord<String, T>.tilKafkaMeldingMedMetadata(): KafkaMeldingMedMetadata<T> {
+    val kafkaValue = requireNotNull(value()) {
+        "Kafka-melding mangler value for key=${key()} på topic ${topic()}"
+    }
+
+    return KafkaMeldingMedMetadata(
+        value = kafkaValue,
+        metadata = KafkaRecordMetadata(
+            partition = partition(),
+            offset = offset(),
+            key = key(),
+        ),
+    )
+}

--- a/src/main/java/no/nav/pto/veilarbportefolje/kafka/unleash/KafkaAivenUnleash.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/kafka/unleash/KafkaAivenUnleash.java
@@ -1,14 +1,16 @@
 package no.nav.pto.veilarbportefolje.kafka.unleash;
 
 import io.getunleash.DefaultUnleash;
-import lombok.RequiredArgsConstructor;
 import no.nav.pto.veilarbportefolje.config.FeatureToggle;
 
 import java.util.function.Supplier;
 
-@RequiredArgsConstructor
 public class KafkaAivenUnleash implements Supplier<Boolean> {
     private final DefaultUnleash defaultUnleash;
+
+    public KafkaAivenUnleash(DefaultUnleash defaultUnleash) {
+        this.defaultUnleash = defaultUnleash;
+    }
 
     @Override
     public Boolean get() {

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingContractTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingContractTest.kt
@@ -1,0 +1,85 @@
+package no.nav.pto.veilarbportefolje.aktiviteter.v1
+
+import no.nav.pto.veilarbportefolje.kafka.deserializers.KotlinJsonDeserializer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import java.util.Date
+
+class PortefoljeAktivitetKafkaMeldingContractTest {
+    private val deserializer = KotlinJsonDeserializer(PortefoljeAktivitetKafkaMelding::class.java)
+
+    @Test
+    fun `skal deserialisere gyldig v4-melding`() {
+        val payload = """
+            {
+              "aktivitetId": "144136",
+              "version": 1,
+              "aktorId": "123456789",
+              "fraDato": "2020-07-09T12:00:00+02:00",
+              "tilDato": null,
+              "endretDato": "2020-05-28T09:47:42.48+02:00",
+              "aktivitetType": "STILLING_FRA_NAV",
+              "aktivitetStatus": "FULLFORT",
+              "endringsType": "OPPRETTET",
+              "lagtInnAv": "NAV",
+              "stillingFraNavData": {
+                "cvKanDelesStatus": "IKKE_SVART",
+                "svarfrist": "2022-08-18"
+              },
+              "avtalt": true,
+              "historisk": false
+            }
+        """.trimIndent()
+
+        val resultat = deserializer.deserialize("pto.portefolje-aktivitet-v1", payload.toByteArray())
+
+        assertThat(resultat).isNotNull
+        assertThat(resultat!!.aktivitetId).isEqualTo("144136")
+        assertThat(resultat.version).isEqualTo(1L)
+        assertThat(resultat.aktorId).isEqualTo("123456789")
+        assertThat(resultat.fraDato).isEqualTo(date("2020-07-09T12:00:00+02:00"))
+        assertThat(resultat.tilDato).isNull()
+        assertThat(resultat.endretDato).isEqualTo(date("2020-05-28T09:47:42.48+02:00"))
+        assertThat(resultat.aktivitetType).isEqualTo(PortefoljeAktivitetKafkaMelding.AktivitetTypeDTO.STILLING_FRA_NAV)
+        assertThat(resultat.aktivitetStatus).isEqualTo(PortefoljeAktivitetKafkaMelding.AktivitetStatus.FULLFORT)
+        assertThat(resultat.endringsType).isEqualTo(PortefoljeAktivitetKafkaMelding.EndringsType.OPPRETTET)
+        assertThat(resultat.lagtInnAv).isEqualTo(PortefoljeAktivitetKafkaMelding.Innsender.NAV)
+        assertThat(resultat.stillingFraNavData?.cvKanDelesStatus).isEqualTo(PortefoljeAktivitetKafkaMelding.CvKanDelesStatus.IKKE_SVART)
+        assertThat(resultat.stillingFraNavData?.svarfrist?.toLocalDate()).isEqualTo(LocalDate.parse("2022-08-18"))
+        assertThat(resultat.avtalt).isTrue()
+        assertThat(resultat.historisk).isFalse()
+    }
+
+    @Test
+    fun `skal ignorere ukjente felter og beholde tiltak as is`() {
+        val payload = """
+            {
+              "aktivitetId": "200",
+              "version": 2,
+              "aktorId": "999",
+              "fraDato": null,
+              "tilDato": null,
+              "endretDato": null,
+              "aktivitetType": "TILTAK",
+              "aktivitetStatus": "GJENNOMFORES",
+              "endringsType": "REDIGERT",
+              "lagtInnAv": "SYSTEM",
+              "avtalt": false,
+              "historisk": false,
+              "tiltakskode": "ARBFORB",
+              "ukjentFelt": "skal ignoreres"
+            }
+        """.trimIndent()
+
+        val resultat = deserializer.deserialize("pto.portefolje-aktivitet-v1", payload.toByteArray())
+
+        assertThat(resultat).isNotNull
+        assertThat(resultat!!.aktivitetType).isEqualTo(PortefoljeAktivitetKafkaMelding.AktivitetTypeDTO.TILTAK)
+        assertThat(resultat.tiltakskode).isEqualTo("ARBFORB")
+        assertThat(resultat.lagtInnAv).isEqualTo(PortefoljeAktivitetKafkaMelding.Innsender.SYSTEM)
+    }
+
+    private fun date(value: String): Date = Date.from(ZonedDateTime.parse(value).toInstant())
+}

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingContractTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingContractTest.kt
@@ -2,10 +2,8 @@ package no.nav.pto.veilarbportefolje.aktiviteter.v1
 
 import no.nav.common.kafka.consumer.util.deserializer.Deserializers
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
-import java.time.ZonedDateTime
-import java.util.*
 
 class PortefoljeAktivitetKafkaMeldingContractTest {
     private val deserializer = Deserializers.jsonDeserializer(PortefoljeAktivitetKafkaMelding::class.java)
@@ -39,15 +37,15 @@ class PortefoljeAktivitetKafkaMeldingContractTest {
         assertThat(resultat!!.aktivitetId).isEqualTo("144136")
         assertThat(resultat.version).isEqualTo(1L)
         assertThat(resultat.aktorId).isEqualTo("123456789")
-        assertThat(resultat.fraDato).isEqualTo(date("2020-07-09T12:00:00+02:00"))
+        assertThat(resultat.fraDato).isEqualTo("2020-07-09T12:00:00+02:00")
         assertThat(resultat.tilDato).isNull()
-        assertThat(resultat.endretDato).isEqualTo(date("2020-05-28T09:47:42.48+02:00"))
-        assertThat(resultat.aktivitetType).isEqualTo(PortefoljeAktivitetKafkaMelding.AktivitetTypeDTO.STILLING_FRA_NAV)
-        assertThat(resultat.aktivitetStatus).isEqualTo(PortefoljeAktivitetKafkaMelding.AktivitetStatus.FULLFORT)
-        assertThat(resultat.endringsType).isEqualTo(PortefoljeAktivitetKafkaMelding.EndringsType.OPPRETTET)
-        assertThat(resultat.lagtInnAv).isEqualTo(PortefoljeAktivitetKafkaMelding.Innsender.NAV)
-        assertThat(resultat.stillingFraNavData?.cvKanDelesStatus).isEqualTo(PortefoljeAktivitetKafkaMelding.CvKanDelesStatus.IKKE_SVART)
-        assertThat(resultat.stillingFraNavData?.svarfrist?.toLocalDate()).isEqualTo(LocalDate.parse("2022-08-18"))
+        assertThat(resultat.endretDato).isEqualTo("2020-05-28T09:47:42.48+02:00")
+        assertThat(resultat.aktivitetType).isEqualTo("STILLING_FRA_NAV")
+        assertThat(resultat.aktivitetStatus).isEqualTo("FULLFORT")
+        assertThat(resultat.endringsType).isEqualTo("OPPRETTET")
+        assertThat(resultat.lagtInnAv).isEqualTo("NAV")
+        assertThat(resultat.stillingFraNavData?.cvKanDelesStatus).isEqualTo("IKKE_SVART")
+        assertThat(resultat.stillingFraNavData?.svarfrist).isEqualTo("2022-08-18")
         assertThat(resultat.avtalt).isTrue()
         assertThat(resultat.historisk).isFalse()
     }
@@ -76,10 +74,72 @@ class PortefoljeAktivitetKafkaMeldingContractTest {
         val resultat = deserializer.deserialize("pto.portefolje-aktivitet-v1", payload.toByteArray())
 
         assertThat(resultat).isNotNull
-        assertThat(resultat!!.aktivitetType).isEqualTo(PortefoljeAktivitetKafkaMelding.AktivitetTypeDTO.TILTAK)
+        assertThat(resultat!!.aktivitetType).isEqualTo("TILTAK")
         assertThat(resultat.tiltakskode).isEqualTo("ARBFORB")
-        assertThat(resultat.lagtInnAv).isEqualTo(PortefoljeAktivitetKafkaMelding.Innsender.SYSTEM)
+        assertThat(resultat.lagtInnAv).isEqualTo("SYSTEM")
     }
 
-    private fun date(value: String): Date = Date.from(ZonedDateTime.parse(value).toInstant())
+    @Test
+    fun `skal feile deserialisering naar paakrevd felt mangler`() {
+        val payload = """
+            {
+              "aktivitetId": "200",
+              "version": 2,
+              "fraDato": null,
+              "tilDato": null,
+              "endretDato": null,
+              "aktivitetType": "TILTAK",
+              "aktivitetStatus": "GJENNOMFORES",
+              "endringsType": "REDIGERT",
+              "lagtInnAv": "SYSTEM",
+              "avtalt": false,
+              "historisk": false
+            }
+        """.trimIndent()
+
+        assertThatThrownBy {
+            deserializer.deserialize("pto.portefolje-aktivitet-v1", payload.toByteArray())
+        }.isInstanceOf(RuntimeException::class.java)
+    }
+
+    @Test
+    fun `skal feile deserialisering naar paakrevd boolean-felt mangler`() {
+        val payload = """
+            {
+              "aktivitetId": "200",
+              "version": 2,
+              "aktorId": "999",
+              "aktivitetType": "TILTAK",
+              "aktivitetStatus": "GJENNOMFORES",
+              "endringsType": "REDIGERT",
+              "lagtInnAv": "SYSTEM",
+              "historisk": false
+            }
+        """.trimIndent()
+
+        assertThatThrownBy {
+            deserializer.deserialize("pto.portefolje-aktivitet-v1", payload.toByteArray())
+        }.isInstanceOf(RuntimeException::class.java)
+    }
+
+    @Test
+    fun `skal feile deserialisering naar paakrevd boolean-felt er null`() {
+        val payload = """
+            {
+              "aktivitetId": "200",
+              "version": 2,
+              "aktorId": "999",
+              "aktivitetType": "TILTAK",
+              "aktivitetStatus": "GJENNOMFORES",
+              "endringsType": "REDIGERT",
+              "lagtInnAv": "SYSTEM",
+              "avtalt": null,
+              "historisk": false
+            }
+        """.trimIndent()
+
+        assertThatThrownBy {
+            deserializer.deserialize("pto.portefolje-aktivitet-v1", payload.toByteArray())
+        }.isInstanceOf(RuntimeException::class.java)
+    }
 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingContractTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingContractTest.kt
@@ -1,14 +1,14 @@
 package no.nav.pto.veilarbportefolje.aktiviteter.v1
 
-import no.nav.pto.veilarbportefolje.kafka.deserializers.KotlinJsonDeserializer
+import no.nav.common.kafka.consumer.util.deserializer.Deserializers
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.ZonedDateTime
-import java.util.Date
+import java.util.*
 
 class PortefoljeAktivitetKafkaMeldingContractTest {
-    private val deserializer = KotlinJsonDeserializer(PortefoljeAktivitetKafkaMelding::class.java)
+    private val deserializer = Deserializers.jsonDeserializer(PortefoljeAktivitetKafkaMelding::class.java)
 
     @Test
     fun `skal deserialisere gyldig v4-melding`() {

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepositoryTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepositoryTest.kt
@@ -1,0 +1,226 @@
+package no.nav.pto.veilarbportefolje.aktiviteter.v1
+
+import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import java.sql.Timestamp
+import java.time.Instant
+
+@SpringBootTest(classes = [ApplicationConfigTest::class])
+class PortefoljeAktivitetKafkaMeldingRepositoryTest(
+    @param:Autowired private val jdbcTemplate: JdbcTemplate,
+) {
+    private lateinit var repository: PortefoljeAktivitetKafkaMeldingRepository
+
+    @BeforeEach
+    fun setup() {
+        repository = PortefoljeAktivitetKafkaMeldingRepository(jdbcTemplate)
+        jdbcTemplate.update("TRUNCATE TABLE KAFKA_AKTIVITET_MELDING")
+    }
+
+    @Test
+    fun `skal lagre ny aktivitet med kafka-metadata`() {
+        val aktivitet = aktivitetEntity()
+
+        val resultat = repository.tryLagreAktivitetDataBatch(listOf(aktivitet))
+        val rad = hentRad(aktivitet.value.aktivitetId)
+
+        assertThat(resultat.prosesserte).isEqualTo(1)
+        assertThat(rad).isNotNull
+        assertThat(rad!!["aktor_id"]).isEqualTo(aktivitet.value.aktorId)
+        assertThat(rad["aktivitet_type"]).isEqualTo(aktivitet.value.aktivitetType)
+        assertThat(rad["tiltakskode"]).isEqualTo(aktivitet.value.tiltakskode)
+        assertThat(rad["record_offset"]).isEqualTo(aktivitet.metadata.recordOffset)
+        assertThat(rad["record_partition"]).isEqualTo(aktivitet.metadata.recordPartition)
+        assertThat(rad["record_key"]).isEqualTo(aktivitet.metadata.recordKey)
+        assertThat(rad["rad_opprettet"]).isInstanceOf(Timestamp::class.java)
+        assertThat(rad["rad_oppdatert"]).isInstanceOf(Timestamp::class.java)
+    }
+
+    @Test
+    fun `skal oppdatere aktivitet naar version er nyere og oppdatere rad_oppdatert`() {
+        val opprinnelig = aktivitetEntity(version = 1, aktivitetStatus = "PLANLAGT", recordOffset = 10)
+        repository.tryLagreAktivitetDataBatch(listOf(opprinnelig))
+        val radFoer = hentRad(opprinnelig.value.aktivitetId)!!
+        val radOpprettetFoer = radFoer["rad_opprettet"] as Timestamp
+        val radOppdatertFoer = radFoer["rad_oppdatert"] as Timestamp
+
+        Thread.sleep(5)
+
+        val oppdatert = aktivitetEntity(version = 2, aktivitetStatus = "FULLFORT", recordOffset = 11, recordKey = "ny-key")
+        val resultat = repository.tryLagreAktivitetDataBatch(listOf(oppdatert))
+        val radEtter = hentRad(opprinnelig.value.aktivitetId)!!
+
+        assertThat(resultat.prosesserte).isEqualTo(1)
+        assertThat(radEtter["version"]).isEqualTo(2L)
+        assertThat(radEtter["aktivitet_status"]).isEqualTo("FULLFORT")
+        assertThat(radEtter["record_offset"]).isEqualTo(11L)
+        assertThat(radEtter["record_key"]).isEqualTo("ny-key")
+        assertThat(radEtter["rad_opprettet"]).isEqualTo(radOpprettetFoer)
+        assertThat((radEtter["rad_oppdatert"] as Timestamp)).isAfter(radOppdatertFoer)
+    }
+
+    @Test
+    fun `skal ignorere eldre version`() {
+        repository.tryLagreAktivitetDataBatch(
+            listOf(aktivitetEntity(version = 2, aktivitetStatus = "FULLFORT", recordOffset = 20)),
+        )
+
+        val resultat = repository.tryLagreAktivitetDataBatch(
+            listOf(aktivitetEntity(version = 1, aktivitetStatus = "PLANLAGT", recordOffset = 21)),
+        )
+        val rad = hentRad("aktivitet-1")!!
+
+        assertThat(resultat.prosesserte).isZero()
+        assertThat(resultat.ignorert).isEqualTo(1)
+        assertThat(rad["version"]).isEqualTo(2L)
+        assertThat(rad["aktivitet_status"]).isEqualTo("FULLFORT")
+        assertThat(rad["record_offset"]).isEqualTo(20L)
+    }
+
+    @Test
+    fun `skal ignorere historisk melding med eldre version enn lagret aktivitet`() {
+        repository.tryLagreAktivitetDataBatch(
+            listOf(aktivitetEntity(version = 3, aktivitetStatus = "FULLFORT", recordOffset = 20)),
+        )
+
+        val resultat = repository.tryLagreAktivitetDataBatch(
+            listOf(aktivitetEntity(historisk = true, version = 2, recordOffset = 21)),
+        )
+        val rad = hentRad("aktivitet-1")!!
+
+        assertThat(resultat.prosesserte).isZero()
+        assertThat(resultat.ignorert).isEqualTo(1)
+        assertThat(rad["version"]).isEqualTo(3L)
+        assertThat(rad["aktivitet_status"]).isEqualTo("FULLFORT")
+        assertThat(rad["record_offset"]).isEqualTo(20L)
+    }
+
+    @Test
+    fun `skal slette aktivitet naar historisk er true og version er nyere`() {
+        repository.tryLagreAktivitetDataBatch(listOf(aktivitetEntity()))
+
+        val resultat = repository.tryLagreAktivitetDataBatch(
+            listOf(aktivitetEntity(historisk = true, version = 2)),
+        )
+
+        assertThat(resultat.prosesserte).isEqualTo(1)
+        assertThat(hentRad("aktivitet-1")).isNull()
+    }
+
+    @Test
+    fun `skal deduplisere og beholde siste melding per aktivitet i batch`() {
+        val resultat = repository.tryLagreAktivitetDataBatch(
+            listOf(
+                aktivitetEntity(aktivitetId = "aktivitet-1", version = 1, aktivitetStatus = "PLANLAGT", recordOffset = 10),
+                aktivitetEntity(aktivitetId = "aktivitet-1", version = 2, aktivitetStatus = "FULLFORT", recordOffset = 11),
+                aktivitetEntity(aktivitetId = "aktivitet-2", version = 5, aktivitetStatus = "GJENNOMFORES", recordOffset = 12),
+            ),
+        )
+
+        val aktivitet1 = hentRad("aktivitet-1")!!
+        val aktivitet2 = hentRad("aktivitet-2")!!
+
+        assertThat(resultat.mottatte).isEqualTo(3)
+        assertThat(resultat.dedupliserte).isEqualTo(1)
+        assertThat(resultat.prosesserte).isEqualTo(2)
+        assertThat(resultat.ignorert).isZero()
+        assertThat(aktivitet1["version"]).isEqualTo(2L)
+        assertThat(aktivitet1["aktivitet_status"]).isEqualTo("FULLFORT")
+        assertThat(aktivitet1["record_offset"]).isEqualTo(11L)
+        assertThat(aktivitet2["version"]).isEqualTo(5L)
+        assertThat(aktivitet2["record_offset"]).isEqualTo(12L)
+    }
+
+    @Test
+    fun `skal haandtere tom batch`() {
+        val resultat = repository.tryLagreAktivitetDataBatch(emptyList())
+
+        assertThat(resultat.mottatte).isZero()
+        assertThat(resultat.prosesserte).isZero()
+    }
+
+    @Test
+    fun `skal haandtere batch med bade upserts og slettinger`() {
+        repository.tryLagreAktivitetDataBatch(
+            listOf(
+                aktivitetEntity(aktivitetId = "aktivitet-1", version = 1),
+                aktivitetEntity(aktivitetId = "aktivitet-2", version = 1),
+            ),
+        )
+
+        val resultat = repository.tryLagreAktivitetDataBatch(
+            listOf(
+                aktivitetEntity(aktivitetId = "aktivitet-1", version = 2, aktivitetStatus = "FULLFORT"),
+                aktivitetEntity(aktivitetId = "aktivitet-2", version = 2, historisk = true),
+            ),
+        )
+
+        assertThat(resultat.mottatte).isEqualTo(2)
+        assertThat(resultat.prosesserte).isEqualTo(2)
+        assertThat(hentRad("aktivitet-1")!!["aktivitet_status"]).isEqualTo("FULLFORT")
+        assertThat(hentRad("aktivitet-2")).isNull()
+    }
+
+    @Test
+    fun `skal ved dedup velge historisk sletting over tidligere upsert for samme aktivitet`() {
+        repository.tryLagreAktivitetDataBatch(
+            listOf(aktivitetEntity(aktivitetId = "aktivitet-1", version = 1)),
+        )
+
+        val resultat = repository.tryLagreAktivitetDataBatch(
+            listOf(
+                aktivitetEntity(aktivitetId = "aktivitet-1", version = 2, aktivitetStatus = "FULLFORT"),
+                aktivitetEntity(aktivitetId = "aktivitet-1", version = 3, historisk = true),
+            ),
+        )
+
+        assertThat(resultat.mottatte).isEqualTo(2)
+        assertThat(resultat.dedupliserte).isEqualTo(1)
+        assertThat(resultat.prosesserte).isEqualTo(1)
+        assertThat(hentRad("aktivitet-1")).isNull()
+    }
+
+    private fun hentRad(aktivitetId: String): Map<String, Any?>? =
+        jdbcTemplate.queryForList(
+            "SELECT * FROM KAFKA_AKTIVITET_MELDING WHERE AKTIVITET_ID = ?",
+            aktivitetId
+        ).firstOrNull()
+
+    private fun aktivitetEntity(
+        aktivitetId: String = "aktivitet-1",
+        version: Long = 1,
+        historisk: Boolean = false,
+        aktivitetStatus: String = "GJENNOMFORES",
+        recordOffset: Long = 15,
+        recordPartition: Int = 3,
+        recordKey: String = aktivitetId,
+    ) = KafkaAktivitetMeldingEntity(
+        value = KafkaAktivitetMeldingValue(
+            aktivitetId = aktivitetId,
+            aktorId = "aktor-1",
+            aktivitetType = "TILTAK",
+            aktivitetStatus = aktivitetStatus,
+            endringsType = "OPPRETTET",
+            fraDato = Timestamp.from(Instant.parse("2024-01-01T10:15:30Z")),
+            tilDato = Timestamp.from(Instant.parse("2024-02-01T10:15:30Z")),
+            endretDato = Timestamp.from(Instant.parse("2024-03-01T10:15:30Z")),
+            tiltakskode = "ARBFORB",
+            lagtInnAv = "NAV",
+            avtalt = true,
+            version = version,
+            historisk = historisk,
+            cvKanDelesStatus = "IKKE_SVART",
+            svarfristStillingFraNav = Timestamp.from(Instant.parse("2024-04-01T00:00:00Z")),
+        ),
+        metadata = KafkaMeldingMetadata(
+            recordOffset = recordOffset,
+            recordPartition = recordPartition,
+            recordKey = recordKey,
+        ),
+    )
+}

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepositoryTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepositoryTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.sql.Timestamp
 import java.time.Instant
 
@@ -18,7 +19,7 @@ class PortefoljeAktivitetKafkaMeldingRepositoryTest(
 
     @BeforeEach
     fun setup() {
-        repository = PortefoljeAktivitetKafkaMeldingRepository(jdbcTemplate)
+        repository = PortefoljeAktivitetKafkaMeldingRepository(NamedParameterJdbcTemplate(jdbcTemplate))
         jdbcTemplate.update("TRUNCATE TABLE KAFKA_AKTIVITET_MELDING")
     }
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepositoryTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepositoryTest.kt
@@ -137,6 +137,41 @@ class PortefoljeAktivitetKafkaMeldingRepositoryTest(
     }
 
     @Test
+    fun `skal bevare rekkefoelge ved dedup - siste melding per aktivitet vinn`() {
+        val resultat = repository.tryLagreAktivitetDataBatch(
+            listOf(
+                aktivitetEntity(aktivitetId = "a1", version = 1, aktivitetStatus = "PLANLAGT", recordOffset = 1),
+                aktivitetEntity(aktivitetId = "a2", version = 1, aktivitetStatus = "PLANLAGT", recordOffset = 2),
+                aktivitetEntity(aktivitetId = "a1", version = 2, aktivitetStatus = "GJENNOMFORES", recordOffset = 3),
+                aktivitetEntity(aktivitetId = "a3", version = 1, aktivitetStatus = "PLANLAGT", recordOffset = 4),
+                aktivitetEntity(aktivitetId = "a2", version = 2, aktivitetStatus = "FULLFORT", recordOffset = 5),
+            ),
+        )
+
+        assertThat(resultat.mottatte).isEqualTo(5)
+        assertThat(resultat.dedupliserte).isEqualTo(2)
+        assertThat(resultat.prosesserte).isEqualTo(3)
+
+        val a1 = hentRad("a1")!!
+        val a2 = hentRad("a2")!!
+        val a3 = hentRad("a3")!!
+
+        // a1: v1 (offset 1) og v2 (offset 3) → v2 vinn fordi den kjem sist i lista
+        assertThat(a1["version"]).isEqualTo(2L)
+        assertThat(a1["aktivitet_status"]).isEqualTo("GJENNOMFORES")
+        assertThat(a1["record_offset"]).isEqualTo(3L)
+
+        // a2: v1 (offset 2) og v2 (offset 5) → v2 vinn
+        assertThat(a2["version"]).isEqualTo(2L)
+        assertThat(a2["aktivitet_status"]).isEqualTo("FULLFORT")
+        assertThat(a2["record_offset"]).isEqualTo(5L)
+
+        // a3: berre éin melding
+        assertThat(a3["version"]).isEqualTo(1L)
+        assertThat(a3["record_offset"]).isEqualTo(4L)
+    }
+
+    @Test
     fun `skal haandtere tom batch`() {
         val resultat = repository.tryLagreAktivitetDataBatch(emptyList())
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepositoryTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepositoryTest.kt
@@ -1,6 +1,8 @@
 package no.nav.pto.veilarbportefolje.aktiviteter.v1
 
 import no.nav.pto.veilarbportefolje.config.ApplicationConfigTest
+import no.nav.pto.veilarbportefolje.database.PostgresTable.KAFKA_AKTIVITET_MELDING.AKTIVITET_ID
+import no.nav.pto.veilarbportefolje.database.PostgresTable.KAFKA_AKTIVITET_MELDING.TABLE_NAME
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,7 +21,7 @@ class PortefoljeAktivitetKafkaMeldingRepositoryTest(
     @BeforeEach
     fun setup() {
         repository = PortefoljeAktivitetKafkaMeldingRepository(NamedParameterJdbcTemplate(jdbcTemplate))
-        jdbcTemplate.update("TRUNCATE TABLE KAFKA_AKTIVITET_MELDING")
+        jdbcTemplate.update("TRUNCATE TABLE $TABLE_NAME")
     }
 
     @Test
@@ -51,7 +53,8 @@ class PortefoljeAktivitetKafkaMeldingRepositoryTest(
 
         Thread.sleep(5)
 
-        val oppdatert = aktivitetEntity(version = 2, aktivitetStatus = "FULLFORT", recordOffset = 11, recordKey = "ny-key")
+        val oppdatert =
+            aktivitetEntity(version = 2, aktivitetStatus = "FULLFORT", recordOffset = 11, recordKey = "ny-key")
         val resultat = repository.tryLagreAktivitetDataBatch(listOf(oppdatert))
         val radEtter = hentRad(opprinnelig.aktivitetId)!!
 
@@ -116,9 +119,24 @@ class PortefoljeAktivitetKafkaMeldingRepositoryTest(
     fun `skal deduplisere og beholde siste melding per aktivitet i batch`() {
         val resultat = repository.tryLagreAktivitetDataBatch(
             listOf(
-                aktivitetEntity(aktivitetId = "aktivitet-1", version = 1, aktivitetStatus = "PLANLAGT", recordOffset = 10),
-                aktivitetEntity(aktivitetId = "aktivitet-1", version = 2, aktivitetStatus = "FULLFORT", recordOffset = 11),
-                aktivitetEntity(aktivitetId = "aktivitet-2", version = 5, aktivitetStatus = "GJENNOMFORES", recordOffset = 12),
+                aktivitetEntity(
+                    aktivitetId = "aktivitet-1",
+                    version = 1,
+                    aktivitetStatus = "PLANLAGT",
+                    recordOffset = 10
+                ),
+                aktivitetEntity(
+                    aktivitetId = "aktivitet-1",
+                    version = 2,
+                    aktivitetStatus = "FULLFORT",
+                    recordOffset = 11
+                ),
+                aktivitetEntity(
+                    aktivitetId = "aktivitet-2",
+                    version = 5,
+                    aktivitetStatus = "GJENNOMFORES",
+                    recordOffset = 12
+                ),
             ),
         )
 
@@ -222,7 +240,7 @@ class PortefoljeAktivitetKafkaMeldingRepositoryTest(
 
     private fun hentRad(aktivitetId: String): Map<String, Any?>? =
         jdbcTemplate.queryForList(
-            "SELECT * FROM KAFKA_AKTIVITET_MELDING WHERE AKTIVITET_ID = ?",
+            "SELECT * FROM $TABLE_NAME WHERE $AKTIVITET_ID = ?",
             aktivitetId
         ).firstOrNull()
 

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepositoryTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingRepositoryTest.kt
@@ -9,7 +9,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.sql.Timestamp
-import java.time.Instant
 
 @SpringBootTest(classes = [ApplicationConfigTest::class])
 class PortefoljeAktivitetKafkaMeldingRepositoryTest(
@@ -28,16 +27,16 @@ class PortefoljeAktivitetKafkaMeldingRepositoryTest(
         val aktivitet = aktivitetEntity()
 
         val resultat = repository.tryLagreAktivitetDataBatch(listOf(aktivitet))
-        val rad = hentRad(aktivitet.value.aktivitetId)
+        val rad = hentRad(aktivitet.aktivitetId)
 
         assertThat(resultat.prosesserte).isEqualTo(1)
         assertThat(rad).isNotNull
-        assertThat(rad!!["aktor_id"]).isEqualTo(aktivitet.value.aktorId)
-        assertThat(rad["aktivitet_type"]).isEqualTo(aktivitet.value.aktivitetType)
-        assertThat(rad["tiltakskode"]).isEqualTo(aktivitet.value.tiltakskode)
-        assertThat(rad["record_offset"]).isEqualTo(aktivitet.metadata.recordOffset)
-        assertThat(rad["record_partition"]).isEqualTo(aktivitet.metadata.recordPartition)
-        assertThat(rad["record_key"]).isEqualTo(aktivitet.metadata.recordKey)
+        assertThat(rad!!["aktor_id"]).isEqualTo(aktivitet.aktorId)
+        assertThat(rad["aktivitet_type"]).isEqualTo(aktivitet.aktivitetType)
+        assertThat(rad["tiltakskode"]).isEqualTo(aktivitet.tiltakskode)
+        assertThat(rad["record_offset"]).isEqualTo(aktivitet.recordOffset)
+        assertThat(rad["record_partition"]).isEqualTo(aktivitet.recordPartition)
+        assertThat(rad["record_key"]).isEqualTo(aktivitet.recordKey)
         assertThat(rad["rad_opprettet"]).isInstanceOf(Timestamp::class.java)
         assertThat(rad["rad_oppdatert"]).isInstanceOf(Timestamp::class.java)
     }
@@ -46,7 +45,7 @@ class PortefoljeAktivitetKafkaMeldingRepositoryTest(
     fun `skal oppdatere aktivitet naar version er nyere og oppdatere rad_oppdatert`() {
         val opprinnelig = aktivitetEntity(version = 1, aktivitetStatus = "PLANLAGT", recordOffset = 10)
         repository.tryLagreAktivitetDataBatch(listOf(opprinnelig))
-        val radFoer = hentRad(opprinnelig.value.aktivitetId)!!
+        val radFoer = hentRad(opprinnelig.aktivitetId)!!
         val radOpprettetFoer = radFoer["rad_opprettet"] as Timestamp
         val radOppdatertFoer = radFoer["rad_oppdatert"] as Timestamp
 
@@ -54,7 +53,7 @@ class PortefoljeAktivitetKafkaMeldingRepositoryTest(
 
         val oppdatert = aktivitetEntity(version = 2, aktivitetStatus = "FULLFORT", recordOffset = 11, recordKey = "ny-key")
         val resultat = repository.tryLagreAktivitetDataBatch(listOf(oppdatert))
-        val radEtter = hentRad(opprinnelig.value.aktivitetId)!!
+        val radEtter = hentRad(opprinnelig.aktivitetId)!!
 
         assertThat(resultat.prosesserte).isEqualTo(1)
         assertThat(radEtter["version"]).isEqualTo(2L)
@@ -236,27 +235,23 @@ class PortefoljeAktivitetKafkaMeldingRepositoryTest(
         recordPartition: Int = 3,
         recordKey: String = aktivitetId,
     ) = KafkaAktivitetMeldingEntity(
-        value = KafkaAktivitetMeldingValue(
-            aktivitetId = aktivitetId,
-            aktorId = "aktor-1",
-            aktivitetType = "TILTAK",
-            aktivitetStatus = aktivitetStatus,
-            endringsType = "OPPRETTET",
-            fraDato = Timestamp.from(Instant.parse("2024-01-01T10:15:30Z")),
-            tilDato = Timestamp.from(Instant.parse("2024-02-01T10:15:30Z")),
-            endretDato = Timestamp.from(Instant.parse("2024-03-01T10:15:30Z")),
-            tiltakskode = "ARBFORB",
-            lagtInnAv = "NAV",
-            avtalt = true,
-            version = version,
-            historisk = historisk,
-            cvKanDelesStatus = "IKKE_SVART",
-            svarfristStillingFraNav = Timestamp.from(Instant.parse("2024-04-01T00:00:00Z")),
-        ),
-        metadata = KafkaMeldingMetadata(
-            recordOffset = recordOffset,
-            recordPartition = recordPartition,
-            recordKey = recordKey,
-        ),
+        aktivitetId = aktivitetId,
+        aktorId = "aktor-1",
+        aktivitetType = "TILTAK",
+        aktivitetStatus = aktivitetStatus,
+        endringsType = "OPPRETTET",
+        fraDato = "2024-01-01T10:15:30Z",
+        tilDato = "2024-02-01T10:15:30Z",
+        endretDato = "2024-03-01T10:15:30Z",
+        tiltakskode = "ARBFORB",
+        lagtInnAv = "NAV",
+        avtalt = true,
+        version = version,
+        historisk = historisk,
+        cvKanDelesStatus = "IKKE_SVART",
+        svarfristStillingFraNav = "2024-04-01",
+        recordOffset = recordOffset,
+        recordPartition = recordPartition,
+        recordKey = recordKey,
     )
 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingServiceTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingServiceTest.kt
@@ -1,0 +1,83 @@
+package no.nav.pto.veilarbportefolje.aktiviteter.v1
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mockito.Mockito.`when`
+import java.sql.Date as SqlDate
+import java.time.Instant
+import java.util.Date as UtilDate
+
+class PortefoljeAktivitetKafkaMeldingServiceTest {
+    private val repository = mock(PortefoljeAktivitetKafkaMeldingRepository::class.java)
+    private val service = PortefoljeAktivitetKafkaMeldingService(repository)
+
+    @Test
+    fun `skal mappe ConsumerRecords til entities og delegere til repository`() {
+        val melding = lagMelding()
+        val record = ConsumerRecord("pto.aktivitet-portefolje-v1", 3, 42L, "record-key", melding)
+        val expectedEntity = melding.toEntity(
+            KafkaMeldingMetadata(recordOffset = 42L, recordPartition = 3, recordKey = "record-key"),
+        )
+
+        `when`(repository.tryLagreAktivitetDataBatch(listOf(expectedEntity))).thenReturn(
+            PortefoljeAktivitetBatchResult(mottatte = 1, dedupliserte = 0, prosesserte = 1, ignorert = 0),
+        )
+
+        service.behandleKafkaRecords(listOf(record))
+
+        verify(repository).tryLagreAktivitetDataBatch(listOf(expectedEntity))
+        verifyNoMoreInteractions(repository)
+    }
+
+    @Test
+    fun `skal returnere tomt resultat for tom liste`() {
+        val resultat = service.behandleKafkaRecords(emptyList())
+
+        assert(resultat.mottatte == 0)
+        verifyNoMoreInteractions(repository)
+    }
+
+    @Test
+    fun `skal sende flere records som en batch til repository`() {
+        val melding1 = lagMelding(aktivitetId = "a1")
+        val melding2 = lagMelding(aktivitetId = "a2")
+        val record1 = ConsumerRecord("pto.aktivitet-portefolje-v1", 0, 10L, "key-1", melding1)
+        val record2 = ConsumerRecord("pto.aktivitet-portefolje-v1", 0, 11L, "key-2", melding2)
+
+        val expectedEntities = listOf(
+            melding1.toEntity(KafkaMeldingMetadata(recordOffset = 10L, recordPartition = 0, recordKey = "key-1")),
+            melding2.toEntity(KafkaMeldingMetadata(recordOffset = 11L, recordPartition = 0, recordKey = "key-2")),
+        )
+
+        `when`(repository.tryLagreAktivitetDataBatch(expectedEntities)).thenReturn(
+            PortefoljeAktivitetBatchResult(mottatte = 2, dedupliserte = 0, prosesserte = 2, ignorert = 0),
+        )
+
+        service.behandleKafkaRecords(listOf(record1, record2))
+
+        verify(repository).tryLagreAktivitetDataBatch(expectedEntities)
+    }
+
+    private fun lagMelding(aktivitetId: String = "aktivitet-1") = PortefoljeAktivitetKafkaMelding(
+        aktivitetId = aktivitetId,
+        version = 2,
+        aktorId = "aktor-1",
+        fraDato = UtilDate.from(Instant.parse("2024-01-01T10:15:30Z")),
+        tilDato = UtilDate.from(Instant.parse("2024-02-01T10:15:30Z")),
+        endretDato = UtilDate.from(Instant.parse("2024-03-01T10:15:30Z")),
+        aktivitetType = PortefoljeAktivitetKafkaMelding.AktivitetTypeDTO.STILLING_FRA_NAV,
+        aktivitetStatus = PortefoljeAktivitetKafkaMelding.AktivitetStatus.GJENNOMFORES,
+        endringsType = PortefoljeAktivitetKafkaMelding.EndringsType.REDIGERT,
+        lagtInnAv = PortefoljeAktivitetKafkaMelding.Innsender.NAV,
+        stillingFraNavData = PortefoljeAktivitetKafkaMelding.StillingFraNavPortefoljeData(
+            cvKanDelesStatus = PortefoljeAktivitetKafkaMelding.CvKanDelesStatus.IKKE_SVART,
+            svarfrist = SqlDate.valueOf("2024-04-01"),
+        ),
+        avtalt = true,
+        historisk = false,
+        tiltakskode = "ARBFORB",
+    )
+}

--- a/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingServiceTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/aktiviteter/v1/PortefoljeAktivitetKafkaMeldingServiceTest.kt
@@ -6,9 +6,6 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.Mockito.`when`
-import java.sql.Date as SqlDate
-import java.time.Instant
-import java.util.Date as UtilDate
 
 class PortefoljeAktivitetKafkaMeldingServiceTest {
     private val repository = mock(PortefoljeAktivitetKafkaMeldingRepository::class.java)
@@ -65,16 +62,16 @@ class PortefoljeAktivitetKafkaMeldingServiceTest {
         aktivitetId = aktivitetId,
         version = 2,
         aktorId = "aktor-1",
-        fraDato = UtilDate.from(Instant.parse("2024-01-01T10:15:30Z")),
-        tilDato = UtilDate.from(Instant.parse("2024-02-01T10:15:30Z")),
-        endretDato = UtilDate.from(Instant.parse("2024-03-01T10:15:30Z")),
-        aktivitetType = PortefoljeAktivitetKafkaMelding.AktivitetTypeDTO.STILLING_FRA_NAV,
-        aktivitetStatus = PortefoljeAktivitetKafkaMelding.AktivitetStatus.GJENNOMFORES,
-        endringsType = PortefoljeAktivitetKafkaMelding.EndringsType.REDIGERT,
-        lagtInnAv = PortefoljeAktivitetKafkaMelding.Innsender.NAV,
+        fraDato = "2024-01-01T10:15:30Z",
+        tilDato = "2024-02-01T10:15:30Z",
+        endretDato = "2024-03-01T10:15:30Z",
+        aktivitetType = "STILLING_FRA_NAV",
+        aktivitetStatus = "GJENNOMFORES",
+        endringsType = "REDIGERT",
+        lagtInnAv = "NAV",
         stillingFraNavData = PortefoljeAktivitetKafkaMelding.StillingFraNavPortefoljeData(
-            cvKanDelesStatus = PortefoljeAktivitetKafkaMelding.CvKanDelesStatus.IKKE_SVART,
-            svarfrist = SqlDate.valueOf("2024-04-01"),
+            cvKanDelesStatus = "IKKE_SVART",
+            svarfrist = "2024-04-01",
         ),
         avtalt = true,
         historisk = false,


### PR DESCRIPTION
## Sammendrag
 
 Denne PR-en legg til ein ny, eigen Spring Kafka-basert consumer for `pto.aktivitet-portefolje-v1`, utan `common-java-modules` for sjølve konsumeringa. Formålet er å støtte batch-konsumering frå Kafka og batch-skriving til databasen, samtidig som vi bevarer rekkefølgje per partition, kontrollert offset-commit og ingen skipping av meldingar ved feil. I dev har førebelse utprøvingar vist ei massiv forbetring i throughput (~20 000 meldingar per sekund vs. ~400-500 meldingar per sekund med common-java-modules sin store-on-failure consumer).
 
Consumeren er feature-toggle-styrt slik at vi enkelt kan skru på/av konsumering frå ny consumer ved behov.
 
 ## Kva er endra?
 
 ### Ny aktivitet-consumer
 
 - Legg til eigen `PortefoljeAktivitetKafkaConsumer` og `PortefoljeAktivitetKafkaConfig`.
 - Den nye consumeren brukar eiga consumer group for `pto.aktivitet-portefolje-v1`. Det gjer at vi kan køyre han parallelt med eksisterande konsumering i test-/utrullingsfasen utan å påverke offsetane til den gamle consumeren
 - Consumeren køyrer med:
   - batch-lyttar
   - éin consumer-tråd (`concurrency = 1`)
   - manuell offset-handtering via `AckMode.BATCH`
   - `enable.auto.commit = false`
   - eksplisitt consumer group
   - `autoStartup = false`, styrt av feature toggle
 
 Dette gir ein enkel mental modell: éin consumer behandlar éin batch om gongen, og offset blir først committa når heile batchen er ferdig lagra.
 
 ### Batch-lagring i databasen
 
 - Legg til batchvis lagring i `KAFKA_AKTIVITET_MELDING`.
 - Brukar `NamedParameterJdbcTemplate.batchUpdate(...)`.
 - Brukar `ON CONFLICT (AKTIVITET_ID) DO UPDATE`.
 - Ignorerer eldre versjonar dersom nyare versjon alt er lagra.
 - Dedupliserer innanfor same batch slik at siste melding per `aktivitetId` vinn.
 - Beheld eksisterande semantikk: `historisk = true` blir tolka som sletting, og versjonskontroll hindrar at eldre meldingar påverkar nyare lagra tilstand.
 
 ### Meir meldingsnær lagringsmodell
 
 Kafka-modellen er justert til å ligge nærare JSON/DB-schemaet:
 
 - dato-/fristfelt blir lagra som tekst
 - enum-liknande felt blir lagra som tekst, ikkje mappa til Kotlin-enum ved innlesing
 - nullability i modellen speglar databasekrav
 - påkravde felt feilar ved manglande eller `null` verdi
 - lagringsentityen er flata ut slik at han speglar tabellen betre
 
 ### Feilhåndtering
 
 Consumeren har retry med eksponentiell ventetid:
 
 - første retry etter 10 sekund
 - maks ventetid mellom forsøk: 1 time
 - stoppar etter ca. 1 time med vedvarande feil
 
 Når retry er brukt opp, stoppar consumer-containeren utan å committe offset. Feature-toggle-logikken startar han ikkje automatisk igjen før tilstanden er nullstilt ved å slå togglen av.
 
 ### Logging og personvern
 
 - Opne logger skal ikkje innehalde meldingstekst, stacktrace eller exception-meldingar som kan innehalde personopplysningar.
 - Retry-/feillogging loggar berre exception-type.
 - Feilmelding ved manglande Kafka key er sanert slik at `aktivitetId` ikkje blir skrive i open logg.
 
 ## Mellombelse tiltak for testing og utrulling
 
 Dette er lagt inn for tryggare testing/gradvis utrulling, og bør fjernast eller ryddast når ny consumer er verifisert:
 
 - feature toggle for å styre ny aktivitet-consumer
 - `autoStartup = false`, slik at consumeren ikkje startar ukontrollert ved deploy
 - mellombels auke i tal på podar/ressursar for å kunne teste ny og gammal konsumering tryggare parallelt
 - ekstra stopp-/restartvern rundt consumeren ved vedvarande feil
 
 ## Testar
 
 Lagt til/oppdatert testar for:
 
 - deserialisering av nytt aktivitetformat
 - ukjende felt i Kafka-payload
 - manglande/null påkravde felt
 - mapping frå Kafka-records til lagringsentity
 - batch upsert
 - ignorering av eldre versjonar
 - sletting ved `historisk = true`
 - deduplisering og rekkefølgje innanfor batch