### PR TITLE
Legger til null sjekk til veilederId på veilederTilOrdnet

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingRepositoryV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingRepositoryV2.java
@@ -35,7 +35,7 @@ public class OppfolgingRepositoryV2 {
     }
 
     public void settVeileder(AktorId aktorId, VeilederId veilederId) {
-        db.update("UPDATE oppfolging_data SET veilederid = ? WHERE aktoerid = ?", veilederId.getValue(), aktorId.get());
+        db.update("UPDATE oppfolging_data SET veilederid = ? WHERE aktoerid = ?", Optional.ofNullable(veilederId).map(VeilederId::getValue).orElse(null), aktorId.get());
     }
 
     public void settNyForVeileder(AktorId aktoerId, boolean nyForVeileder) {

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingRepositoryV2Test.java
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/OppfolgingRepositoryV2Test.java
@@ -44,7 +44,7 @@ public class OppfolgingRepositoryV2Test {
         List<AktorId> aktorIds = oppfolgingRepository.hentAlleBrukereUnderOppfolging();
 
         assertThat(aktorIds.isEmpty()).isFalse();
-        assertThat(aktorIds.get(0)).isEqualTo(aktoerId);
+        assertThat(aktorIds.getFirst()).isEqualTo(aktoerId);
         assertThat(VeilederId.of(oppfolgingData.getVeilederId())).isEqualTo(veilederId);
     }
 


### PR DESCRIPTION
## Description

Vi må legge til en null-sjekk på veilederId for å sikre at oppfølgingsdata lagres korrekt i databasen og for å unngå følgende feil:

java.lang.NullPointerException: Cannot invoke "no.nav.pto.veilarbportefolje.domene.VeilederId.getValue()" because "veilederId" is null
at no.nav.pto.veilarbportefolje.oppfolging.OppfolgingRepositoryV2.settVeileder(OppfolgingRepositoryV2.java:38)

Se også logger:
https://logs.az.nav.no/app/discover#/doc/c4992d50-be41-11f0-aab5-1ff58dd1d822/.ds-logs.nais-000221?id=a77C9J4B8qlpI86gMx31

Årsak

VeilederTilordnetDTO tillater at veilederId er null. Dette fører til at det oppstår en NullPointerException når OppfolgingRepositoryV2.settVeileder() kaller getValue() på veilederId uten å sjekke om objektet er null.

Endringen ble introdusert i forbindelse med produksjonssettingen av feilrettingen for deserialisering av tilordningsdato 17. juni. Da ble VeilederTilordnetDTO konvertert fra Java til Kotlin, og datatypen til veilederId ble endret fra VeilederId til VeilederId?.

## Trello ticket number and link


