### PR TITLE
Feilretting veiledertilordning

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetService.kt
@@ -39,7 +39,7 @@ class VeilederTilordnetService(
         oppfolgingRepositoryV2.settVeileder(aktoerId, veilederId)
         oppfolgingRepositoryV2.settTildeltTidspunkt(aktoerId, tildeltTidspunkt)
 
-        kastErrorHvisBrukerSkalVaereUnderOppfolging(aktoerId, veilederId)
+//        kastErrorHvisBrukerIkkeErUnderOppfolging(aktoerId, veilederId)
         opensearchIndexerPaDatafelt.oppdaterVeileder(aktoerId, veilederId, tildeltTidspunkt)
         secureLog.info("Oppdatert bruker: $aktoerId, til veileder med id: $veilederId, med tildelt tidspunkt: $tildeltTidspunkt")
 
@@ -58,13 +58,13 @@ class VeilederTilordnetService(
         }
     }
 
-    private fun kastErrorHvisBrukerSkalVaereUnderOppfolging(aktorId: AktorId?, veilederId: VeilederId?) {
-        if (hentVeileder(aktorId) == veilederId) {
-            return
-        }
-        val erUnderOppfolgingIVeilarboppfolging = oppfolgingClient.hentUnderOppfolging(aktorId)
-        check(!erUnderOppfolgingIVeilarboppfolging) { "Fikk 'veileder melding' på bruker som enda ikke er under oppfølging i veilarbportefolje" }
-    }
+//      private fun kastErrorHvisBrukerIkkeErUnderOppfolging(aktorId: AktorId?, veilederId: VeilederId?) {
+//        if (hentVeileder(aktorId) == veilederId) {
+//            return
+//        }
+//        val erUnderOppfolgingIVeilarboppfolging = oppfolgingClient.hentUnderOppfolging(aktorId)
+//        check(erUnderOppfolgingIVeilarboppfolging) { "Fikk 'veileder melding' på bruker som enda ikke er under oppfølging i veilarboppfolging" }
+//    }
 
     private fun hentVeileder(aktoerId: AktorId?): VeilederId? {
         return oppfolgingRepositoryV2.hentVeilederForBruker(aktoerId)

--- a/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetService.kt
+++ b/src/main/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetService.kt
@@ -3,7 +3,7 @@ package no.nav.pto.veilarbportefolje.oppfolging
 import no.nav.common.types.identer.AktorId
 import no.nav.common.types.identer.Fnr
 import no.nav.pto.veilarbportefolje.domene.VeilederId
-import no.nav.pto.veilarbportefolje.domene.VeilederId.Companion.of
+//import no.nav.pto.veilarbportefolje.domene.VeilederId.Companion.of
 import no.nav.pto.veilarbportefolje.fargekategori.FargekategoriService
 import no.nav.pto.veilarbportefolje.huskelapp.HuskelappService
 import no.nav.pto.veilarbportefolje.kafka.KafkaCommonNonKeyedConsumerService
@@ -17,7 +17,7 @@ import java.util.*
 
 @Service
 class VeilederTilordnetService(
-    private val oppfolgingClient: OppfolgingClient,
+//    private val oppfolgingClient: OppfolgingClient,
     private val oppfolgingRepositoryV2: OppfolgingRepositoryV2,
     private val huskelappService: HuskelappService,
     private val fargekategoriService: FargekategoriService,
@@ -66,8 +66,8 @@ class VeilederTilordnetService(
 //        check(erUnderOppfolgingIVeilarboppfolging) { "Fikk 'veileder melding' på bruker som enda ikke er under oppfølging i veilarboppfolging" }
 //    }
 
-    private fun hentVeileder(aktoerId: AktorId?): VeilederId? {
-        return oppfolgingRepositoryV2.hentVeilederForBruker(aktoerId)
-            .orElse(of(null))
-    }
+//    private fun hentVeileder(aktoerId: AktorId?): VeilederId? {
+//        return oppfolgingRepositoryV2.hentVeilederForBruker(aktoerId)
+//            .orElse(of(null))
+//    }
 }

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetServiceTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.pto.veilarbportefolje.oppfolging
 
 import no.nav.pto.veilarbportefolje.client.AktorClient
 import no.nav.pto.veilarbportefolje.domene.VeilederId.Companion.of
+import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingClient
 import no.nav.pto.veilarbportefolje.oppfolging.dto.VeilederTilordnetDTO
 import no.nav.pto.veilarbportefolje.util.EndToEndTest
 import no.nav.pto.veilarbportefolje.util.TestDataUtils.randomAktorId
@@ -16,6 +17,7 @@ import java.time.ZonedDateTime
 
 internal class VeilederTilordnetServiceTest @Autowired constructor(
     private val aktorClient: AktorClient,
+    private val oppfolgingClient: OppfolgingClient,
     private val veilederTilordnetService: VeilederTilordnetService
 ) : EndToEndTest() {
     @Test
@@ -25,6 +27,7 @@ internal class VeilederTilordnetServiceTest @Autowired constructor(
         val tilordnet = ZonedDateTime.now()
         val forventetTildeltTidspunkt = tilordnet.toLocalDateTime()
         Mockito.`when`(aktorClient.hentFnr(aktoerId)).thenReturn(randomFnr())
+        Mockito.`when`(oppfolgingClient.hentUnderOppfolging(aktoerId)).thenReturn(true)
 
         testDataClient.lagreBrukerUnderOppfolging(
             aktoerId,
@@ -49,6 +52,7 @@ internal class VeilederTilordnetServiceTest @Autowired constructor(
         val aktoerId = randomAktorId()
         val nyVeileder = of(null)
         Mockito.`when`(aktorClient.hentFnr(aktoerId)).thenReturn(randomFnr())
+        Mockito.`when`(oppfolgingClient.hentUnderOppfolging(aktoerId)).thenReturn(true)
 
         testDataClient.lagreBrukerUnderOppfolging(
             aktoerId,

--- a/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetServiceTest.kt
+++ b/src/test/java/no/nav/pto/veilarbportefolje/oppfolging/VeilederTilordnetServiceTest.kt
@@ -2,7 +2,7 @@ package no.nav.pto.veilarbportefolje.oppfolging
 
 import no.nav.pto.veilarbportefolje.client.AktorClient
 import no.nav.pto.veilarbportefolje.domene.VeilederId.Companion.of
-import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingClient
+//import no.nav.pto.veilarbportefolje.oppfolging.OppfolgingClient
 import no.nav.pto.veilarbportefolje.oppfolging.dto.VeilederTilordnetDTO
 import no.nav.pto.veilarbportefolje.util.EndToEndTest
 import no.nav.pto.veilarbportefolje.util.TestDataUtils.randomAktorId


### PR DESCRIPTION
Kommenterer ut en sjekk i veiledertildeling, som sannsynligvis er lagt inn for å sørge for at meldinger blir spart hvis det er en race condition mellom meldinger for start oppfølging og tildel veileder.