### PR TITLE
Oppfølgingsenhet ved identbytte

### DIFF
--- a/src/main/java/no/nav/pto/veilarbportefolje/database/PostgresTable.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/database/PostgresTable.java
@@ -21,11 +21,13 @@ public class PostgresTable {
         public static final String OPPFOLGINGSBRUKER_ARENA_V2_FODSELSNR = "OPPFOLGINGSBRUKER_ARENA_V2_FODSELSNR";
         public static final String OPPFOLGINGSBRUKER_ARENA_V2_FORMIDLINGSGRUPPEKODE = "OPPFOLGINGSBRUKER_ARENA_V2_FORMIDLINGSGRUPPEKODE";
         public static final String OPPFOLGINGSBRUKER_ARENA_V2_ISERV_FRA_DATO = "OPPFOLGINGSBRUKER_ARENA_V2_ISERV_FRA_DATO";
-        public static final String OPPFOLGINGSBRUKER_ARENA_V2_NAV_KONTOR = "OPPFOLGINGSBRUKER_ARENA_V2_NAV_KONTOR";
         public static final String OPPFOLGINGSBRUKER_ARENA_V2_KVALIFISERINGSGRUPPEKODE = "OPPFOLGINGSBRUKER_ARENA_V2_KVALIFISERINGSGRUPPEKODE";
         public static final String OPPFOLGINGSBRUKER_ARENA_V2_RETTIGHETSGRUPPEKODE = "OPPFOLGINGSBRUKER_ARENA_V2_RETTIGHETSGRUPPEKODE";
         public static final String OPPFOLGINGSBRUKER_ARENA_V2_HOVEDMAALKODE = "OPPFOLGINGSBRUKER_ARENA_V2_HOVEDMAALKODE";
         public static final String OPPFOLGINGSBRUKER_ARENA_V2_ENDRET_DATO = "OPPFOLGINGSBRUKER_ARENA_V2_ENDRET_DATO";
+
+        // AO_KONTOR
+        public static final String AO_KONTOR_KONTOR_ID = "AO_KONTOR_KONTOR_ID";
 
         // NOM_SKJERMING
         public static final String NOM_SKJERMING_ER_SKJERMET = "NOM_SKJERMING_ER_SKJERMET";
@@ -167,10 +169,10 @@ public class PostgresTable {
 
         private AO_KONTOR() { /* no-op */ }
 
-        public static final String TABLE_NAME = "ao_kontor";
-        public static final String AKTORID = "aktorid";
-        public static final String IDENT = "ident";
-        public static final String KONTOR_ID = "kontor_id";
+        public static final String TABLE_NAME = "AO_KONTOR";
+        public static final String AKTORID = "AKTORID";
+        public static final String IDENT = "IDENT";
+        public static final String KONTOR_ID = "KONTOR_ID";
     }
 
     public static final class DIALOG {

--- a/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexer.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/opensearch/OpensearchIndexer.java
@@ -8,7 +8,9 @@ import no.nav.pto.veilarbportefolje.opensearch.domene.PortefoljebrukerOpensearch
 import no.nav.pto.veilarbportefolje.postgres.BrukerRepositoryV2;
 import no.nav.pto.veilarbportefolje.postgres.PostgresOpensearchMapper;
 import org.opensearch.OpenSearchException;
+import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.client.RequestOptions;
@@ -65,7 +67,17 @@ public class OpensearchIndexer {
                 .forEach(bulk::add);
 
         try {
-            restHighLevelClient.bulk(bulk, RequestOptions.DEFAULT);
+            BulkResponse response = restHighLevelClient.bulk(bulk, RequestOptions.DEFAULT);
+
+            int antallTotalt = response.getItems().length;
+            int antallFeilede = 0;
+            for (BulkItemResponse item : response.getItems()) {
+                if (item.isFailed()) antallFeilede++;
+            }
+            int antallSuksess = antallTotalt - antallFeilede;
+
+            log.info("OpenSearch bulk stats: total={}, succeeded={}, failed={}, tookMs={}", antallTotalt, antallSuksess, antallFeilede, response.getTook().getMillis());
+
             secureLog.info("Skrev {} brukere til indeks: {}", brukerOpensearchModellList.size(), aktoerIds);
         } catch (IOException e) {
             secureLog.error(String.format("Klart ikke å skrive til indeks: %s", aktoerIds), e);

--- a/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
+++ b/src/main/java/no/nav/pto/veilarbportefolje/postgres/BrukerRepositoryV2.java
@@ -63,8 +63,7 @@ public class BrukerRepositoryV2 {
                                OPPFOLGINGSBRUKER_ARENA_V2.FODSELSNR                     as OPPFOLGINGSBRUKER_ARENA_V2_FODSELSNR,
                                OPPFOLGINGSBRUKER_ARENA_V2.FORMIDLINGSGRUPPEKODE         as OPPFOLGINGSBRUKER_ARENA_V2_FORMIDLINGSGRUPPEKODE,
                                OPPFOLGINGSBRUKER_ARENA_V2.ISERV_FRA_DATO                as OPPFOLGINGSBRUKER_ARENA_V2_ISERV_FRA_DATO,
-                               ao_kontor.kontor_id
-                                                                                        as OPPFOLGINGSBRUKER_ARENA_V2_NAV_KONTOR,
+                               AO_KONTOR.KONTOR_ID                                      as AO_KONTOR_KONTOR_ID,
                                OPPFOLGINGSBRUKER_ARENA_V2.KVALIFISERINGSGRUPPEKODE      as OPPFOLGINGSBRUKER_ARENA_V2_KVALIFISERINGSGRUPPEKODE,
                                OPPFOLGINGSBRUKER_ARENA_V2.RETTIGHETSGRUPPEKODE          as OPPFOLGINGSBRUKER_ARENA_V2_RETTIGHETSGRUPPEKODE,
                                OPPFOLGINGSBRUKER_ARENA_V2.HOVEDMAALKODE                 as OPPFOLGINGSBRUKER_ARENA_V2_HOVEDMAALKODE,
@@ -153,7 +152,7 @@ public class BrukerRepositoryV2 {
                                  left join YTELSER_TILTAKSPENGER                        on YTELSER_TILTAKSPENGER.NORSK_IDENT = AKTIVE_IDENTER.FNR
                                  left join YTELSER_DAGPENGER                            on YTELSER_DAGPENGER.NORSK_IDENT = AKTIVE_IDENTER.FNR
                                  left join YTELSER_UNGDOMSPROGRAM                       on YTELSER_UNGDOMSPROGRAM.NORSK_IDENT = AKTIVE_IDENTER.FNR
-                                 left join ao_kontor                                    on ao_kontor.ident = OPPFOLGINGSBRUKER_ARENA_V2.FODSELSNR
+                                 left join AO_KONTOR                                    on AO_KONTOR.AKTORID = AKTIVE_IDENTER.AKTORID
                                  where AKTIVE_IDENTER.AKTORID = any (?::varchar[])
                         """;
 
@@ -181,13 +180,10 @@ public class BrukerRepositoryV2 {
                             FODSELSNR as OPPFOLGINGSBRUKER_ARENA_V2_FODSELSNR,
                             FORMIDLINGSGRUPPEKODE as OPPFOLGINGSBRUKER_ARENA_V2_FORMIDLINGSGRUPPEKODE,
                             KVALIFISERINGSGRUPPEKODE as OPPFOLGINGSBRUKER_ARENA_V2_KVALIFISERINGSGRUPPEKODE,
-                            ao_kontor.kontor_id
-                             as OPPFOLGINGSBRUKER_ARENA_V2_NAV_KONTOR,
                             ISERV_FRA_DATO as OPPFOLGINGSBRUKER_ARENA_V2_ISERV_FRA_DATO,
                             RETTIGHETSGRUPPEKODE as OPPFOLGINGSBRUKER_ARENA_V2_RETTIGHETSGRUPPEKODE,
                             HOVEDMAALKODE as OPPFOLGINGSBRUKER_ARENA_V2_HOVEDMAALKODE
                         from OPPFOLGINGSBRUKER_ARENA_V2
-                        left join ao_kontor on ao_kontor.ident = OPPFOLGINGSBRUKER_ARENA_V2.FODSELSNR
                         where FODSELSNR in
                             (select IDENT from BRUKER_IDENTER where PERSON =
                                 (select PERSON from BRUKER_IDENTER where IDENT = ?)
@@ -246,6 +242,7 @@ public class BrukerRepositoryV2 {
         brukerOpensearchModell.setAapunntakukerigjen(konverterDagerTilUker(rs.getObject(YTELSE_STATUS_FOR_BRUKER_AAPUNNTAKDAGERIGJEN, Integer.class)));
         brukerOpensearchModell.setFargekategori(rs.getString(FARGEKATEGORI_VERDI));
         brukerOpensearchModell.setFargekategori_enhetId(rs.getString(FARGEKATEGORI_ENHET_ID));
+        brukerOpensearchModell.setEnhet_id(rs.getString(AO_KONTOR_KONTOR_ID));
 
         setHuskelapp(brukerOpensearchModell, rs);
         setBrukersSituasjon(brukerOpensearchModell, rs);
@@ -386,7 +383,6 @@ public class BrukerRepositoryV2 {
         String kvalifiseringsgruppekode = rs.getString(OPPFOLGINGSBRUKER_ARENA_V2_KVALIFISERINGSGRUPPEKODE);
 
         brukerOpensearchModell.setFnr(fnr);
-        brukerOpensearchModell.setEnhet_id(rs.getString(OPPFOLGINGSBRUKER_ARENA_V2_NAV_KONTOR));
         brukerOpensearchModell.setIserv_fra_dato(toIsoUTC(rs.getTimestamp(OPPFOLGINGSBRUKER_ARENA_V2_ISERV_FRA_DATO)));
         brukerOpensearchModell.setRettighetsgruppekode(rs.getString(OPPFOLGINGSBRUKER_ARENA_V2_RETTIGHETSGRUPPEKODE));
         brukerOpensearchModell.setFormidlingsgruppekode(formidlingsgruppekode);


### PR DESCRIPTION
* Sjekkar på AktørID i staden for naturleg ident, slik at vi også får med og setter oppfølgingskontor dersom ein person får ny naturleg ident (eks: DNR --> FNR)
* Legger på litt ekstra logging ifm. batch-kall mot OpenSearch
* Fjernar ein unødvendig join med `AO_KONTOR`-tabellen i `leggTilHistoriskArenaDataHvisTilgjengelig`-funksjonen då `AO_KONTOR` uansett er heilt uavhengig av `OPPFOLGINGSBRUKER_ARENA_V2`-tabellen